### PR TITLE
Validate UE 5.4–5.7 compatibility, fix INITGUID auto-fix bug

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,179 @@
+# AGENTS.md
+
+Guidelines for AI coding agents working in this repository.
+
+## Build / Lint / Test Commands
+
+```bash
+# Build
+go build -o ludus -v              # Linux/macOS
+go build -o ludus.exe -v .        # Windows
+GOOS=windows go build -o /dev/null .  # Cross-compile check from Linux
+
+# Lint (golangci-lint v2 required — v1 does not support Go 1.24)
+golangci-lint run ./...
+
+# Test
+go test ./...                          # All tests
+go test -v ./internal/toolchain        # Single package
+go test -v -run TestParseBuildVersion ./internal/toolchain  # Single test
+go test -v -run TestParseBuildVersion/valid_JSON ./internal/toolchain  # Single subtest
+
+# Other
+go vet ./...                      # Static analysis
+go mod tidy                       # Clean up module dependencies
+```
+
+Pre-commit hooks (`.hooks/pre-commit`) run build, lint, and test. Activate with
+`git config core.hooksPath .hooks`.
+
+## Project Structure
+
+- `main.go` — Entry point; calls `root.Execute()`.
+- `cmd/` — Cobra command packages. Each exports `var Cmd = &cobra.Command{...}`,
+  registered in `cmd/root/root.go`. Handler functions are named `run<Command>`.
+- `cmd/globals/` — Mutable global state: `Cfg`, `Verbose`, `JSONOutput`, `DryRun`.
+- `internal/` — All business logic (unexported). One primary type per file.
+  Key packages: `config`, `runner`, `engine`, `game`, `container`, `deploy`,
+  `gamelift`, `stack`, `binary`, `anywhere`, `tags`, `state`, `cache`, `status`,
+  `prereq`, `toolchain`, `wrapper`, `ci`, `dockerbuild`.
+- Platform-specific files use `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
+
+## Code Style
+
+### Formatting
+
+Enforced by `gofmt` (configured in `.golangci.yml`). No manual formatting exceptions.
+
+### Imports
+
+Two groups separated by a blank line: (1) stdlib, (2) everything else (third-party
+and project imports together). Sorted alphabetically within each group.
+
+```go
+import (
+    "context"
+    "fmt"
+
+    "github.com/devrecon/ludus/internal/runner"
+    "github.com/spf13/cobra"
+)
+```
+
+Aliases only to resolve naming conflicts, using concise names:
+
+```go
+awsconfig "github.com/aws/aws-sdk-go-v2/config"
+gltypes   "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+```
+
+### Naming
+
+- **Packages**: lowercase, single word (`config`, `deploy`, `gamelift`). Multi-word
+  concatenated (`dockerbuild`), never underscored.
+- **Files**: `snake_case.go`. Build-tagged files: `checker_unix.go`, `process_windows.go`.
+- **Acronyms**: Fully uppercase: `ID`, `URI`, `ARN`, `ECR`, `IAM`, `AWS`, `SDK`, `IP`.
+- **Structs**: PascalCase nouns — `Builder`, `Deployer`, `Exporter`, `TargetAdapter`.
+- **Options/Results**: `BuildOptions`, `BuildResult`, `DeployOptions`, `FleetStatus`.
+- **Unexported constants**: camelCase (`iamRoleName`, `pollInterval`).
+- **Exported constants**: PascalCase (`WrapperRepo`, `StageEngine`).
+- **Variables**: camelCase. Short names for narrow scope (`r`, `b`, `cfg`, `ctx`).
+  Descriptive names for broader scope (`serverBuildDir`, `engineVersion`).
+
+### Constructors and Methods
+
+Constructors use `New*` and return a pointer:
+
+```go
+func NewBuilder(opts BuildOptions, r *runner.Runner) *Builder
+func NewDeployer(opts DeployOptions, awsCfg aws.Config) *Deployer
+```
+
+Method receivers are pointer receivers with a single-letter name matching the type:
+`b` for `*Builder`, `d` for `*Deployer`, `r` for `*Runner`, `c` for `*Checker`.
+
+### Context
+
+`context.Context` is the first parameter for all I/O or long-running methods.
+Pure computation functions omit it.
+
+```go
+func (b *Builder) Build(ctx context.Context) (*BuildResult, error)
+func (d *Deployer) CreateFleet(ctx context.Context, ...) (...)
+```
+
+### Error Handling
+
+- Wrap with `fmt.Errorf("brief context: %w", err)`. Context is lowercase, no trailing
+  punctuation: `"reading config: %w"`, `"creating location: %w"`.
+- Terminal errors (no underlying cause) use `fmt.Errorf` without `%w`:
+  `fmt.Errorf("Setup.sh not found at %s", path)`.
+- No sentinel errors (`var Err* = errors.New(...)`) — the codebase does not use them.
+- No custom error types — all errors are `fmt.Errorf` or from library calls.
+- Non-fatal issues print a warning and continue:
+  `fmt.Printf("Warning: failed to write state: %v\n", err)`.
+- AWS not-found checks use string matching helpers (`isNotFound()`), not `errors.Is()`.
+
+### Comments
+
+Doc comments on all exported identifiers, starting with the identifier name:
+
+```go
+// Builder compiles UE5 from source.
+// NewBuilder creates a new engine builder.
+// BuildOptions configures the engine build.
+```
+
+Struct fields get inline `//` comments in config types. Inline code comments explain
+"why", not "what".
+
+### Output / Logging
+
+No logging library. All output via `fmt` functions:
+- `fmt.Println` / `fmt.Printf` for status messages.
+- `fmt.Fprintln(os.Stderr, ...)` for warnings to stderr.
+- Status messages within stages are indented 2 spaces.
+- Verbose command echoing is handled by the `runner.Runner` (prints `+ command`).
+- JSON output conditional on `globals.JSONOutput`.
+
+## Test Conventions
+
+- **stdlib only** — no testify or assertion libraries.
+- **Same-package tests** (access to unexported symbols): `package toolchain`, not
+  `package toolchain_test`.
+- **Table-driven tests** using anonymous struct slices. Loop variable is `tt`:
+  ```go
+  tests := []struct{ name string; input string; want int }{ ... }
+  for _, tt := range tests {
+      t.Run(tt.name, func(t *testing.T) { ... })
+  }
+  ```
+- **Assertions** via `if got != want` with `t.Errorf` / `t.Fatalf`.
+- **Temp dirs** via `t.TempDir()` (auto-cleaned).
+- **Skip** unavailable tests with `t.Skipf(...)`.
+- Test files are co-located: `builder_test.go` alongside `builder.go`.
+
+## Lint Configuration
+
+Enabled linters (`.golangci.yml`, v2 format): errcheck, govet, ineffassign,
+staticcheck, unused, gocritic, misspell, unconvert, gosec.
+
+Key gosec exclusions: G104 (unhandled errors in best-effort cleanup), G204/G702
+(subprocess with variable — intentional), G304/G703 (file inclusion via variable —
+intentional), G115 (integer overflow — bounded values), G301 (dir perms 0755),
+G306 (WriteFile 0644).
+
+ST1005 (uppercase error strings) is suppressed — error messages may start with proper
+nouns like `Setup.sh` or `Lyra.uproject`.
+
+## Key Patterns
+
+- **Builder pattern**: `New*(opts)` constructor, operation methods, structured results.
+- **Runner abstraction**: Never call `exec.Command` directly — use `runner.Runner`
+  which handles verbose/dry-run uniformly.
+- **Pluggable targets**: `deploy.Target` interface with `gamelift`, `stack`, `binary`,
+  `anywhere` implementations. Factory in `cmd/globals/resolve.go`.
+- **State persistence**: `.ludus/state.json` for fleet/session/client info.
+- **Build caching**: `.ludus/cache.json` with input hashing per stage.
+- **Platform dispatch**: `//go:build windows` / `//go:build !windows` pairs providing
+  matching function signatures. Minor differences use `runtime.GOOS` inline.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -168,7 +168,7 @@ Backward compatibility: if `ludus.yaml` uses the old `lyra:` key, values are mig
 - Client builds support Linux and Win64; native Win64 builds work if UE5 is built from source on Windows
 - `ludus connect` launches the client directly on both platforms (Windows: `os/exec` child process, Linux: `syscall.Exec` process replacement). On Linux with a Win64 client, it prints copy/run instructions instead.
 - UE5 content cooking requires 24+ GB RAM; 32 GB recommended. On Ubuntu, `systemd-oomd` kills the cook process at 50% memory pressure — disable it before building (`sudo systemctl disable --now systemd-oomd systemd-oomd.socket`)
