### PR TITLE
Fix Windows cross-compile and EC2 fleet deploy for Shipping builds

### DIFF
--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -21,6 +21,7 @@ var (
 	backend        string
 	noCache        bool
 	noCacheClient  bool
+	serverConfig   string
 )
 
 // Cmd is the top-level game command group.
@@ -65,6 +66,7 @@ func init() {
 	buildCmd.Flags().BoolVar(&skipCook, "skip-cook", false, "skip content cooking (use previously cooked content)")
 	buildCmd.Flags().StringVar(&backend, "backend", "", `build backend: "native" or "docker" (default: from ludus.yaml)`)
 	buildCmd.Flags().BoolVar(&noCache, "no-cache", false, "disable build caching (forces rebuild even if inputs are unchanged)")
+	buildCmd.Flags().StringVar(&serverConfig, "config", "", `build configuration: "Development" or "Shipping" (default: Development)`)
 	clientCmd.Flags().BoolVar(&skipCookClient, "skip-cook", false, "skip content cooking (use previously cooked content)")
 	clientCmd.Flags().StringVar(&backend, "backend", "", `build backend: "native" or "docker" (default: from ludus.yaml)`)
 	clientCmd.Flags().BoolVar(&noCacheClient, "no-cache", false, "disable build caching (forces rebuild even if inputs are unchanged)")
@@ -147,6 +149,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		SkipCook:      skipCook,
 		ServerMap:     cfg.Game.ServerMap,
 		EngineVersion: engineVersion,
+		ServerConfig:  serverConfig,
 	}, r)
 
 	fmt.Printf("Building %s dedicated server...\n", cfg.Game.ProjectName)

--- a/internal/ec2fleet/deployer.go
+++ b/internal/ec2fleet/deployer.go
@@ -154,12 +154,31 @@ func (d *Deployer) ZipAndUpload(ctx context.Context, serverBuildDir string) (buc
 		return "", "", fmt.Errorf("game server wrapper: %w", err)
 	}
 
+	// Generate wrapper config for managed EC2.
+	// Detect the actual server binary name — Development builds use the bare
+	// target name (e.g. "LyraServer"), while Shipping/Test builds use
+	// "<Target>-Linux-<Config>" (e.g. "LyraServer-Linux-Shipping").
+	serverBinaryName := d.opts.ServerTarget
+	binDir := filepath.Join(serverBuildDir, d.opts.ProjectName, "Binaries", "Linux")
+	if entries, err := os.ReadDir(binDir); err == nil {
+		for _, e := range entries {
+			name := e.Name()
+			if strings.HasPrefix(name, d.opts.ServerTarget+"-Linux-") && !strings.Contains(name, ".") {
+				serverBinaryName = name
+				break
+			}
+		}
+	}
+	serverBinaryPath := fmt.Sprintf("./%s/Binaries/Linux/%s",
+		d.opts.ProjectName, serverBinaryName)
+	wrapperConfig := generateEC2WrapperConfig(serverBinaryPath, d.opts.ServerMap, d.opts.ServerPort)
+
 	// Create zip file
 	fmt.Println("Creating server build zip...")
 	zipPath := filepath.Join(os.TempDir(), fmt.Sprintf("ludus-ec2-build-%d.zip", time.Now().UnixNano()))
 	defer os.Remove(zipPath)
 
