### PR TITLE
Add UE source patch testing procedures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -177,3 +177,40 @@ nouns like `Setup.sh` or `Lyra.uproject`.
 - **Build caching**: `.ludus/cache.json` with input hashing per stage.
 - **Platform dispatch**: `//go:build windows` / `//go:build !windows` pairs providing
   matching function signatures. Minor differences use `runtime.GOOS` inline.
+
+## Testing UE Source Patches
+
+Ludus applies patches to UE source files at init/build time. To validate these
+against real UE source, download releases via GitHub CLI (requires Epic Games
+account linked to GitHub):
+
+```bash
+# Download a specific UE release
+gh release download 5.6.1-release --repo EpicGames/UnrealEngine --archive tar.gz -O ue-5.6.1.tar.gz
+```
+
+### INITGUID auto-fix (Windows + UE 5.6 only)
+
+The auto-fix in `internal/prereq/checker_windows.go` patches
+`NNERuntimeORT.Build.cs` to add `INITGUID` after `ORT_USE_NEW_DXCORE_FEATURES`.
+It only triggers on Windows SDK >= 26100 with engine version 5.6 (skipped on
+5.4, 5.5, 5.7). To test:
+
+1. Extract `NNERuntimeORT.Build.cs` from a UE 5.6 tarball
+2. Point `engine.sourcePath` at the extracted tree
+3. Run `ludus init --fix --verbose`
+4. Verify the patched file has `PublicDefinitions.Add("INITGUID");` on the line
+   after `PublicDefinitions.Add("ORT_USE_NEW_DXCORE_FEATURES");`
+
+### Full multi-version structural validation (Linux)
+
+`scripts/validate_ue_versions.sh` checks Ludus's assumptions (file paths,
+markers, plugin structure) against multiple UE source tarballs without building.
+Place tarballs named `UnrealEngine-X.Y.Z-release.tar.gz` in `~/Downloads/` and
+run:
+
+```bash
+bash scripts/validate_ue_versions.sh ~/Downloads
+```
+
+See `UE_SOURCE_PATCHES.md` for full details on each patch and testing procedures.

--- a/UE_SOURCE_PATCHES.md
+++ b/UE_SOURCE_PATCHES.md
@@ -114,6 +114,55 @@ in the content copy step, ensuring plugin content is included.
 
 ---
 
+## Testing Patches
+
+### Quick test: INITGUID auto-fix (Windows, requires UE 5.6 source)
+
+Download UE 5.6.1 and extract only the patch target file:
+```bash
+gh release download 5.6.1-release --repo EpicGames/UnrealEngine --archive tar.gz -O ue-5.6.1.tar.gz
+
+# Linux/macOS:
+tar -xzf ue-5.6.1.tar.gz --wildcards "*/NNERuntimeORT/NNERuntimeORT.Build.cs"
+
+# Windows (PowerShell — no --wildcards support):
+tar -xzf ue-5.6.1.tar.gz "<prefix>/Engine/Plugins/NNE/NNERuntimeORT/Source/NNERuntimeORT/NNERuntimeORT.Build.cs"
+# (get <prefix> from: tar -tzf ue-5.6.1.tar.gz | Select-Object -First 1)
+```
+
+Point `engine.sourcePath` in `ludus.yaml` at the extracted directory and run:
+```bash
+ludus init --fix --verbose
+```
+
+Verify the patched `NNERuntimeORT.Build.cs` has `INITGUID` inserted correctly:
+```csharp
+PublicDefinitions.Add("ORT_USE_NEW_DXCORE_FEATURES");
+PublicDefinitions.Add("INITGUID");  // <-- should appear on the next line
+```
+
+The auto-fix is version-gated to 5.6 only and requires Windows SDK >= 26100.
+On 5.4, 5.5, or 5.7, the check is skipped entirely.
+
+### Full structural validation (Linux)
+
+Download release tarballs for each target version to `~/Downloads/`:
+```bash
+gh release download 5.4.4-release --repo EpicGames/UnrealEngine --archive tar.gz -O ~/Downloads/UnrealEngine-5.4.4-release.tar.gz
+gh release download 5.5.4-release --repo EpicGames/UnrealEngine --archive tar.gz -O ~/Downloads/UnrealEngine-5.5.4-release.tar.gz
+gh release download 5.6.1-release --repo EpicGames/UnrealEngine --archive tar.gz -O ~/Downloads/UnrealEngine-5.6.1-release.tar.gz
+gh release download 5.7.3-release --repo EpicGames/UnrealEngine --archive tar.gz -O ~/Downloads/UnrealEngine-5.7.3-release.tar.gz
+```
+
+Run the validation script:
+```bash
+bash scripts/validate_ue_versions.sh ~/Downloads
+```
+
+Report is saved to `~/Downloads/ue_version_compatibility_report.txt`.
+
+---
+
 ## Validation Checklist for Future UE Versions
 
 When upgrading UE, check if these are still needed:


### PR DESCRIPTION
## Summary

- Add testing instructions to `UE_SOURCE_PATCHES.md`: how to download UE releases via `gh`, extract the INITGUID patch target file, run `ludus init --fix`, and verify the result. Includes both a quick single-file test (any OS) and full multi-version structural validation (Linux).
- Add matching "Testing UE Source Patches" section to `AGENTS.md` so coding agents working in this repo know how to validate patches against real UE source without being told explicitly.