-- UE 5.6.1 on Windows requires specific source patches and toolchain versions — see `UE_SOURCE_PATCHES.md` for details (INITGUID fix for NNERuntimeORT on SDK >= 26100, MSVC 14.38 toolchain requirement)
+- UE 5.6.1 on Windows requires specific source patches and toolchain versions — see `UE_SOURCE_PATCHES.md` for details (INITGUID fix for NNERuntimeORT on SDK >= 26100 — 5.6 only, fixed by Epic in 5.7; MSVC 14.38 toolchain requirement). Structural validation has been run against UE 5.4.4, 5.5.4, 5.6.1, and 5.7.3.
 
 ## CI / Linting
 

--- a/SPEC.md
+++ b/SPEC.md
@@ -207,21 +207,20 @@ ludus/
 - [x] Game session creation and client connect
 - [x] Pluggable deployment targets (`gamelift`, `stack`, `binary`)
 - [x] Cross-compile toolchain management (engine version → clang SDK mapping)
-- [x] MCP server for AI agent orchestration (13 tools)
+- [x] MCP server for AI agent orchestration (15 tools)
 - [x] GitHub Actions CI integration (workflow generation + self-hosted runner management)
 - [x] Cross-platform support (Linux server pipeline, Windows client build + connect)
 - [x] Persistent state tracking (`.ludus/state.json`)
 - [x] CloudFormation-based deployment (`ludus deploy stack`) with atomic rollback
 - [x] Centralized, configurable AWS resource tagging (`aws.tags` in `ludus.yaml`)
