### PR TITLE
Silence Cobra usage on error and auto-install VS components via --fix

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -16,8 +16,9 @@ import (
 var cfgFile string
 
 var rootCmd = &cobra.Command{
-	Use:   "ludus",
-	Short: "Streamline UE5 Lyra dedicated server deployment to AWS GameLift Containers",
+	Use:          "ludus",
+	SilenceUsage: true,
+	Short:        "Streamline UE5 Lyra dedicated server deployment to AWS GameLift Containers",
 	Long: `Ludus automates the end-to-end pipeline for building Unreal Engine 5 from source,
 compiling the Lyra sample project as a Linux dedicated server, containerizing it,
 and deploying it to AWS GameLift Containers.

--- a/internal/prereq/checker_windows.go
+++ b/internal/prereq/checker_windows.go
@@ -99,12 +99,61 @@ func (c *Checker) checkVisualStudio() CheckResult {
 	}
 
 	if len(missing) > 0 {
+		if !c.Fix {
+			return CheckResult{
+				Name:   "Visual Studio",
+				Passed: false,
+				Message: fmt.Sprintf("%s found but missing components: %s; "+
+					"run with --fix to install them",
+					edition, strings.Join(missing, ", ")),
+			}
+		}
+
+		// Auto-fix: launch VS Installer to add missing components
+		setupPath := filepath.Join(
+			os.Getenv("ProgramFiles(x86)"),
+			"Microsoft Visual Studio", "Installer", "setup.exe",
+		)
+		if _, err := os.Stat(setupPath); os.IsNotExist(err) {
+			return CheckResult{
+				Name:   "Visual Studio",
+				Passed: false,
+				Message: fmt.Sprintf("VS Installer setup.exe not found at %s; install components manually via VS Installer > Modify",
+					setupPath),
+			}
+		}
+
+		// Build the list of missing component IDs
+		missingIDs := make(map[string]string)
+		for _, comp := range requiredComponents {
+			for _, m := range missing {
+				if comp.name == m {
+					missingIDs[comp.id] = comp.name
+				}
+			}
+		}
+
+		args := []string{"modify", "--installPath", installs[0].InstallationPath}
+		for id := range missingIDs {
+			args = append(args, "--add", id)
+		}
+		args = append(args, "--passive")
+
+		cmd := exec.Command(setupPath, args...)
+		if err := cmd.Start(); err != nil {
+			return CheckResult{
+				Name:   "Visual Studio",
+				Passed: false,
+				Message: fmt.Sprintf("failed to launch VS Installer: %v", err),
+			}
+		}
+
 		return CheckResult{
-			Name:   "Visual Studio",
-			Passed: false,
-			Message: fmt.Sprintf("%s found but missing components: %s. "+
-				"Install via VS Installer > Modify",
-				edition, strings.Join(missing, ", ")),
+			Name:    "Visual Studio",
+			Passed:  true,
+			Warning: true,
+			Message: fmt.Sprintf("launched VS Installer to add: %s; re-run ludus init after installation completes",
+				strings.Join(missing, ", ")),
 		}
 	}
 


### PR DESCRIPTION
## Summary

- **Silence usage on error**: Set `SilenceUsage: true` on the root Cobra command so errors no longer dump the full help/flags text. Users still get help via `--help`.
- **Auto-install VS components**: `ludus init --fix` now launches the VS Installer in passive mode to add missing C++ workloads and MSVC v14.38, matching the existing `--fix` pattern used by BuildConfiguration.xml and NNERuntimeORT patch checks.

## Test plan

- [ ] `ludus.exe init --verbose` — confirm error output is clean (no usage dump)
- [ ] `ludus.exe init --fix --verbose` with missing VS components — confirm VS Installer launches with correct `--add` flags
- [ ] Re-run `ludus.exe init --verbose` after VS Installer completes — confirm all checks pass
- [ ] `ludus.exe --bogus-flag` — confirm Cobra still shows usage for invalid flags (unaffected by SilenceUsage)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Visual Studio prerequisite detection on Windows. When missing components are detected and `--fix` is enabled, the VS Installer now automatically launches to add required components. Users are guided to re-run initialization after installation completes.

* **Improvements**
  * Enhanced error display formatting in command output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->