### PR TITLE
Add Windows E2E stabilization fixes for UE 5.6+

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -13,6 +13,13 @@ else
 fi
 
 echo "==> Running tests..."
+# On Windows, AppLocker may block test executables from %TEMP%.
+# Redirect Go's temp dir to a location that AppLocker allows.
+if [[ "$OSTYPE" == "msys" || "$OSTYPE" == "win32" || "$OSTYPE" == "cygwin" ]]; then
+    GOTMPDIR="${GOTMPDIR:-$HOME/.cache/go-test-tmp}"
+    mkdir -p "$GOTMPDIR"
+    export GOTMPDIR
+fi
 go test ./...
 
 echo "==> All checks passed"

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,7 +40,7 @@ func Load(path string) (*Config, error) {
 	if v.IsSet("lyra") && !v.IsSet("game") {
 		fmt.Fprintln(os.Stderr, "WARNING: 'lyra:' config key is deprecated, rename to 'game:' in ludus.yaml")
 		// Copy lyra sub-keys into game namespace so Viper unmarshals them correctly
-		for _, key := range []string{"projectPath", "projectName", "serverTarget", "clientTarget", "gameTarget", "platform", "skipCook", "serverMap", "contentValidation"} {
+		for _, key := range []string{"projectPath", "projectName", "contentSourcePath", "serverTarget", "clientTarget", "gameTarget", "platform", "skipCook", "serverMap", "contentValidation"} {
 			if v.IsSet("lyra." + key) {
 				v.Set("game."+key, v.Get("lyra."+key))
 			}
@@ -102,6 +102,13 @@ type GameConfig struct {
 	ProjectPath string `yaml:"projectPath"`
 	// ProjectName is the name of the UE5 project (e.g. "Lyra", "MyGame").
 	ProjectName string `yaml:"projectName"`
+	// ContentSourcePath is the path to the downloaded game content that needs to
+	// be overlaid onto the engine source tree. For Lyra, this is the path to the
+	// "Lyra Starter Game" downloaded from the Epic Games Launcher (e.g.
+	// "C:\Users\...\Unreal Projects\LyraStarterGame"). When set, `ludus init --fix`
+	// will copy Content/ and plugin Content/ directories into the engine's
+	// Samples/Games/Lyra/ directory.
+	ContentSourcePath string `yaml:"contentSourcePath"`
 	// ServerTarget is the server build target name. Defaults to ProjectName + "Server".
 	ServerTarget string `yaml:"serverTarget"`
 	// ClientTarget is the client build target name. Defaults to ProjectName + "Game".

--- a/internal/game/builder.go
+++ b/internal/game/builder.go
@@ -328,8 +328,15 @@ func (b *Builder) applyNuGetAuditWorkaround() {
 // modes, which prevents UnrealEditor-Cmd.exe from detecting the Linux platform
 // during content cooking. By setting it on the runner, it's merged into every
 // child process environment regardless of what RunUAT does internally.
+//
+// On Windows, if the env var is not set in the current process (common after
+// toolchain install without restarting the terminal), falls back to reading
+// the system environment from the Windows registry.
 func (b *Builder) ensureLinuxMultiarchRoot() {
 	v := os.Getenv("LINUX_MULTIARCH_ROOT")
+	if v == "" && runtime.GOOS == "windows" {
+		v = readSystemEnvVar("LINUX_MULTIARCH_ROOT")
+	}
 	if v != "" {
 		b.Runner.Env = append(b.Runner.Env, "LINUX_MULTIARCH_ROOT="+v)
 	}

--- a/internal/game/sysenv_unix.go
+++ b/internal/game/sysenv_unix.go
@@ -1,0 +1,10 @@
+//go:build !windows
+
+package game
+
+// readSystemEnvVar is a no-op on non-Windows platforms. On Linux/macOS,
+// environment variables set by installers are immediately available in the
+// current shell (no registry indirection).
+func readSystemEnvVar(_ string) string {
+	return ""
+}

--- a/internal/game/sysenv_windows.go
+++ b/internal/game/sysenv_windows.go
@@ -1,0 +1,37 @@
+//go:build windows
+
+package game
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// readSystemEnvVar reads a system-level environment variable from the Windows
+// registry. This is useful when the current process was started before the
+// variable was set (e.g. after a toolchain installer sets LINUX_MULTIARCH_ROOT
+// without the user restarting their terminal).
+func readSystemEnvVar(name string) string {
+	out, err := exec.Command("reg", "query",
+		`HKLM\SYSTEM\CurrentControlSet\Control\Session Manager\Environment`,
+		"/v", name,
+	).Output()
+	if err != nil {
+		return ""
+	}
+	// Output format: "    LINUX_MULTIARCH_ROOT    REG_SZ    C:\UnrealToolchains\..."
+	for _, line := range strings.Split(string(out), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.Contains(line, name) {
+			parts := strings.SplitN(line, "REG_SZ", 2)
+			if len(parts) == 2 {
+				return strings.TrimSpace(parts[1])
+			}
+			parts = strings.SplitN(line, "REG_EXPAND_SZ", 2)
+			if len(parts) == 2 {
+				return strings.TrimSpace(parts[1])
+			}
+		}
+	}
+	return ""
+}

--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -202,15 +202,9 @@ func (c *Checker) checkLyraContent() CheckResult {
 	contentDir := filepath.Join(lyraDir, "Content")
 	gameData := filepath.Join(contentDir, "DefaultGameData.uasset")
 
+	contentMissing := false
 	if _, err := os.Stat(gameData); os.IsNotExist(err) {
-		return CheckResult{
-			Name:   "Lyra Content",
-			Passed: false,
-			Message: fmt.Sprintf("Lyra Content not found at %s. "+
-				"Epic does not distribute Lyra assets via GitHub. "+
-				"Download 'Lyra Starter Game' from the Epic Games Launcher Marketplace, "+
-				"then copy its Content/ folder to %s", contentDir, contentDir),
-		}
+		contentMissing = true
 	}
 
 	// Verify plugin content dirs exist (common oversight: copying only top-level Content/)
@@ -220,30 +214,149 @@ func (c *Checker) checkLyraContent() CheckResult {
 		"TopDownArena",
 	}
 
-	var missing []string
-	for _, plugin := range pluginContentDirs {
-		pluginDir := filepath.Join(lyraDir, "Plugins", "GameFeatures", plugin, "Content")
-		if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
-			missing = append(missing, plugin)
+	var missingPlugins []string
+	if !contentMissing {
+		for _, plugin := range pluginContentDirs {
+			pluginDir := filepath.Join(lyraDir, "Plugins", "GameFeatures", plugin, "Content")
+			if _, err := os.Stat(pluginDir); os.IsNotExist(err) {
+				missingPlugins = append(missingPlugins, plugin)
+			}
 		}
 	}
 
-	if len(missing) > 0 {
+	// Content is fully present
+	if !contentMissing && len(missingPlugins) == 0 {
+		return CheckResult{
+			Name:    "Lyra Content",
+			Passed:  true,
+			Message: fmt.Sprintf("found at %s (including plugin content)", contentDir),
+		}
+	}
+
+	// Content is missing — check if we can auto-fix
+	contentSourcePath := ""
+	if c.GameConfig != nil {
+		contentSourcePath = c.GameConfig.ContentSourcePath
+	}
+
+	if contentMissing {
+		if contentSourcePath == "" {
+			return CheckResult{
+				Name:   "Lyra Content",
+				Passed: false,
+				Message: fmt.Sprintf("Lyra Content not found at %s. "+
+					"Download 'Lyra Starter Game' from the Epic Games Launcher, "+
+					"then either copy it to %s manually, or set game.contentSourcePath "+
+					"in ludus.yaml and run ludus init --fix", contentDir, lyraDir),
+			}
+		}
+		if !c.Fix {
+			return CheckResult{
+				Name:   "Lyra Content",
+				Passed: false,
+				Message: fmt.Sprintf("Lyra Content not found at %s; "+
+					"run with --fix to overlay from %s",
+					contentDir, contentSourcePath),
+			}
+		}
+		return c.overlayLyraContent(contentSourcePath, lyraDir)
+	}
+
+	// Top-level content exists but plugin content is missing
+	if contentSourcePath != "" && c.Fix {
+		return c.overlayLyraContent(contentSourcePath, lyraDir)
+	}
+
+	return CheckResult{
+		Name:   "Lyra Content",
+		Passed: false,
+		Message: fmt.Sprintf("top-level Content/ found but plugin content missing for: %s. "+
+			"Copy the ENTIRE downloaded Lyra project over %s (overlay, not just Content/). "+
+			"Each GameFeature plugin has its own Content/ directory required for cooking.",
+			strings.Join(missingPlugins, ", "), lyraDir),
+	}
+}
+
+// overlayLyraContent copies the downloaded Lyra project content from
+// contentSourcePath into the engine's Lyra directory. This overlays Content/
+// directories at both the top level and under Plugins/GameFeatures/*/Content/.
+func (c *Checker) overlayLyraContent(srcPath, dstPath string) CheckResult {
+	if _, err := os.Stat(srcPath); os.IsNotExist(err) {
+		return CheckResult{
+			Name:    "Lyra Content",
+			Passed:  false,
+			Message: fmt.Sprintf("content source path does not exist: %s", srcPath),
+		}
+	}
+
+	fmt.Printf("  Overlaying Lyra content from %s to %s...\n", srcPath, dstPath)
+
+	// Use robocopy on Windows (handles long paths, preserves structure) or
+	// cp -a on Unix. We copy the entire source directory contents into the
+	// destination, which overlays Content/ and Plugins/ without destroying
+	// existing source code files.
+	var copyErr error
+	if runtime.GOOS == "windows" {
+		copyErr = c.robocopyOverlay(srcPath, dstPath)
+	} else {
+		copyErr = c.cpOverlay(srcPath, dstPath)
+	}
+
+	if copyErr != nil {
+		return CheckResult{
+			Name:    "Lyra Content",
+			Passed:  false,
+			Message: fmt.Sprintf("failed to overlay content: %v", copyErr),
+		}
+	}
+
+	// Verify the overlay worked
+	gameData := filepath.Join(dstPath, "Content", "DefaultGameData.uasset")
+	if _, err := os.Stat(gameData); os.IsNotExist(err) {
 		return CheckResult{
 			Name:   "Lyra Content",
 			Passed: false,
-			Message: fmt.Sprintf("top-level Content/ found but plugin content missing for: %s. "+
-				"Copy the ENTIRE downloaded Lyra project over %s (overlay, not just Content/). "+
-				"Each GameFeature plugin has its own Content/ directory required for cooking.",
-				strings.Join(missing, ", "), lyraDir),
+			Message: fmt.Sprintf("overlay completed but Content/DefaultGameData.uasset still missing; "+
+				"verify %s contains the correct Lyra project", srcPath),
 		}
 	}
 
 	return CheckResult{
 		Name:    "Lyra Content",
 		Passed:  true,
-		Message: fmt.Sprintf("found at %s (including plugin content)", contentDir),
+		Message: fmt.Sprintf("overlaid from %s", srcPath),
 	}
+}
+
+// robocopyOverlay uses robocopy to copy srcPath contents into dstPath.
+// Robocopy exit codes 0-7 indicate success (various levels of files copied/skipped).
+func (c *Checker) robocopyOverlay(srcPath, dstPath string) error {
+	cmd := exec.Command("robocopy", srcPath, dstPath, "/E", "/NFL", "/NDL", "/NJH", "/NJS", "/NC", "/NS")
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	err := cmd.Run()
+	if err != nil {
+		// robocopy returns non-zero for success (1 = files copied, etc.)
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			if exitErr.ExitCode() < 8 {
+				return nil // exit codes 0-7 are success
+			}
+		}
+		return fmt.Errorf("robocopy failed: %w", err)
+	}
+	return nil
+}
+
+// cpOverlay uses cp -a to copy srcPath contents into dstPath.
+func (c *Checker) cpOverlay(srcPath, dstPath string) error {
+	// Ensure trailing slash on src so cp copies contents, not the directory itself
+	if !strings.HasSuffix(srcPath, "/") {
+		srcPath += "/"
+	}
+	cmd := exec.Command("cp", "-a", srcPath+".", dstPath)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
 }
 
 func (c *Checker) checkToolchain() CheckResult {

--- a/internal/prereq/checker_windows.go
+++ b/internal/prereq/checker_windows.go
@@ -38,6 +38,15 @@ func (c *Checker) platformChecks() []CheckResult {
 		}
 	}
 
+	// UE 5.6+ added a Dataflow plugin dependency to HairStrands. The
+	// HairStrandsEditor DLL imports DataflowEditor DLL, but the Dataflow
+	// plugin's Binaries/Win64/ dir is not in the DLL search path during
+	// plugin loading. Without the fix, the cook phase fails with
+	// GetLastError=4551 ("Missing import: UnrealEditor-DataflowEditor.dll").
+	if c.EngineSourcePath != "" && needsDataflowFix(c.EngineSourcePath, c.EngineVersion) {
+		results = append(results, c.checkDataflowPluginDLLs())
+	}
+
 	return results
 }
 
@@ -209,6 +218,26 @@ func needsNewerMSVC(sourcePath, configVersion string) bool {
 		return false
 	}
 	return minor >= 7
+}
+
+// needsDataflowFix returns true when the engine version is 5.6 or later.
+// UE 5.6 introduced a Dataflow plugin dependency in HairStrands that causes
+// DLL loading failures during cook unless the Dataflow DLLs are copied to
+// Engine/Binaries/Win64/.
+func needsDataflowFix(sourcePath, configVersion string) bool {
+	ver, _ := toolchain.DetectEngineVersion(sourcePath, configVersion)
+	if ver == "" {
+		return false // unknown version — skip to avoid touching files unnecessarily
+	}
+	parts := strings.SplitN(ver, ".", 2)
+	if len(parts) < 2 {
+		return false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return false
+	}
+	return minor >= 6
 }
 
 // msvcVersionForEngine returns the MSVC version string to pin in
@@ -456,6 +485,95 @@ func (c *Checker) checkNNERuntimeORTPatch() CheckResult {
 		Name:    "NNERuntimeORT Patch",
 		Passed:  true,
 		Message: fmt.Sprintf("patched %s (added INITGUID definition)", buildCSPath),
+	}
+}
+
+// checkDataflowPluginDLLs verifies that the Dataflow plugin's editor DLLs
+// are present in Engine/Binaries/Win64/ where the DLL loader can find them.
+// In UE 5.6+, HairStrandsEditor.dll imports DataflowEditor.dll, but the
+// Dataflow plugin builds its DLLs into its own Binaries/Win64/ subdirectory
+// which is not in the DLL search path when HairStrands loads.
+func (c *Checker) checkDataflowPluginDLLs() CheckResult {
+	const checkName = "Dataflow Plugin DLLs"
+
+	srcDir := filepath.Join(c.EngineSourcePath,
+		"Engine", "Plugins", "Experimental", "Dataflow", "Binaries", "Win64")
+	dstDir := filepath.Join(c.EngineSourcePath, "Engine", "Binaries", "Win64")
+
+	// DLLs that HairStrandsEditor transitively depends on
+	dllNames := []string{
+		"UnrealEditor-DataflowAssetTools.dll",
+		"UnrealEditor-DataflowEditor.dll",
+		"UnrealEditor-DataflowEnginePlugin.dll",
+		"UnrealEditor-DataflowNodes.dll",
+	}
+
+	// Check if the source plugin DLLs exist at all (engine must be built first)
+	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
+		return CheckResult{
+			Name:    checkName,
+			Passed:  true,
+			Warning: true,
+			Message: fmt.Sprintf("Dataflow plugin not built yet (%s); will be checked after engine build", srcDir),
+		}
+	}
+
+	// Check which DLLs are missing from the engine binaries dir
+	var missing []string
+	for _, dll := range dllNames {
+		srcPath := filepath.Join(srcDir, dll)
+		if _, err := os.Stat(srcPath); os.IsNotExist(err) {
+			continue // source DLL doesn't exist, skip
+		}
+		dstPath := filepath.Join(dstDir, dll)
+		if _, err := os.Stat(dstPath); os.IsNotExist(err) {
+			missing = append(missing, dll)
+		}
+	}
+
+	if len(missing) == 0 {
+		return CheckResult{
+			Name:    checkName,
+			Passed:  true,
+			Message: "Dataflow plugin DLLs present in Engine/Binaries/Win64/",
+		}
+	}
+
+	if !c.Fix {
+		return CheckResult{
+			Name:   checkName,
+			Passed: false,
+			Message: fmt.Sprintf("missing %d Dataflow DLL(s) in Engine/Binaries/Win64/ "+
+				"(cook will fail with HairStrandsEditor load error); "+
+				"run with --fix to copy them", len(missing)),
+		}
+	}
+
+	// Auto-fix: copy missing DLLs from the plugin dir to Engine/Binaries/Win64/
+	for _, dll := range missing {
+		src := filepath.Join(srcDir, dll)
+		dst := filepath.Join(dstDir, dll)
+		data, err := os.ReadFile(src)
+		if err != nil {
+			return CheckResult{
+				Name:    checkName,
+				Passed:  false,
+				Message: fmt.Sprintf("failed to read %s: %v", src, err),
+			}
+		}
+		if err := os.WriteFile(dst, data, 0o644); err != nil {
+			return CheckResult{
+				Name:    checkName,
+				Passed:  false,
+				Message: fmt.Sprintf("failed to write %s: %v", dst, err),
+			}
+		}
+	}
+
+	return CheckResult{
+		Name:    checkName,
+		Passed:  true,
+		Message: fmt.Sprintf("copied %d Dataflow DLL(s) to Engine/Binaries/Win64/", len(missing)),
 	}
 }
 


### PR DESCRIPTION
## Summary

Three fixes discovered during cross-version E2E testing (UE 5.4.4, 5.5.4, 5.6.1, 5.7.3) on Windows:

- **Dataflow plugin DLL check** (`ludus init --fix`): UE 5.6+ added a Dataflow dependency to HairStrands that causes cook failures (`GetLastError=4551`, missing `DataflowEditor.dll`). Auto-copies 4 Dataflow DLLs to `Engine/Binaries/Win64/` for UE >= 5.6. Version-gated, same pattern as the existing NNERuntimeORT INITGUID patch.

- **`LINUX_MULTIARCH_ROOT` registry fallback**: After cross-compile toolchain install, the system env var is set but the current terminal session doesn't have it. The game builder now reads the Windows registry (`HKLM\...\Environment`) as a fallback, eliminating the need to restart the terminal after `ludus init --fix` installs the toolchain.

- **`game.contentSourcePath` config + auto-overlay**: Users can now set the path to their downloaded Lyra content (from Epic Games Launcher) in `ludus.yaml`. `ludus init --fix` copies it into the engine's `Samples/Games/Lyra/` directory automatically using `robocopy` (Windows) or `cp -a` (Unix).

Also fixes pre-commit hook on Windows machines with AppLocker policies by redirecting `GOTMPDIR` away from `%TEMP%`.

## Test plan

- [x] `go build` passes (Windows)
- [x] `GOOS=linux go build` cross-compile passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass (including `internal/game` with GOTMPDIR fix)
- [x] `ludus init --verbose` correctly detects missing Dataflow DLLs as `[FAIL]`
- [x] `ludus init --fix --verbose` copies Dataflow DLLs and shows `[OK]`
- [x] Verified against UE 5.7.3 engine (build in progress, Dataflow DLLs persisted)
- [x] Verified against UE 5.6.1 (cook succeeded after Dataflow DLL copy)
- [ ] CI (GitHub Actions) — lint + build + test on Ubuntu and Windows