+- [x] Docker build backend — Build via a private engine Docker image as alternative to native builds
+- [x] Build caching — Skip unchanged pipeline stages based on file hashes
+- [x] GameLift Anywhere — Local fleet deployment for development and testing
+- [x] Configurable Docker base image
 
 ## Future / Out of Scope (for now)
 
-- **Docker build backend** — Build via a private engine Docker image as alternative to native builds
-- **Build caching** — Skip unchanged pipeline stages based on file hashes
 - **BuildGraph / DAG-based orchestration** — Parallel builds, distributed execution, artifact caching
 - **CGD Toolkit integration** — Use Ludus within the Cloud Game Development Toolkit's CI/CD pipeline
-- **FlexMatch matchmaking** — GameLift matchmaking configuration
-- **Multi-region deployment** — Fleet replication across regions
-- **Client-side auth stack** — Cognito + API Gateway for player authentication
 - **WSL2 support** — OS prereq check update, .wslconfig memory guidance
 - **macOS support** — Mac-specific engine scripts, cross-compilation strategy

--- a/UE_SOURCE_PATCHES.md
+++ b/UE_SOURCE_PATCHES.md
@@ -1,7 +1,7 @@
-# UE 5.6.1 Source Patches Required by Ludus
+# UE Source Patches Required by Ludus
 
-These patches are needed for UE 5.6.1 when building on Windows with SDK >= 26100 (Windows 11 24H2+).
-When Epic fixes these in a future UE release, the corresponding patches can be removed.
+These patches address UE build issues on Windows with SDK >= 26100 (Windows 11 24H2+).
+Validated against UE 5.4.4, 5.5.4, 5.6.1, and 5.7.3 (Feb 2026).
 
 ## 1. NNERuntimeORT: Missing INITGUID for DXCore GUID (Windows SDK >= 26100)
 
