### PR TITLE
Improve AGENTS.md: fix inaccuracies, add missing patterns

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,31 +24,36 @@ go vet ./...                      # Static analysis
 go mod tidy                       # Clean up module dependencies
 ```
 
-Pre-commit hooks (`.hooks/pre-commit`) run build, lint, and test. Activate with
-`git config core.hooksPath .hooks`.
+Pre-commit hooks (`.hooks/pre-commit`) run `go build ./...`, lint, and `go test ./...`.
+Activate with `git config core.hooksPath .hooks`.
 
 ## Project Structure
 
 - `main.go` — Entry point; calls `root.Execute()`.
-- `cmd/` — Cobra command packages. Each exports `var Cmd = &cobra.Command{...}`,
-  registered in `cmd/root/root.go`. Handler functions are named `run<Command>`.
-- `cmd/globals/` — Mutable global state: `Cfg`, `Verbose`, `JSONOutput`, `DryRun`.
+- `cmd/` — Cobra command packages. Each command package exports `var Cmd = &cobra.Command{...}`,
+  registered in `cmd/root/root.go` via `rootCmd.AddCommand(...)` in `init()`.
+  Handler functions are named `run<Command>`.
+  - **Exceptions**: `cmd/globals/` exports mutable global state (`Cfg`, `Verbose`,
+    `JSONOutput`, `DryRun`), not a `Cmd`. The `init` command is defined as an
+    unexported `initCmd` in `cmd/root/init.go`.
+  - **Subcommand groups**: Some commands are groups with subcommands (e.g., `deploy`
+    has `fleet`, `stack`, `session`, `anywhere`, `destroy`; `engine` has `build`,
+    `setup`, `push`). These `Cmd` vars have no `RunE` of their own.
+  - `cmd/mcp/` — MCP (Model Context Protocol) server for AI agent orchestration
+    via stdio JSON-RPC.
 - `internal/` — All business logic (unexported). One primary type per file.
   Key packages: `config`, `runner`, `engine`, `game`, `container`, `deploy`,
   `gamelift`, `stack`, `binary`, `anywhere`, `tags`, `state`, `cache`, `status`,
   `prereq`, `toolchain`, `wrapper`, `ci`, `dockerbuild`.
+- Config loaded via Viper from `ludus.yaml`.
 - Platform-specific files use `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
 
 ## Code Style
 
-### Formatting
+### Formatting & Imports
 
-Enforced by `gofmt` (configured in `.golangci.yml`). No manual formatting exceptions.
-
-### Imports
-
-Two groups separated by a blank line: (1) stdlib, (2) everything else (third-party
-and project imports together). Sorted alphabetically within each group.
+Enforced by `gofmt`. Two import groups separated by a blank line: (1) stdlib,
+(2) everything else (third-party and project imports together, sorted alphabetically).
 
 ```go
 import (
@@ -60,80 +65,52 @@ import (
 )
 ```
 
-Aliases only to resolve naming conflicts, using concise names:
-
-```go
-awsconfig "github.com/aws/aws-sdk-go-v2/config"
-gltypes   "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
-```
+Aliases only to resolve naming conflicts, using concise names. Common patterns
+include AWS type packages (`gltypes`, `cftypes`, `iamtypes`) and cmd-vs-internal
+disambiguation (`engBuilder`, `gameBuilder`, `ctrBuilder`, `internalstatus`).
 
 ### Naming
 
-- **Packages**: lowercase, single word (`config`, `deploy`, `gamelift`). Multi-word
-  concatenated (`dockerbuild`), never underscored.
-- **Files**: `snake_case.go`. Build-tagged files: `checker_unix.go`, `process_windows.go`.
+- **Packages**: lowercase, single word. Multi-word concatenated (`dockerbuild`).
+- **Files**: `snake_case.go`. Build-tagged: `checker_unix.go`, `process_windows.go`.
 - **Acronyms**: Fully uppercase: `ID`, `URI`, `ARN`, `ECR`, `IAM`, `AWS`, `SDK`, `IP`.
-- **Structs**: PascalCase nouns — `Builder`, `Deployer`, `Exporter`, `TargetAdapter`.
+- **Structs**: PascalCase nouns — `Builder`, `Deployer`, `TargetAdapter`.
 - **Options/Results**: `BuildOptions`, `BuildResult`, `DeployOptions`, `FleetStatus`.