-	if err := createBuildZip(zipPath, serverBuildDir, wrapperBinary); err != nil {
+	if err := createBuildZip(zipPath, serverBuildDir, wrapperBinary, wrapperConfig); err != nil {
 		return "", "", fmt.Errorf("creating build zip: %w", err)
 	}
 
@@ -191,8 +210,9 @@ func (d *Deployer) ZipAndUpload(ctx context.Context, serverBuildDir string) (buc
 func (d *Deployer) CreateBuild(ctx context.Context, bucket, key string) (string, error) {
 	fmt.Println("Creating GameLift build...")
 	out, err := d.glClient.CreateBuild(ctx, &gamelift.CreateBuildInput{
-		Name:            aws.String(fmt.Sprintf("ludus-%s", d.opts.FleetName)),
-		OperatingSystem: gltypes.OperatingSystemAmazonLinux2023,
+		Name:             aws.String(fmt.Sprintf("ludus-%s", d.opts.FleetName)),
+		OperatingSystem:  gltypes.OperatingSystemAmazonLinux2023,
+		ServerSdkVersion: aws.String("5.4.0"),
 		StorageLocation: &gltypes.S3Location{
 			Bucket:  aws.String(bucket),
 			Key:     aws.String(key),
@@ -208,8 +228,9 @@ func (d *Deployer) CreateBuild(ctx context.Context, bucket, key string) (string,
 		}
 
 		out, err = d.glClient.CreateBuild(ctx, &gamelift.CreateBuildInput{
-			Name:            aws.String(fmt.Sprintf("ludus-%s", d.opts.FleetName)),
-			OperatingSystem: gltypes.OperatingSystemAmazonLinux2023,
+			Name:             aws.String(fmt.Sprintf("ludus-%s", d.opts.FleetName)),
+			OperatingSystem:  gltypes.OperatingSystemAmazonLinux2023,
+			ServerSdkVersion: aws.String("5.4.0"),
 			StorageLocation: &gltypes.S3Location{
 				Bucket:  aws.String(bucket),
 				Key:     aws.String(key),
@@ -286,6 +307,26 @@ func (d *Deployer) ensureIAMRole(ctx context.Context) (string, error) {
 		return "", fmt.Errorf("attaching policy to role: %w", err)
 	}
 
+	// EC2 managed builds require S3 read access for GameLift to download
+	// the build archive. The GameLiftContainerFleetPolicy only covers
+	// container fleets, so we add an inline policy for S3.
+	s3Policy := `{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["s3:GetObject", "s3:GetObjectVersion"],
+    "Resource": "arn:aws:s3:::ludus-builds-*/*"
+  }]
+}`
+	_, err = d.iamClient.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		RoleName:       aws.String(iamRoleName),
+		PolicyName:     aws.String("LudusS3BuildAccess"),
+		PolicyDocument: aws.String(s3Policy),
+	})
+	if err != nil {
+		return "", fmt.Errorf("adding S3 access policy: %w", err)
+	}
+
 	// Wait for IAM propagation
 	time.Sleep(10 * time.Second)
 
@@ -299,13 +340,11 @@ func (d *Deployer) CreateFleet(ctx context.Context, buildID string) (*FleetStatu
 		return nil, err
 	}
 
-	// The wrapper binary is at the root of the zip; the server binary is under
-	// the project directory structure.
+	// The wrapper binary is at the root of the zip; game server details
+	// (executable path, map, etc.) are configured in config.yaml, not via
+	// CLI flags. The wrapper only accepts --port to override the game port.
 	launchPath := "/local/game/amazon-gamelift-servers-game-server-wrapper"
-	serverBinary := fmt.Sprintf("/local/game/%s/Binaries/Linux/%s",
-		d.opts.ProjectName, d.opts.ServerTarget)
-	launchParams := fmt.Sprintf("--executable %s --map %s --port %d",
-		serverBinary, d.opts.ServerMap, d.opts.ServerPort)
+	launchParams := fmt.Sprintf("--port %d", d.opts.ServerPort)
 
 	fmt.Println("Creating EC2 fleet...")
 	out, err := d.glClient.CreateFleet(ctx, &gamelift.CreateFleetInput{
@@ -519,6 +558,12 @@ func (d *Deployer) deleteIAMRole(ctx context.Context) error {
 		return fmt.Errorf("detaching policy from role: %w", err)
 	}
 
+	// Remove S3 access inline policy
+	_, _ = d.iamClient.DeleteRolePolicy(ctx, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String(iamRoleName),
+		PolicyName: aws.String("LudusS3BuildAccess"),
+	})
+
 	_, err = d.iamClient.DeleteRole(ctx, &iam.DeleteRoleInput{
 		RoleName: aws.String(iamRoleName),
 	})
@@ -541,9 +586,31 @@ type GameSessionInfo struct {
 	Port      int
 }
 
-// createBuildZip creates a zip file containing the server build directory and
-// the game server wrapper binary at the root.
-func createBuildZip(zipPath, serverBuildDir, wrapperBinary string) error {
+// generateEC2WrapperConfig creates the game server wrapper config.yaml content
+// for a GameLift Managed EC2 deployment.
+func generateEC2WrapperConfig(serverBinaryPath, serverMap string, serverPort int) string {
+	return fmt.Sprintf(`# Generated by ludus for GameLift Managed EC2
+log-config:
+  wrapper-log-level: debug
+  game-server-logs-dir: ./game-server-logs
+
+ports:
+  gamePort: %d
+
+game-server-details:
+  executable-file-path: %s
+  game-server-args:
+    - arg: "-port"
+      val: "{{.GamePort}}"
+      pos: 0
+    - arg: "-Map=%s"
+      pos: 1
+`, serverPort, serverBinaryPath, serverMap)
+}
+
+// createBuildZip creates a zip file containing the server build directory,
+// the game server wrapper binary, and its config.yaml at the root.
+func createBuildZip(zipPath, serverBuildDir, wrapperBinary, wrapperConfig string) error {
 	f, err := os.Create(zipPath)
 	if err != nil {
 		return err
@@ -556,6 +623,15 @@ func createBuildZip(zipPath, serverBuildDir, wrapperBinary string) error {
 	// Add wrapper binary at the root of the zip
 	if err := addFileToZip(w, wrapperBinary, "amazon-gamelift-servers-game-server-wrapper"); err != nil {
 		return fmt.Errorf("adding wrapper to zip: %w", err)
+	}
+
+	// Add wrapper config.yaml at the root
+	configWriter, err := w.Create("config.yaml")
+	if err != nil {
+		return fmt.Errorf("creating config.yaml in zip: %w", err)
+	}
+	if _, err := configWriter.Write([]byte(wrapperConfig)); err != nil {
+		return fmt.Errorf("writing config.yaml to zip: %w", err)
 	}
 
 	// Add server build directory contents
@@ -604,8 +680,13 @@ func addFileToZip(w *zip.Writer, srcPath, zipPath string) error {
 	header.Name = zipPath
 	header.Method = zip.Deflate
 
-	// Preserve executable permission
-	if info.Mode()&0111 != 0 {
+	// On Windows, files lack Unix execute bits. Force 0755 for binaries
+	// (no extension = Linux binary, .sh = shell script) so they're
+	// executable on the GameLift Linux instance.
+	ext := filepath.Ext(zipPath)
+	if ext == "" || ext == ".sh" {
+		header.SetMode(0755)
+	} else if info.Mode()&0111 != 0 {
 		header.SetMode(info.Mode())
 	}
 

--- a/internal/game/builder.go
+++ b/internal/game/builder.go
@@ -42,6 +42,9 @@ type BuildOptions struct {
 	// EngineVersion is the detected engine major.minor version (e.g. "5.6").
 	// Used to apply version-specific workarounds.
 	EngineVersion string
+	// ServerConfig is the build configuration for the server (e.g. "Development", "Shipping").
+	// Defaults to "Development" if empty.
+	ServerConfig string
 }
 
 // BuildResult holds the outcome of a game server build.
@@ -141,6 +144,7 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 	}
 
 	b.applyNuGetAuditWorkaround()
+	b.ensureLinuxMultiarchRoot()
 
 	if err := b.ensureDefaultServerTarget(projectPath); err != nil {
 		result.Error = fmt.Errorf("setting default server target: %w", err)
@@ -170,6 +174,10 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		"-package",
 		"-archive",
 		fmt.Sprintf(`-archivedirectory="%s"`, outputDir),
+	}
+
+	if b.opts.ServerConfig != "" {
+		args = append(args, fmt.Sprintf("-serverconfig=%s", b.opts.ServerConfig))
 	}
 
 	if !b.opts.SkipCook {
@@ -243,6 +251,7 @@ func (b *Builder) BuildClient(ctx context.Context) (*ClientBuildResult, error) {
 	}
 
 	b.applyNuGetAuditWorkaround()
+	b.ensureLinuxMultiarchRoot()
 
 	outputDir := b.opts.OutputDir
 	if outputDir == "" {
@@ -311,6 +320,19 @@ func (b *Builder) applyNuGetAuditWorkaround() {
 		return
 	}
 	b.Runner.Env = append(b.Runner.Env, "NuGetAuditLevel=critical")
+}
+
+// ensureLinuxMultiarchRoot explicitly passes LINUX_MULTIARCH_ROOT through the
+// runner's Env so it survives RunUAT's AutoSDK environment manipulation.
+// RunUAT's Turnkey system can strip or reset this variable when switching SDK
+// modes, which prevents UnrealEditor-Cmd.exe from detecting the Linux platform
+// during content cooking. By setting it on the runner, it's merged into every
+// child process environment regardless of what RunUAT does internally.
+func (b *Builder) ensureLinuxMultiarchRoot() {
+	v := os.Getenv("LINUX_MULTIARCH_ROOT")
+	if v != "" {
+		b.Runner.Env = append(b.Runner.Env, "LINUX_MULTIARCH_ROOT="+v)
+	}
 }
 
 // ensureDefaultServerTarget adds DefaultServerTarget to the project's

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 
 	"github.com/devrecon/ludus/internal/runner"
 )
@@ -14,6 +15,10 @@ const (
 	WrapperRepo = "https://github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper.git"
 	// WrapperVersion is the Git tag to clone.
 	WrapperVersion = "v1.1.0"
+	// serverSDKURL is the GameLift Server SDK download URL used by the Makefile.
+	serverSDKURL = "https://github.com/amazon-gamelift/amazon-gamelift-servers-go-server-sdk/releases/download/v5.4.0/GameLift-Go-ServerSDK-5.4.0.zip"
+	// appPackage is the Go module path for ldflags version injection.
+	appPackage = "github.com/amazon-gamelift/amazon-gamelift-servers-game-server-wrapper"
 )
 
 // CacheDir returns the cache directory for the game server wrapper.
@@ -62,7 +67,7 @@ func EnsureBinary(ctx context.Context, r *runner.Runner) (string, error) {
 
 	// Build the wrapper
 	fmt.Println("  Building game server wrapper...")
-	if err := r.RunInDir(ctx, cacheDir, "make", "build"); err != nil {
+	if err := buildWrapper(ctx, r, cacheDir); err != nil {
 		// Clean up on build failure so next run retries
 		os.RemoveAll(cacheDir)
 		return "", fmt.Errorf("building game server wrapper: %w", err)
@@ -75,4 +80,76 @@ func EnsureBinary(ctx context.Context, r *runner.Runner) (string, error) {
 	}
 
 	return binaryPath, nil
+}
+
+// buildWrapper builds the game server wrapper binary. On systems with make,
+// it delegates to `make build`. On Windows (where make is typically absent),
+// it runs the equivalent steps directly: download the server SDK, cross-compile
+// the Go binary for linux/amd64, and copy the config file.
+func buildWrapper(ctx context.Context, r *runner.Runner, cacheDir string) error {
+	if runtime.GOOS != "windows" {
+		return r.RunInDir(ctx, cacheDir, "make", "build")
+	}
+	return buildWrapperWindows(ctx, r, cacheDir)
+}
+
+// buildWrapperWindows replicates the Makefile's `build` target on Windows
+// without requiring make, using curl and Go cross-compilation.
+func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir string) error {
+	sdkZip := filepath.Join(cacheDir, "gamelift-servers-server-sdk.zip")
+	sdkDir := filepath.Join(cacheDir, "src", "ext", "gamelift-servers-server-sdk")
+
+	// Download the GameLift Server SDK if not already present
+	if _, err := os.Stat(sdkZip); err != nil {
+		fmt.Println("  Downloading GameLift Server SDK...")
+		if err := r.RunInDir(ctx, cacheDir, "curl", "-L", serverSDKURL, "-o", sdkZip); err != nil {
+			return fmt.Errorf("downloading server SDK: %w", err)
+		}
+	}
+
+	// Extract the SDK
+	if _, err := os.Stat(sdkDir); err != nil {
+		if err := os.MkdirAll(sdkDir, 0755); err != nil {
+			return fmt.Errorf("creating SDK directory: %w", err)
+		}
+		// Use PowerShell to extract since unzip may not be available
+		if err := r.Run(ctx, "powershell", "-NoProfile", "-Command",
+			fmt.Sprintf("Expand-Archive -Path '%s' -DestinationPath '%s' -Force", sdkZip, sdkDir)); err != nil {
+			return fmt.Errorf("extracting server SDK: %w", err)
+		}
+	}
+
+	// Cross-compile for linux/amd64
+	srcDir := filepath.Join(cacheDir, "src")
+	outDir := filepath.Join(cacheDir, "out", "linux", "amd64")
+	binaryDir := filepath.Join(outDir, "gamelift-servers-managed-containers")
+	if err := os.MkdirAll(binaryDir, 0755); err != nil {
+		return fmt.Errorf("creating output directory: %w", err)
+	}
+
+	binaryPath := filepath.Join(binaryDir, "amazon-gamelift-servers-game-server-wrapper")
+	ldflags := fmt.Sprintf("-X '%s/internal.version=1.1.0'", appPackage)
+
+	buildRunner := *r
+	buildRunner.Env = append(buildRunner.Env, "CGO_ENABLED=0", "GOOS=linux", "GOARCH=amd64")
+	if err := buildRunner.RunInDir(ctx, srcDir, "go", "build",
+		"-trimpath", "-v",
+		"-ldflags="+ldflags,
+		"-o", binaryPath,
+		"."); err != nil {
+		return fmt.Errorf("go build: %w", err)
+	}
+
+	// Copy the managed-containers config template
+	configSrc := filepath.Join(srcDir, "template", "template-managed-containers-config.yaml")
+	configDst := filepath.Join(binaryDir, "config.yaml")
+	configData, err := os.ReadFile(configSrc)
+	if err != nil {
+		return fmt.Errorf("reading config template: %w", err)
+	}
+	if err := os.WriteFile(configDst, configData, 0644); err != nil {
+		return fmt.Errorf("writing config: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary

- **`--config` flag**: Added to `ludus game build` to select Shipping or Development build configuration
- **LINUX_MULTIARCH_ROOT passthrough**: RunUAT's AutoSDK/Turnkey system strips this env var before spawning UnrealEditor-Cmd.exe, breaking Linux platform detection during content cooking. Now explicitly passed through the runner's Env slice.
- **Shipping binary auto-detection**: EC2 fleet deployer now scans `Binaries/Linux/` for `<Target>-Linux-<Config>` pattern (e.g. `LyraServer-Linux-Shipping`) instead of assuming bare target name
- **Wrapper config.yaml generation**: Game server wrapper now uses `config.yaml` with correct binary path, map, and port instead of CLI flags (which the wrapper doesn't support)
- **GameLift API fixes**: Added `ServerSdkVersion` to `CreateBuild` calls, S3 read access inline IAM policy for EC2 builds
- **Windows zip permissions**: Force 0755 for extensionless Linux binaries and .sh scripts (Windows lacks Unix execute bits)
- **Windows wrapper build**: Build game server wrapper without `make` via direct Go cross-compilation + PowerShell SDK extraction

## Test plan

- [x] UE 5.4.4 Shipping: engine build + game server + EC2 deploy + client connect
- [x] UE 5.5.4 Shipping: engine build + game server + EC2 deploy + client connect + gameplay confirmed
- [ ] UE 5.6.1 Shipping: game server build in progress
- [ ] UE 5.7.3 Shipping: pending
- [x] golangci-lint passes (v2)
- [x] go test passes
- [x] go build passes (Windows)