@@ -25,7 +25,9 @@ if (Version.TryParse(Target.WindowsPlatform.WindowsSdkVersion, out Version Windo
 }
 ```
 
-**Status**: Bug in UE 5.6.1. Expected to be fixed in 5.6.2+.
+**Status**: Bug in UE 5.6.x only. Epic disabled `ORT_USE_NEW_DXCORE_FEATURES` in 5.7 (commented
+out the code block). The feature does not exist in 5.4 or 5.5. Ludus version-gates this patch
+to 5.6 only.
 
 ---
 
@@ -61,16 +63,21 @@ Ludus should auto-detect and handle this in `ludus init`.
 
 These are applied automatically by ludus at build time:
 
-### NuGet Audit Level (`ensureNuGetAuditDisabled`)
-**File**: `Engine/Source/Programs/Directory.Build.props` (created at runtime)
+### NuGet Audit Level (`applyNuGetAuditWorkaround`)
+**Method**: Sets `NuGetAuditLevel=critical` as an environment variable on child processes.
+Does NOT create `Directory.Build.props` — the env var approach avoids modifying the source tree.
 **Reason**: UE 5.6's Gauntlet test framework depends on Magick.NET 14.7.0 with known CVEs.
 Combined with `TreatWarningsAsErrors`, AutomationTool script modules fail to compile.
-Setting `NuGetAuditLevel=critical` allows non-critical CVEs through.
+The env var is harmless on other versions (MSBuild ignores it). Gauntlet + Magick.NET
+are present in UE 5.4–5.7.
 
 ### Default Server Target (`ensureDefaultServerTarget`)
 **File**: `Samples/Games/Lyra/Config/DefaultEngine.ini` (modified at runtime)
-**Reason**: UE 5.6 Lyra ships with multiple server targets. `DefaultServerTarget=LyraServer`
-must be set for RunUAT to know which target to build.
+**Reason**: Lyra ships with multiple server targets across all UE 5.x versions (5.4–5.7).
+`DefaultServerTarget=LyraServer` must be set for RunUAT to know which target to build.
+The INI structure is identical in all tested versions (`DefaultGameTarget=LyraGame` under
+`[/Script/BuildSettings.BuildSettings]`). The patch degrades gracefully — if the expected
+anchor line is missing, it skips without error.
 
 ---
 
@@ -110,9 +117,9 @@ in the content copy step, ensuring plugin content is included.
 ## Validation Checklist for Future UE Versions
 
 When upgrading UE, check if these are still needed:
-- [ ] NNERuntimeORT links correctly without INITGUID on SDK >= 26100
-- [ ] AnimNextAnimGraph compiles without C4756 on the latest MSVC
-- [ ] RigLogicLib compiles without C4458 on the latest MSVC
-- [ ] Gauntlet's Magick.NET dependency is updated (no more NuGet audit failures)
-- [ ] Lyra's DefaultEngine.ini includes DefaultServerTarget by default
+- [x] NNERuntimeORT links correctly without INITGUID on SDK >= 26100 — **Fixed in 5.7** (Epic commented out `ORT_USE_NEW_DXCORE_FEATURES`; not present in 5.4/5.5)
+- [ ] AnimNextAnimGraph compiles without C4756 on the latest MSVC — Windows-only, needs build test
+- [ ] RigLogicLib compiles without C4458 on the latest MSVC — Windows-only, needs build test
+- [ ] Gauntlet's Magick.NET dependency is updated (no more NuGet audit failures) — present in 5.4–5.7
+- [ ] Lyra's DefaultEngine.ini includes DefaultServerTarget by default — not set in 5.4–5.7
 - [ ] Lyra Marketplace download includes GameFeature plugin Content in a single package (no separate copy needed)

--- a/internal/prereq/checker_windows.go
+++ b/internal/prereq/checker_windows.go
@@ -329,27 +329,34 @@ func (c *Checker) checkNNERuntimeORTPatch() CheckResult {
 		}
 	}
 
-	// Auto-fix: insert PublicDefinitions.Add("INITGUID"); before PublicDependencyModuleNames
-	marker := "PublicDependencyModuleNames"
+	// Auto-fix: insert PublicDefinitions.Add("INITGUID"); after ORT_USE_NEW_DXCORE_FEATURES
+	marker := `PublicDefinitions.Add("ORT_USE_NEW_DXCORE_FEATURES");`
 	idx := strings.Index(content, marker)
 	if idx == -1 {
 		return CheckResult{
 			Name:   "NNERuntimeORT Patch",
 			Passed: false,
-			Message: fmt.Sprintf("could not find %s in %s; patch manually per UE_SOURCE_PATCHES.md",
-				marker, buildCSPath),
+			Message: fmt.Sprintf("could not find ORT_USE_NEW_DXCORE_FEATURES in %s; patch manually per UE_SOURCE_PATCHES.md",
+				buildCSPath),
 		}
 	}
 
-	// Find the start of the line containing the marker to preserve indentation
+	// Find the end of the marker line so we can insert after it
 	lineStart := strings.LastIndex(content[:idx], "\n") + 1
 	indent := content[lineStart:idx]
 	if trimmed := strings.TrimLeft(indent, " \t"); len(trimmed) > 0 {
 		indent = indent[:len(indent)-len(trimmed)]
 	}
 
+	lineEnd := strings.Index(content[idx:], "\n")
+	if lineEnd == -1 {
+		lineEnd = len(content)
+	} else {
+		lineEnd += idx + 1 // include the newline
+	}
+
 	patchLine := indent + "PublicDefinitions.Add(\"INITGUID\");\n"
-	patched := content[:lineStart] + patchLine + content[lineStart:]
+	patched := content[:lineEnd] + patchLine + content[lineEnd:]
 
 	if err := os.WriteFile(buildCSPath, []byte(patched), 0o644); err != nil {
 		return CheckResult{

--- a/scripts/validate_ue_versions.sh
+++ b/scripts/validate_ue_versions.sh
@@ -1,0 +1,265 @@
+#!/usr/bin/env bash
+# validate_ue_versions.sh — Structural validation of UE source releases against
+# Ludus's assumptions. Extracts only the specific files Ludus touches and checks
+# compatibility without building anything.
+set -euo pipefail
+
+DOWNLOADS_DIR="${1:-$HOME/Downloads}"
+WORK_DIR=$(mktemp -d)
+REPORT_FILE="$DOWNLOADS_DIR/ue_version_compatibility_report.txt"
+
+trap 'rm -rf "$WORK_DIR"' EXIT
+
+TARBALLS=(
+    "UnrealEngine-5.4.4-release.tar.gz"
+    "UnrealEngine-5.5.4-release.tar.gz"
+    "UnrealEngine-5.6.1-release.tar.gz"
+    "UnrealEngine-5.7.3-release.tar.gz"
+)
+
+PASS="[PASS]"
+FAIL="[FAIL]"
+WARN="[WARN]"
+INFO="[INFO]"
+
+{
+echo "========================================================================"
+echo "  Ludus — UE Version Compatibility Report"
+echo "  Generated: $(date -u '+%Y-%m-%d %H:%M:%S UTC')"
+echo "========================================================================"
+echo ""
+
+for tarball in "${TARBALLS[@]}"; do
+    tarpath="$DOWNLOADS_DIR/$tarball"
+    version="${tarball#UnrealEngine-}"
+    version="${version%-release.tar.gz}"
+
+    echo "------------------------------------------------------------------------"
+    echo "  UE $version"
+    echo "------------------------------------------------------------------------"
+    echo ""
+
+    if [[ ! -f "$tarpath" ]]; then
+        echo "  $FAIL Tarball not found: $tarpath"
+        echo ""
+        continue
+    fi
+
+    echo "  $INFO Tarball: $tarball ($(du -h "$tarpath" | cut -f1))"
+
+    # Step 1: Generate full file listing ONCE (takes ~30-60s per tarball)
+    echo "  $INFO Generating file listing..."
+    LISTING="$WORK_DIR/${version}_listing.txt"
+    tar -tzf "$tarpath" > "$LISTING"
+    FILE_COUNT=$(wc -l < "$LISTING")
+    echo "  $INFO $FILE_COUNT files in archive"
+
+    # Discover the top-level directory prefix
+    PREFIX=$(head -1 "$LISTING")
+    PREFIX="${PREFIX%%/*}"
+    echo "  $INFO Archive prefix: $PREFIX"
+    echo ""
+
+    # Step 2: Extract only the files we need to inspect
+    VDIR="$WORK_DIR/$version"
+    mkdir -p "$VDIR"
+
+    EXTRACT_FILES=(
+        "$PREFIX/Engine/Build/Build.version"
+        "$PREFIX/Engine/Plugins/NNE/NNERuntimeORT/Source/NNERuntimeORT/NNERuntimeORT.Build.cs"
+        "$PREFIX/Samples/Games/Lyra/Config/DefaultEngine.ini"
+        "$PREFIX/Engine/Source/Programs/Directory.Build.props"
+    )
+    for f in "${EXTRACT_FILES[@]}"; do
+        tar -xzf "$tarpath" -C "$VDIR" "$f" 2>/dev/null || true
+    done
+
+    EDIR="$VDIR/$PREFIX"
+
+    # ---------------------------------------------------------------
+    # 1. Engine/Build/Build.version
+    # ---------------------------------------------------------------
+    echo "  --- Build.version ---"
+    BV_PATH="$EDIR/Engine/Build/Build.version"
+    ENGINE_VER=""
+    if [[ -f "$BV_PATH" ]]; then
+        MAJOR=$(python3 -c "import json; d=json.load(open('$BV_PATH')); print(d['MajorVersion'])" 2>/dev/null || echo "?")
+        MINOR=$(python3 -c "import json; d=json.load(open('$BV_PATH')); print(d['MinorVersion'])" 2>/dev/null || echo "?")
+        PATCH=$(python3 -c "import json; d=json.load(open('$BV_PATH')); print(d['PatchVersion'])" 2>/dev/null || echo "?")
+        ENGINE_VER="${MAJOR}.${MINOR}"
+        echo "  $PASS Build.version found: ${MAJOR}.${MINOR}.${PATCH}"
+
+        case "$ENGINE_VER" in
+            5.4|5.5|5.6|5.7)
+                echo "  $PASS Engine $ENGINE_VER is in Ludus toolchainMap"
+                ;;
+            *)
+                echo "  $FAIL Engine $ENGINE_VER is NOT in Ludus toolchainMap (needs entry)"
+                ;;
+        esac
+    else
+        echo "  $FAIL Build.version not found at expected path"
+    fi
+    echo ""
+
+    # ---------------------------------------------------------------
+    # 2. NNERuntimeORT.Build.cs (INITGUID patch target)
+    # ---------------------------------------------------------------
+    echo "  --- NNERuntimeORT.Build.cs (INITGUID patch) ---"
+    ORT_PATH="$EDIR/Engine/Plugins/NNE/NNERuntimeORT/Source/NNERuntimeORT/NNERuntimeORT.Build.cs"
+    if [[ -f "$ORT_PATH" ]]; then
+        echo "  $PASS File exists at expected path"
+
+        if grep -q "INITGUID" "$ORT_PATH"; then
+            echo "  $PASS INITGUID already present — patch NOT needed"
+        else
+            echo "  $WARN INITGUID not present — patch may be needed (Windows SDK >= 26100)"
+        fi
+
+        if grep -q "ORT_USE_NEW_DXCORE_FEATURES" "$ORT_PATH"; then
+            echo "  $WARN Contains ORT_USE_NEW_DXCORE_FEATURES — DXCore GUID bug may apply"
+        else
+            echo "  $INFO No ORT_USE_NEW_DXCORE_FEATURES reference — DXCore issue N/A"
+        fi
+
+        if grep -q "PublicDependencyModuleNames" "$ORT_PATH"; then
+            echo "  $PASS PublicDependencyModuleNames marker found (Ludus auto-fix insertion point OK)"
+        else
+            echo "  $FAIL PublicDependencyModuleNames marker NOT found — Ludus auto-fix would FAIL"
+        fi
+    else
+        if grep -q "Engine/Plugins/NNE/" "$LISTING"; then
+            echo "  $WARN NNE plugin exists but NNERuntimeORT.Build.cs at different path"
+            grep "NNERuntimeORT.Build.cs" "$LISTING" | head -3 | while read -r p; do
+                echo "  $INFO   Found: $p"
+            done
+        else
+            echo "  $INFO NNE plugin does not exist in this version — INITGUID patch N/A"
+        fi
+    fi
+    echo ""
+
+    # ---------------------------------------------------------------
+    # 3. Lyra project structure
+    # ---------------------------------------------------------------
+    echo "  --- Lyra project ---"
+    LYRA_INI="$EDIR/Samples/Games/Lyra/Config/DefaultEngine.ini"
+
+    if grep -q "$PREFIX/Samples/Games/Lyra/Lyra.uproject" "$LISTING"; then
+        echo "  $PASS Lyra.uproject found at expected path"
+    else
+        LYRA_HIT=$(grep "Lyra.uproject" "$LISTING" | head -1 || echo "")
+        if [[ -n "$LYRA_HIT" ]]; then
+            echo "  $WARN Lyra.uproject found at different path: $LYRA_HIT"
+        else
+            echo "  $FAIL Lyra.uproject not found anywhere in archive"
+        fi
+    fi
+
+    if [[ -f "$LYRA_INI" ]]; then
+        echo "  $PASS DefaultEngine.ini found"
+
+        if grep -q "DefaultServerTarget" "$LYRA_INI"; then
+            echo "  $PASS DefaultServerTarget already set — Ludus patch NOT needed"
+        else
+            echo "  $WARN DefaultServerTarget not set — Ludus will add it at build time"
+        fi
+
+        if grep -q "DefaultGameTarget=" "$LYRA_INI"; then
+            GAME_TARGET=$(grep "DefaultGameTarget=" "$LYRA_INI" | head -1 | tr -d '\r')
+            echo "  $PASS Found: $GAME_TARGET (Ludus insertion anchor present)"
+        else
+            echo "  $WARN DefaultGameTarget= not found — Ludus DefaultServerTarget patch would SKIP"
+        fi
+    else
+        echo "  $INFO DefaultEngine.ini not extracted (may not exist in source — Lyra Content needed)"
+    fi
+
+    echo ""
+    echo "  --- Lyra GameFeature plugins (source structure) ---"
+    PLUGINS=("ShooterCore" "ShooterMaps" "TopDownArena" "ShooterExplorer" "ShooterTests")
+    for plugin in "${PLUGINS[@]}"; do
+        if grep -q "$PREFIX/Samples/Games/Lyra/Plugins/GameFeatures/$plugin/" "$LISTING"; then
+            echo "  $PASS $plugin plugin directory exists"
+        else
+            echo "  $WARN $plugin plugin directory NOT found"
+        fi
+    done
+    echo ""
+
+    # ---------------------------------------------------------------
+    # 4. Linux cross-compile toolchain (bundled SDK)
+    # ---------------------------------------------------------------
+    echo "  --- Linux cross-compile toolchain ---"
+    TC_DIRS=$(grep "$PREFIX/Engine/Extras/ThirdPartyNotUE/SDKs/HostLinux/Linux_x64/" "$LISTING" 2>/dev/null \
+        | grep -oP "Linux_x64/[^/]+" | sort -u || echo "")
+    if [[ -n "$TC_DIRS" ]]; then
+        echo "  $PASS SDK directory exists. Bundled toolchains:"
+        while read -r tc; do
+            tc_name="${tc#Linux_x64/}"
+            echo "  $INFO   $tc_name"
+        done <<< "$TC_DIRS"
+    else
+        echo "  $WARN HostLinux/Linux_x64 SDK path not found (toolchain needs manual install via Setup.sh)"
+    fi
+    echo ""
+
+    # ---------------------------------------------------------------
+    # 5. Directory.Build.props (NuGet audit)
+    # ---------------------------------------------------------------
+    echo "  --- Directory.Build.props (NuGet audit) ---"
+    DBPROPS="$EDIR/Engine/Source/Programs/Directory.Build.props"
+    if [[ -f "$DBPROPS" ]]; then
+        echo "  $INFO Directory.Build.props exists in source tree"
+        if grep -q "NuGetAudit" "$DBPROPS"; then
+            echo "  $INFO Contains NuGet audit config"
+        fi
+    else
+        echo "  $INFO Not present (Ludus uses env var workaround — no file modification needed)"
+    fi
+    echo ""
+
+    # ---------------------------------------------------------------
+    # 6. Setup scripts
+    # ---------------------------------------------------------------
+    echo "  --- Setup scripts ---"
+    if grep -q "^$PREFIX/Setup.sh$" "$LISTING"; then
+        echo "  $PASS Setup.sh found (Linux engine source check passes)"
+    else
+        echo "  $FAIL Setup.sh NOT found (Ludus engine source validation would FAIL)"
+    fi
+    if grep -q "^$PREFIX/Setup.bat$" "$LISTING"; then
+        echo "  $PASS Setup.bat found (Windows engine source check passes)"
+    else
+        echo "  $FAIL Setup.bat NOT found (Ludus Windows validation would FAIL)"
+    fi
+    echo ""
+
+    # ---------------------------------------------------------------
+    # Summary
+    # ---------------------------------------------------------------
+    echo "  --- Ludus version-gated patch summary for UE $version ---"
+    if [[ "$ENGINE_VER" == "5.6" ]]; then
+        echo "  $INFO INITGUID patch:          APPLIES (gated to 5.6)"
+        echo "  $INFO NuGet audit workaround:   APPLIES (gated to 5.6)"
+    else
+        echo "  $INFO INITGUID patch:          SKIPPED (gated to 5.6 only)"
+        echo "  $INFO NuGet audit workaround:   SKIPPED (gated to 5.6 only)"
+    fi
+    echo "  $INFO DefaultServerTarget:     APPLIES (no version gate — graceful skip if anchor missing)"
+    echo "  $WARN MSVC 14.38 pin:          APPLIES UNCONDITIONALLY — may be wrong for $ENGINE_VER"
+    echo ""
+    echo ""
+
+    # Clean up extracted files
+    rm -rf "$VDIR"
+done
+
+echo "========================================================================"
+echo "  End of report"
+echo "========================================================================"
+
+} 2>&1 | tee "$REPORT_FILE"
+
+echo ""
+echo "Report saved to: $REPORT_FILE"


### PR DESCRIPTION
## Summary

- **Bug fix**: `checkNNERuntimeORTPatch` searched for `PublicDependencyModuleNames` as the insertion marker, but no version of `NNERuntimeORT.Build.cs` has that string — all use `PrivateDependencyModuleNames`. The auto-fix (`ludus init --fix`) would silently fail on every UE version. Fixed to use `ORT_USE_NEW_DXCORE_FEATURES` as the correct insertion point.
- **UE version validation**: Ran structural validation against UE 5.4.4, 5.5.4, 5.6.1, and 5.7.3 source tarballs. Key finding: Epic disabled `ORT_USE_NEW_DXCORE_FEATURES` in 5.7 (commented out the code block), so the INITGUID patch is only needed for 5.6 — the existing version gate is correct.
- **Docs updated**: Added `AGENTS.md` with agent guidelines, updated `SPEC.md` (moved 4 completed items to Implemented, removed 3 deprioritized Future items, fixed MCP tool count 13→15), updated `UE_SOURCE_PATCHES.md` with multi-version findings, added `scripts/validate_ue_versions.sh` for future UE release testing.

## Validation results (all 4 versions)

| Check | 5.4 | 5.5 | 5.6 | 5.7 |
|---|---|---|---|---|
| Build.version parses | ✅ | ✅ | ✅ | ✅ |
| Toolchain map entry | ✅ | ✅ | ✅ | ✅ |
| Setup.sh / Setup.bat | ✅ | ✅ | ✅ | ✅ |
| Lyra project + INI | ✅ | ✅ | ✅ | ✅ |
| DefaultGameTarget anchor | ✅ | ✅ | ✅ | ✅ |
| GameFeature plugins (5/5) | ✅ | ✅ | ✅ | ✅ |
| INITGUID needed | N/A | N/A | Yes | Fixed by Epic |