-- **Unexported constants**: camelCase (`iamRoleName`, `pollInterval`).
-- **Exported constants**: PascalCase (`WrapperRepo`, `StageEngine`).
-- **Variables**: camelCase. Short names for narrow scope (`r`, `b`, `cfg`, `ctx`).
-  Descriptive names for broader scope (`serverBuildDir`, `engineVersion`).
+- **Constants**: Unexported camelCase (`iamRoleName`), exported PascalCase (`WrapperRepo`).
+- **Variables**: camelCase. Short for narrow scope (`r`, `b`, `cfg`, `ctx`),
+  descriptive for broader scope (`serverBuildDir`, `engineVersion`).
 
 ### Constructors and Methods
 
 Constructors use `New*` and return a pointer:
-
 ```go
 func NewBuilder(opts BuildOptions, r *runner.Runner) *Builder
-func NewDeployer(opts DeployOptions, awsCfg aws.Config) *Deployer
 ```
 
-Method receivers are pointer receivers with a single-letter name matching the type:
+Method receivers are single-letter pointer receivers matching the type initial:
 `b` for `*Builder`, `d` for `*Deployer`, `r` for `*Runner`, `c` for `*Checker`.
-
-### Context
 
 `context.Context` is the first parameter for all I/O or long-running methods.
 Pure computation functions omit it.
 
-```go
-func (b *Builder) Build(ctx context.Context) (*BuildResult, error)
-func (d *Deployer) CreateFleet(ctx context.Context, ...) (...)
-```
-
 ### Error Handling
 
-- Wrap with `fmt.Errorf("brief context: %w", err)`. Context is lowercase, no trailing
-  punctuation: `"reading config: %w"`, `"creating location: %w"`.
-- Terminal errors (no underlying cause) use `fmt.Errorf` without `%w`:
-  `fmt.Errorf("Setup.sh not found at %s", path)`.
-- No sentinel errors (`var Err* = errors.New(...)`) — the codebase does not use them.
-- No custom error types — all errors are `fmt.Errorf` or from library calls.
-- Non-fatal issues print a warning and continue:
-  `fmt.Printf("Warning: failed to write state: %v\n", err)`.
+- Wrap with `fmt.Errorf("brief context: %w", err)`. Context is lowercase, no
+  trailing punctuation: `"reading config: %w"`, `"creating location: %w"`.
+- Terminal errors (no underlying cause) use `fmt.Errorf` without `%w`.
+- No sentinel errors (`var Err*`) and no custom error types — all errors are
+  `fmt.Errorf` or from library calls.
+- Non-fatal issues: `fmt.Printf("Warning: failed to write state: %v\n", err)`.
 - AWS not-found checks use string matching helpers (`isNotFound()`), not `errors.Is()`.
 
-### Comments
+### Comments & Output
 
-Doc comments on all exported identifiers, starting with the identifier name:
+Doc comments on all exported identifiers, starting with the identifier name.
+Struct fields get inline `//` comments in config types. Inline comments explain "why".
 
-```go
-// Builder compiles UE5 from source.
-// NewBuilder creates a new engine builder.
-// BuildOptions configures the engine build.
-```
-
-Struct fields get inline `//` comments in config types. Inline code comments explain
-"why", not "what".
-
-### Output / Logging
-
-No logging library. All output via `fmt` functions:
-- `fmt.Println` / `fmt.Printf` for status messages.
-- `fmt.Fprintln(os.Stderr, ...)` for warnings to stderr.
-- Status messages within stages are indented 2 spaces.
-- Verbose command echoing is handled by the `runner.Runner` (prints `+ command`).
+No logging library. All output via `fmt`:
+- `fmt.Println` / `fmt.Printf` for status; `fmt.Fprintln(os.Stderr, ...)` for warnings.
+- Stage messages indented 2 spaces. Verbose echoing via `runner.Runner` (`+ command`).
 - JSON output conditional on `globals.JSONOutput`.
 
 ## Test Conventions
@@ -149,7 +126,7 @@ No logging library. All output via `fmt` functions:
   }
   ```
 - **Assertions** via `if got != want` with `t.Errorf` / `t.Fatalf`.
-- **Temp dirs** via `t.TempDir()` (auto-cleaned).
+- **Temp dirs** via `t.TempDir()`, **env overrides** via `t.Setenv()` (both auto-cleaned).
 - **Skip** unavailable tests with `t.Skipf(...)`.
 - Test files are co-located: `builder_test.go` alongside `builder.go`.
 
@@ -158,59 +135,27 @@ No logging library. All output via `fmt` functions:
 Enabled linters (`.golangci.yml`, v2 format): errcheck, govet, ineffassign,
 staticcheck, unused, gocritic, misspell, unconvert, gosec.
 
-Key gosec exclusions: G104 (unhandled errors in best-effort cleanup), G204/G702
-(subprocess with variable — intentional), G304/G703 (file inclusion via variable —
-intentional), G115 (integer overflow — bounded values), G301 (dir perms 0755),
-G306 (WriteFile 0644).
-
-ST1005 (uppercase error strings) is suppressed — error messages may start with proper
-nouns like `Setup.sh` or `Lyra.uproject`.
+Key gosec exclusions: G104 (unhandled errors in cleanup), G204/G702 (subprocess
+with variable), G304/G703 (file inclusion via variable), G115 (integer overflow),
+G301/G306 (dir/file perms). ST1005 suppressed — error messages may start with
+proper nouns like `Setup.sh`.
 
 ## Key Patterns
 
 - **Builder pattern**: `New*(opts)` constructor, operation methods, structured results.
 - **Runner abstraction**: Never call `exec.Command` directly — use `runner.Runner`
   which handles verbose/dry-run uniformly.
+- **Dual build backends**: Engine and game builds support both `native` and `docker`
+  backends. See `internal/dockerbuild/`.
 - **Pluggable targets**: `deploy.Target` interface with `gamelift`, `stack`, `binary`,
   `anywhere` implementations. Factory in `cmd/globals/resolve.go`.
 - **State persistence**: `.ludus/state.json` for fleet/session/client info.
 - **Build caching**: `.ludus/cache.json` with input hashing per stage.
-- **Platform dispatch**: `//go:build windows` / `//go:build !windows` pairs providing
+- **Platform dispatch**: `//go:build windows` / `//go:build !windows` pairs with
   matching function signatures. Minor differences use `runtime.GOOS` inline.
 
-## Testing UE Source Patches
+## UE Source Patches
 
-Ludus applies patches to UE source files at init/build time. To validate these
-against real UE source, download releases via GitHub CLI (requires Epic Games
-account linked to GitHub):
-
-```bash
-# Download a specific UE release
-gh release download 5.6.1-release --repo EpicGames/UnrealEngine --archive tar.gz -O ue-5.6.1.tar.gz
-```
-
-### INITGUID auto-fix (Windows + UE 5.6 only)
-
-The auto-fix in `internal/prereq/checker_windows.go` patches
-`NNERuntimeORT.Build.cs` to add `INITGUID` after `ORT_USE_NEW_DXCORE_FEATURES`.
-It only triggers on Windows SDK >= 26100 with engine version 5.6 (skipped on
-5.4, 5.5, 5.7). To test:
-
-1. Extract `NNERuntimeORT.Build.cs` from a UE 5.6 tarball
-2. Point `engine.sourcePath` at the extracted tree
-3. Run `ludus init --fix --verbose`
-4. Verify the patched file has `PublicDefinitions.Add("INITGUID");` on the line
-   after `PublicDefinitions.Add("ORT_USE_NEW_DXCORE_FEATURES");`
-
-### Full multi-version structural validation (Linux)
-
-`scripts/validate_ue_versions.sh` checks Ludus's assumptions (file paths,
-markers, plugin structure) against multiple UE source tarballs without building.
-Place tarballs named `UnrealEngine-X.Y.Z-release.tar.gz` in `~/Downloads/` and
-run:
-
-```bash
-bash scripts/validate_ue_versions.sh ~/Downloads
-```
-
-See `UE_SOURCE_PATCHES.md` for full details on each patch and testing procedures.
+Ludus patches UE source files at init/build time. See `UE_SOURCE_PATCHES.md` for
+full details on each patch and testing procedures. Use `scripts/validate_ue_versions.sh`
+for multi-version structural validation against UE source tarballs.


### PR DESCRIPTION
## Summary

- Fix inaccurate claim that all cmd packages export `Cmd` — document exceptions (`globals/`, `root/init.go`) and subcommand groups (`deploy`, `engine`)
- Add missing documentation: MCP server (`cmd/mcp/`), Viper config (`ludus.yaml`), dual build backends (native/docker), richer import alias patterns (cmd-vs-internal disambiguation), `t.Setenv()` in test conventions
- Condense from 216 to 161 lines by merging redundant sections (Formatting+Imports, Comments+Output, Context into Constructors) and replacing the 36-line UE Source Patches testing section with a 3-line reference to `UE_SOURCE_PATCHES.md`

All claims verified against the actual codebase.