### PR TITLE
Add ARM64/Graviton server build and deploy support

### DIFF
--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/devrecon/ludus/internal/cache"
+	"github.com/devrecon/ludus/internal/config"
 	ctrBuilder "github.com/devrecon/ludus/internal/container"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/spf13/cobra"
@@ -57,11 +58,12 @@ func init() {
 // resolveServerBuildDir determines the server build directory from config.
 func resolveServerBuildDir() string {
 	cfg := globals.Cfg
+	platformDir := config.ServerPlatformDir(cfg.Game.ResolvedArch())
 	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", "LinuxServer")
+		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
 	}
 	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", "LinuxServer")
+		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
 	}
 	return ""
 }

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -22,6 +22,7 @@ var (
 	targetFlag   string
 	stackName    string
 	anywhereIP   string
+	ec2Arch      string
 )
 
 // Cmd is the top-level deploy command group.
@@ -118,6 +119,7 @@ func init() {
 
 	stackCmd.Flags().StringVar(&stackName, "stack-name", "", "CloudFormation stack name (default: ludus-<fleet-name>)")
 	anywhereCmd.Flags().StringVar(&anywhereIP, "ip", "", "local IP address override (default: auto-detect)")
+	ec2Cmd.Flags().StringVar(&ec2Arch, "arch", "", `target CPU architecture: amd64, arm64 (default: from ludus.yaml)`)
 
 	Cmd.AddCommand(fleetCmd)
 	Cmd.AddCommand(stackCmd)
@@ -353,6 +355,9 @@ func runEC2(cmd *cobra.Command, args []string) error {
 	if fleetName != "" {
 		cfg.GameLift.FleetName = fleetName
 	}
+	if ec2Arch != "" {
+		cfg.Game.Arch = ec2Arch
+	}
 
 	target, err := globals.ResolveTarget(cmd.Context(), cfg, "ec2")
 	if err != nil {
@@ -382,11 +387,12 @@ func runEC2(cmd *cobra.Command, args []string) error {
 
 // resolveServerBuildDirFromCfg determines the server build directory from config.
 func resolveServerBuildDirFromCfg(cfg *config.Config) string {
+	platformDir := config.ServerPlatformDir(cfg.Game.ResolvedArch())
 	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", "LinuxServer")
+		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
 	}
 	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", "LinuxServer")
+		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
 	}
 	return ""
 }

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/devrecon/ludus/internal/cache"
+	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/dockerbuild"
 	gameBuilder "github.com/devrecon/ludus/internal/game"
 	"github.com/devrecon/ludus/internal/runner"
@@ -24,6 +25,7 @@ var (
 	serverConfig   string
 	maxJobs        int
 	maxJobsClient  int
+	archFlag       string
 )
 
 // Cmd is the top-level game command group.
@@ -70,6 +72,7 @@ func init() {
 	buildCmd.Flags().BoolVar(&noCache, "no-cache", false, "disable build caching (forces rebuild even if inputs are unchanged)")
 	buildCmd.Flags().StringVar(&serverConfig, "config", "", `build configuration: "Development" or "Shipping" (default: Development)`)
 	buildCmd.Flags().IntVarP(&maxJobs, "jobs", "j", 0, "max parallel compile actions (0 = auto-detect from RAM, halved for cross-compile)")
+	buildCmd.Flags().StringVar(&archFlag, "arch", "", `target CPU architecture: amd64, arm64 (default: from ludus.yaml)`)
 	clientCmd.Flags().BoolVar(&skipCookClient, "skip-cook", false, "skip content cooking (use previously cooked content)")
 	clientCmd.Flags().StringVar(&backend, "backend", "", `build backend: "native" or "docker" (default: from ludus.yaml)`)
 	clientCmd.Flags().BoolVar(&noCacheClient, "no-cache", false, "disable build caching (forces rebuild even if inputs are unchanged)")
@@ -86,6 +89,14 @@ func resolveBackend() string {
 		return backend
 	}
 	return globals.Cfg.Engine.Backend
+}
+
+// resolveArch returns the effective architecture, preferring CLI flag over config.
+func resolveArch() string {
+	if archFlag != "" {
+		return config.NormalizeArch(archFlag)
+	}
+	return globals.Cfg.Game.ResolvedArch()
 }
 
 // resolveEngineImage determines the Docker image to use for game builds.
@@ -141,6 +152,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 	engineVersion, _ := toolchain.DetectEngineVersion(enginePath, cfg.Engine.Version)
 
+	arch := resolveArch()
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)
 	builder := gameBuilder.NewBuilder(gameBuilder.BuildOptions{
 		EnginePath:    enginePath,
@@ -149,6 +161,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		ServerTarget:  cfg.Game.ResolvedServerTarget(),
 		GameTarget:    cfg.Game.ResolvedGameTarget(),
 		Platform:      cfg.Game.Platform,
+		Arch:          arch,
 		ServerOnly:    true,
 		SkipCook:      skipCook,
 		ServerMap:     cfg.Game.ServerMap,
@@ -157,7 +170,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		MaxJobs:       maxJobs,
 	}, r)
 
-	fmt.Printf("Building %s dedicated server...\n", cfg.Game.ProjectName)
+	fmt.Printf("Building %s dedicated server (%s)...\n", cfg.Game.ProjectName, arch)
 	result, err := builder.Build(cmd.Context())
 	if err != nil {
 		return err

--- a/cmd/globals/resolve.go
+++ b/cmd/globals/resolve.go
@@ -142,6 +142,7 @@ func resolveEC2Fleet(ctx context.Context, cfg *config.Config) (deploy.Target, er
 		ProjectName:  cfg.Game.ProjectName,
 		ServerTarget: cfg.Game.ResolvedServerTarget(),
 		ServerMap:    cfg.Game.ServerMap,
+		Arch:         cfg.Game.ResolvedArch(),
 		Tags:         tags.Build(cfg),
 	}, awsCfg, r)
 
@@ -150,11 +151,12 @@ func resolveEC2Fleet(ctx context.Context, cfg *config.Config) (deploy.Target, er
 
 // resolveServerBuildDir determines the server build directory from config.
 func resolveServerBuildDir(cfg *config.Config) string {
+	platformDir := config.ServerPlatformDir(cfg.Game.ResolvedArch())
 	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", "LinuxServer")
+		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
 	}
 	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", "LinuxServer")
+		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
 	}
 	return ""
 }

--- a/cmd/mcp/helpers.go
+++ b/cmd/mcp/helpers.go
@@ -9,11 +9,12 @@ import (
 // resolveServerBuildDir determines the server build directory from config,
 // matching the logic in cmd/container and cmd/pipeline.
 func resolveServerBuildDir(cfg *config.Config) string {
+	platformDir := config.ServerPlatformDir(cfg.Game.ResolvedArch())
 	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", "LinuxServer")
+		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
 	}
 	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", "LinuxServer")
+		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
 	}
 	return ""
 }

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -44,6 +44,7 @@ type deployEC2Input struct {
 	Region       string `json:"region,omitempty" jsonschema:"AWS region override"`
 	InstanceType string `json:"instance_type,omitempty" jsonschema:"EC2 instance type override"`
 	FleetName    string `json:"fleet_name,omitempty" jsonschema:"GameLift fleet name override"`
+	Arch         string `json:"arch,omitempty" jsonschema:"Target CPU architecture: amd64 or arm64 (default: from config)"`
 	DryRun       bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
 
@@ -352,6 +353,9 @@ func handleDeployEC2(ctx context.Context, _ *mcp.CallToolRequest, input deployEC
 	}
 	if input.FleetName != "" {
 		cfg.GameLift.FleetName = input.FleetName
+	}
+	if input.Arch != "" {
+		cfg.Game.Arch = input.Arch
 	}
 
 	target, err := globals.ResolveTarget(ctx, cfg, "ec2")

--- a/cmd/mcp/tools_game.go
+++ b/cmd/mcp/tools_game.go
@@ -19,6 +19,7 @@ import (
 type gameBuildInput struct {
 	SkipCook bool   `json:"skip_cook,omitempty" jsonschema:"Skip content cooking (use previously cooked content)"`
 	Backend  string `json:"backend,omitempty" jsonschema:"Build backend: native or docker (default: from config)"`
+	Arch     string `json:"arch,omitempty" jsonschema:"Target CPU architecture: amd64 or arm64 (default: from config)"`
 	NoCache  bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
 	DryRun   bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
@@ -63,6 +64,7 @@ func makeGameBuildOpts(cfg *config.Config, skipCook bool, clientPlatform string)
 		ClientTarget:   cfg.Game.ResolvedClientTarget(),
 		GameTarget:     cfg.Game.ResolvedGameTarget(),
 		Platform:       cfg.Game.Platform,
+		Arch:           cfg.Game.ResolvedArch(),
 		ClientPlatform: clientPlatform,
 		SkipCook:       skipCook,
 		ServerMap:      cfg.Game.ServerMap,
@@ -95,6 +97,11 @@ func mcpResolveEngineImage(cfg *config.Config) (string, error) {
 
 func handleGameBuild(ctx context.Context, _ *mcp.CallToolRequest, input gameBuildInput) (*mcp.CallToolResult, any, error) {
 	cfg := globals.Cfg
+
+	// Apply arch override
+	if input.Arch != "" {
+		cfg.Game.Arch = input.Arch
+	}
 
 	be := input.Backend
 	if be == "" {

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/devrecon/ludus/internal/cache"
+	"github.com/devrecon/ludus/internal/config"
 	ctrBuilder "github.com/devrecon/ludus/internal/container"
 	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/dockerbuild"
@@ -114,13 +115,14 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 	caps := target.Capabilities()
 
 	// Derive server build directory from project path
+	arch := cfg.Game.ResolvedArch()
 	projectPath := cfg.Game.ProjectPath
 	if projectPath == "" && cfg.Game.ProjectName == "Lyra" {
 		projectPath = filepath.Join(cfg.Engine.SourcePath,
 			"Samples", "Games", "Lyra", "Lyra.uproject")
 	}
 	serverBuildDir := filepath.Join(filepath.Dir(projectPath),
-		"PackagedServer", "LinuxServer")
+		"PackagedServer", config.ServerPlatformDir(arch))
 
 	// Compute cache hashes upfront
 	engineHash := cache.EngineKey(cfg)
@@ -209,7 +211,7 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 			},
 		},
 		{
-			name: fmt.Sprintf("Build %s server (Linux)", projectName),
+			name: fmt.Sprintf("Build %s server (%s)", projectName, config.UEPlatformName(arch)),
 			skip: skipGame,
 			fn: func(ctx context.Context) error {
 				if !noCache && buildCache.IsHit(cache.StageGameServer, serverHash) {
@@ -246,6 +248,7 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 						ServerTarget:  cfg.Game.ResolvedServerTarget(),
 						GameTarget:    cfg.Game.ResolvedGameTarget(),
 						Platform:      cfg.Game.Platform,
+						Arch:          arch,
 						ServerOnly:    true,
 						ServerMap:     cfg.Game.ServerMap,
 						EngineVersion: engineVersion,

--- a/internal/anywhere/adapter.go
+++ b/internal/anywhere/adapter.go
@@ -52,9 +52,9 @@ func (a *TargetAdapter) Deploy(ctx context.Context, input deploy.DeployInput) (*
 		fmt.Printf("Detected local IP: %s\n", ipAddress)
 	}
 
-	// 2. Ensure game server wrapper binary
+	// 2. Ensure game server wrapper binary (anywhere always runs on the local machine's arch)
 	fmt.Println("Ensuring game server wrapper binary...")
-	wrapperBinary, err := wrapper.EnsureBinary(ctx, d.Runner)
+	wrapperBinary, err := wrapper.EnsureBinary(ctx, d.Runner, "")
 	if err != nil {
 		return nil, fmt.Errorf("game server wrapper: %w", err)
 	}

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -150,6 +150,7 @@ func GameServerKey(cfg *config.Config, engineHash string) string {
 		cfg.Game.ServerMap,
 		fmt.Sprintf("%v", cfg.Game.SkipCook),
 		cfg.Engine.Version,
+		cfg.Game.ResolvedArch(),
 	)
 }
 
@@ -168,6 +169,7 @@ func GameClientKey(cfg *config.Config, engineHash string, platform string) strin
 		platform,
 		fmt.Sprintf("%v", cfg.Game.SkipCook),
 		cfg.Engine.Version,
+		cfg.Game.ResolvedArch(),
 	)
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/viper"
 )
@@ -117,6 +118,9 @@ type GameConfig struct {
 	GameTarget string `yaml:"gameTarget"`
 	// Platform is the target build platform (default: "linux").
 	Platform string `yaml:"platform"`
+	// Arch is the target CPU architecture for server builds: "amd64" or "arm64".
+	// Also accepts "x86_64" and "aarch64" (normalized to Go names).
+	Arch string `yaml:"arch"`
 	// SkipCook skips content cooking.
 	SkipCook bool `yaml:"skipCook"`
 	// ServerMap is the default map for the dedicated server.
@@ -159,6 +163,51 @@ func (g *GameConfig) ResolvedGameTarget() string {
 		return g.GameTarget
 	}
 	return g.ProjectName + "Game"
+}
+
+// ResolvedArch returns the normalized architecture, defaulting to "amd64".
+func (g *GameConfig) ResolvedArch() string {
+	return NormalizeArch(g.Arch)
+}
+
+// NormalizeArch maps architecture aliases to Go's GOARCH values.
+// Accepts: amd64, x86_64, arm64, aarch64 (case-insensitive). Defaults to "amd64".
+func NormalizeArch(s string) string {
+	switch strings.ToLower(strings.TrimSpace(s)) {
+	case "arm64", "aarch64":
+		return "arm64"
+	case "amd64", "x86_64", "":
+		return "amd64"
+	default:
+		return "amd64"
+	}
+}
+
+// ServerPlatformDir returns the UE output directory name for server builds.
+// amd64 → "LinuxServer", arm64 → "LinuxArm64Server".
+func ServerPlatformDir(arch string) string {
+	if NormalizeArch(arch) == "arm64" {
+		return "LinuxArm64Server"
+	}
+	return "LinuxServer"
+}
+
+// BinariesPlatformDir returns the UE Binaries subdirectory for the architecture.
+// amd64 → "Linux", arm64 → "LinuxArm64".
+func BinariesPlatformDir(arch string) string {
+	if NormalizeArch(arch) == "arm64" {
+		return "LinuxArm64"
+	}
+	return "Linux"
+}
+
+// UEPlatformName returns the UE platform name used in RunUAT -platform= flag.
+// amd64 → "Linux", arm64 → "LinuxArm64".
+func UEPlatformName(arch string) string {
+	if NormalizeArch(arch) == "arm64" {
+		return "LinuxArm64"
+	}
+	return "Linux"
 }
 
 // AnywhereConfig holds GameLift Anywhere settings for local development.
@@ -244,6 +293,7 @@ func Defaults() *Config {
 		Game: GameConfig{
 			ProjectName: "Lyra",
 			Platform:    "linux",
+			Arch:        "amd64",
 			ServerMap:   "L_Expanse",
 		},
 		Container: ContainerConfig{

--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -85,8 +85,9 @@ func (b *Builder) resolveServerTarget() string {
 
 // ensureWrapper delegates to the shared wrapper package to clone and build
 // the Amazon GameLift Game Server Wrapper binary.
+// Container builds target amd64 (Docker images are single-arch by default).
 func (b *Builder) ensureWrapper(ctx context.Context) (string, error) {
-	return wrapper.EnsureBinary(ctx, b.Runner)
+	return wrapper.EnsureBinary(ctx, b.Runner, "amd64")
 }
 
 // GenerateWrapperConfig produces the config.yaml for the GameLift Game Server Wrapper.

--- a/internal/ec2fleet/deployer.go
+++ b/internal/ec2fleet/deployer.go
@@ -19,6 +19,7 @@ import (
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 
+	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/tags"
 	"github.com/devrecon/ludus/internal/wrapper"
@@ -34,6 +35,7 @@ type DeployOptions struct {
 	ProjectName  string
 	ServerTarget string
 	ServerMap    string
+	Arch         string // "amd64" (default) or "arm64"
 	Tags         map[string]string
 }
 
@@ -148,8 +150,9 @@ func (d *Deployer) ZipAndUpload(ctx context.Context, serverBuildDir string) (buc
 	key = fmt.Sprintf("ludus/%s/%s.zip", d.opts.FleetName, time.Now().UTC().Format("20060102-150405"))
 
 	// Ensure wrapper binary
-	fmt.Println("Ensuring game server wrapper binary...")
-	wrapperBinary, err := wrapper.EnsureBinary(ctx, d.Runner)
+	arch := config.NormalizeArch(d.opts.Arch)
+	fmt.Printf("Ensuring game server wrapper binary (%s)...\n", arch)
+	wrapperBinary, err := wrapper.EnsureBinary(ctx, d.Runner, arch)
 	if err != nil {
 		return "", "", fmt.Errorf("game server wrapper: %w", err)
 	}
@@ -157,20 +160,21 @@ func (d *Deployer) ZipAndUpload(ctx context.Context, serverBuildDir string) (buc
 	// Generate wrapper config for managed EC2.
 	// Detect the actual server binary name — Development builds use the bare
 	// target name (e.g. "LyraServer"), while Shipping/Test builds use
-	// "<Target>-Linux-<Config>" (e.g. "LyraServer-Linux-Shipping").
+	// "<Target>-<Platform>-<Config>" (e.g. "LyraServer-Linux-Shipping").
+	binPlatform := config.BinariesPlatformDir(arch)
 	serverBinaryName := d.opts.ServerTarget
-	binDir := filepath.Join(serverBuildDir, d.opts.ProjectName, "Binaries", "Linux")
+	binDir := filepath.Join(serverBuildDir, d.opts.ProjectName, "Binaries", binPlatform)
 	if entries, err := os.ReadDir(binDir); err == nil {
 		for _, e := range entries {
 			name := e.Name()
-			if strings.HasPrefix(name, d.opts.ServerTarget+"-Linux-") && !strings.Contains(name, ".") {
+			if strings.HasPrefix(name, d.opts.ServerTarget+"-"+binPlatform+"-") && !strings.Contains(name, ".") {
 				serverBinaryName = name
 				break
 			}
 		}
 	}
-	serverBinaryPath := fmt.Sprintf("./%s/Binaries/Linux/%s",
-		d.opts.ProjectName, serverBinaryName)
+	serverBinaryPath := fmt.Sprintf("./%s/Binaries/%s/%s",
+		d.opts.ProjectName, binPlatform, serverBinaryName)
 	wrapperConfig := generateEC2WrapperConfig(serverBinaryPath, d.opts.ServerMap, d.opts.ServerPort)
 
 	// Create zip file

--- a/internal/game/builder.go
+++ b/internal/game/builder.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/runner"
 )
 
@@ -44,6 +45,8 @@ type BuildOptions struct {
 	// EngineVersion is the detected engine major.minor version (e.g. "5.6").
 	// Used to apply version-specific workarounds.
 	EngineVersion string
+	// Arch is the target CPU architecture: "amd64" (default) or "arm64".
+	Arch string
 	// ServerConfig is the build configuration for the server (e.g. "Development", "Shipping").
 	// Defaults to "Development" if empty.
 	ServerConfig string
@@ -156,6 +159,14 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		return result, result.Error
 	}
 
+	arch := config.NormalizeArch(b.opts.Arch)
+	if arch == "arm64" {
+		if err := b.ensureTargetArchitecture(projectPath); err != nil {
+			result.Error = fmt.Errorf("setting target architecture: %w", err)
+			return result, result.Error
+		}
+	}
+
 	outputDir := b.opts.OutputDir
 	if outputDir == "" {
 		outputDir = filepath.Join(filepath.Dir(projectPath), "PackagedServer")
@@ -167,10 +178,11 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		serverTarget = b.opts.ProjectName + "Server"
 	}
 
+	uePlatform := config.UEPlatformName(arch)
 	args := []string{
 		"BuildCookRun",
 		fmt.Sprintf(`-project="%s"`, projectPath),
-		"-platform=Linux",
+		"-platform=" + uePlatform,
 		"-server",
 		"-noclient",
 		fmt.Sprintf("-servertargetname=%s", serverTarget),
@@ -209,7 +221,7 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 	}
 
 	result.Success = true
-	result.ServerBinary = filepath.Join(outputDir, "LinuxServer", serverTarget)
+	result.ServerBinary = filepath.Join(outputDir, config.ServerPlatformDir(arch), serverTarget)
 	result.Duration = time.Since(start).Seconds()
 	return result, nil
 }
@@ -524,5 +536,40 @@ func (b *Builder) ensureDefaultServerTarget(projectPath string) error {
 
 	content = strings.Replace(content, old, replacement, 1)
 	fmt.Printf("  Setting DefaultServerTarget=%s in %s\n", serverTarget, iniPath)
+	return os.WriteFile(iniPath, []byte(content), 0644)
+}
+
+// ensureTargetArchitecture sets TargetArchitecture=AArch64 in the project's
+// DefaultEngine.ini for ARM64 builds. UE5 requires this setting under
+// [/Script/LinuxTargetPlatform.LinuxTargetSettings] to target ARM64.
+func (b *Builder) ensureTargetArchitecture(projectPath string) error {
+	iniPath := filepath.Join(filepath.Dir(projectPath), "Config", "DefaultEngine.ini")
+
+	data, err := os.ReadFile(iniPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			fmt.Printf("  %s not found, skipping TargetArchitecture configuration\n", iniPath)
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", iniPath, err)
+	}
+
+	content := string(data)
+	if strings.Contains(content, "TargetArchitecture=AArch64") {
+		return nil
+	}
+
+	section := "[/Script/LinuxTargetPlatform.LinuxTargetSettings]"
+	entry := "TargetArchitecture=AArch64"
+
+	if strings.Contains(content, section) {
+		// Append the setting after the section header
+		content = strings.Replace(content, section, section+"\n"+entry, 1)
+	} else {
+		// Append the entire section at the end
+		content += "\n" + section + "\n" + entry + "\n"
+	}
+
+	fmt.Printf("  Setting %s in %s\n", entry, iniPath)
 	return os.WriteFile(iniPath, []byte(content), 0644)
 }

--- a/internal/status/status.go
+++ b/internal/status/status.go
@@ -34,7 +34,7 @@ func CheckAll(ctx context.Context, cfg *config.Config, target deploy.Target) []S
 	} else if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
 		gameOutputDir = filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer")
 	}
-	stages = append(stages, CheckServerBuild(cfg.Game.ProjectName, gameOutputDir))
+	stages = append(stages, CheckServerBuild(cfg.Game.ProjectName, gameOutputDir, cfg.Game.ResolvedArch()))
 	stages = append(stages, CheckContainerImage(cfg.Container.ImageName))
 	stages = append(stages, CheckClientBuild(cfg.Game.ProjectName))
 	stages = append(stages, CheckDeployTarget(ctx, target, cfg.Deploy.Target))
@@ -91,14 +91,15 @@ func CheckEngineBuild(sourcePath string) StageStatus {
 }
 
 // CheckServerBuild checks whether the packaged server exists.
-func CheckServerBuild(projectName, outputDir string) StageStatus {
+// arch should be "amd64" or "arm64" (defaults to "amd64" if empty).
+func CheckServerBuild(projectName, outputDir, arch string) StageStatus {
 	s := StageStatus{Name: projectName + " Server Build"}
 	if outputDir == "" {
 		s.Status = "unknown"
 		s.Detail = "output directory unknown"
 		return s
 	}
-	serverDir := filepath.Join(outputDir, "LinuxServer")
+	serverDir := filepath.Join(outputDir, config.ServerPlatformDir(arch))
 	if _, err := os.Stat(serverDir); os.IsNotExist(err) {
 		s.Status = "fail"
 		s.Detail = "not built"

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -30,52 +30,61 @@ func CacheDir() (string, error) {
 	return filepath.Join(home, ".cache", "ludus", "game-server-wrapper"), nil
 }
 
-// BinaryPath returns the path to the cached wrapper binary.
-func BinaryPath(cacheDir string) string {
-	return filepath.Join(cacheDir, "out", "linux", "amd64",
+// BinaryPath returns the path to the cached wrapper binary for the given architecture.
+// arch should be "amd64" or "arm64".
+func BinaryPath(cacheDir, arch string) string {
+	if arch == "" {
+		arch = "amd64"
+	}
+	return filepath.Join(cacheDir, "out", "linux", arch,
 		"gamelift-servers-managed-containers", "amazon-gamelift-servers-game-server-wrapper")
 }
 
 // EnsureBinary clones and builds the Amazon GameLift Game Server Wrapper,
 // returning the path to the built binary. Results are cached in ~/.cache/ludus/.
-func EnsureBinary(ctx context.Context, r *runner.Runner) (string, error) {
+// arch should be "amd64" or "arm64" (defaults to "amd64").
+func EnsureBinary(ctx context.Context, r *runner.Runner, arch string) (string, error) {
+	if arch == "" {
+		arch = "amd64"
+	}
+
 	cacheDir, err := CacheDir()
 	if err != nil {
 		return "", err
 	}
 
-	binaryPath := BinaryPath(cacheDir)
+	binaryPath := BinaryPath(cacheDir, arch)
 
 	// Check if cached binary already exists
 	if _, err := os.Stat(binaryPath); err == nil {
-		fmt.Println("  Using cached game server wrapper binary")
+		fmt.Printf("  Using cached game server wrapper binary (%s)\n", arch)
 		return binaryPath, nil
 	}
 
-	// Clone the repository
-	fmt.Println("  Cloning game server wrapper repository...")
-	if err := os.MkdirAll(filepath.Dir(cacheDir), 0755); err != nil {
-		return "", fmt.Errorf("creating cache directory: %w", err)
-	}
-	// Remove stale cache if it exists but binary is missing
-	os.RemoveAll(cacheDir)
+	// Clone the repository if not already present
+	srcDir := filepath.Join(cacheDir, "src")
+	if _, err := os.Stat(srcDir); os.IsNotExist(err) {
+		fmt.Println("  Cloning game server wrapper repository...")
+		if err := os.MkdirAll(filepath.Dir(cacheDir), 0755); err != nil {
+			return "", fmt.Errorf("creating cache directory: %w", err)
+		}
+		// Remove stale cache if it exists but source is missing
+		os.RemoveAll(cacheDir)
 
-	if err := r.Run(ctx, "git", "clone", "--branch", WrapperVersion, "--depth", "1",
-		WrapperRepo, cacheDir); err != nil {
-		return "", fmt.Errorf("cloning game server wrapper: %w", err)
+		if err := r.Run(ctx, "git", "clone", "--branch", WrapperVersion, "--depth", "1",
+			WrapperRepo, cacheDir); err != nil {
+			return "", fmt.Errorf("cloning game server wrapper: %w", err)
+		}
 	}
 
 	// Build the wrapper
-	fmt.Println("  Building game server wrapper...")
-	if err := buildWrapper(ctx, r, cacheDir); err != nil {
-		// Clean up on build failure so next run retries
-		os.RemoveAll(cacheDir)
+	fmt.Printf("  Building game server wrapper for %s...\n", arch)
+	if err := buildWrapper(ctx, r, cacheDir, arch); err != nil {
 		return "", fmt.Errorf("building game server wrapper: %w", err)
 	}
 
 	// Verify the binary was produced
 	if _, err := os.Stat(binaryPath); err != nil {
-		os.RemoveAll(cacheDir)
 		return "", fmt.Errorf("wrapper binary not found after build at %s", binaryPath)
 	}
 
@@ -83,19 +92,18 @@ func EnsureBinary(ctx context.Context, r *runner.Runner) (string, error) {
 }
 
 // buildWrapper builds the game server wrapper binary. On systems with make,
-// it delegates to `make build`. On Windows (where make is typically absent),
-// it runs the equivalent steps directly: download the server SDK, cross-compile
-// the Go binary for linux/amd64, and copy the config file.
-func buildWrapper(ctx context.Context, r *runner.Runner, cacheDir string) error {
-	if runtime.GOOS != "windows" {
+// it delegates to `make build` for amd64. On Windows (where make is typically
+// absent) or for arm64, it runs the equivalent steps directly.
+func buildWrapper(ctx context.Context, r *runner.Runner, cacheDir, arch string) error {
+	if runtime.GOOS != "windows" && arch == "amd64" {
 		return r.RunInDir(ctx, cacheDir, "make", "build")
 	}
-	return buildWrapperWindows(ctx, r, cacheDir)
+	return buildWrapperWindows(ctx, r, cacheDir, arch)
 }
 
 // buildWrapperWindows replicates the Makefile's `build` target on Windows
-// without requiring make, using curl and Go cross-compilation.
-func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir string) error {
+// (or for non-amd64 architectures) using curl and Go cross-compilation.
+func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir, arch string) error {
 	sdkZip := filepath.Join(cacheDir, "gamelift-servers-server-sdk.zip")
 	sdkDir := filepath.Join(cacheDir, "src", "ext", "gamelift-servers-server-sdk")
 
@@ -112,16 +120,21 @@ func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir string)
 		if err := os.MkdirAll(sdkDir, 0755); err != nil {
 			return fmt.Errorf("creating SDK directory: %w", err)
 		}
-		// Use PowerShell to extract since unzip may not be available
-		if err := r.Run(ctx, "powershell", "-NoProfile", "-Command",
-			fmt.Sprintf("Expand-Archive -Path '%s' -DestinationPath '%s' -Force", sdkZip, sdkDir)); err != nil {
-			return fmt.Errorf("extracting server SDK: %w", err)
+		if runtime.GOOS == "windows" {
+			if err := r.Run(ctx, "powershell", "-NoProfile", "-Command",
+				fmt.Sprintf("Expand-Archive -Path '%s' -DestinationPath '%s' -Force", sdkZip, sdkDir)); err != nil {
+				return fmt.Errorf("extracting server SDK: %w", err)
+			}
+		} else {
+			if err := r.Run(ctx, "unzip", "-o", sdkZip, "-d", sdkDir); err != nil {
+				return fmt.Errorf("extracting server SDK: %w", err)
+			}
 		}
 	}
 
-	// Cross-compile for linux/amd64
+	// Cross-compile for linux/<arch>
 	srcDir := filepath.Join(cacheDir, "src")
-	outDir := filepath.Join(cacheDir, "out", "linux", "amd64")
+	outDir := filepath.Join(cacheDir, "out", "linux", arch)
 	binaryDir := filepath.Join(outDir, "gamelift-servers-managed-containers")
 	if err := os.MkdirAll(binaryDir, 0755); err != nil {
 		return fmt.Errorf("creating output directory: %w", err)
@@ -131,7 +144,7 @@ func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir string)
 	ldflags := fmt.Sprintf("-X '%s/internal.version=1.1.0'", appPackage)
 
 	buildRunner := *r
-	buildRunner.Env = append(buildRunner.Env, "CGO_ENABLED=0", "GOOS=linux", "GOARCH=amd64")
+	buildRunner.Env = append(buildRunner.Env, "CGO_ENABLED=0", "GOOS=linux", "GOARCH="+arch)
 	if err := buildRunner.RunInDir(ctx, srcDir, "go", "build",
 		"-trimpath", "-v",
 		"-ldflags="+ldflags,

--- a/ludus.example.yaml
+++ b/ludus.example.yaml
@@ -33,6 +33,9 @@ game:
   gameTarget: ""
   # Target platform
   platform: "linux"
+  # Target CPU architecture for server builds: "amd64" (default) or "arm64"
+  # Use "arm64" to cross-compile for AWS Graviton instances (20-30% cheaper)
+  # arch: "arm64"
   # Default server map (L_Expanse bypasses main menu)
   serverMap: "L_Expanse"
   # Content validation settings (optional, Lyra uses built-in checks)


### PR DESCRIPTION
## Summary

- Add ARM64 (LinuxArm64) architecture support for cross-compiling UE5 dedicated servers targeting AWS Graviton instances (20-30% cheaper than x86_64)
- New `game.arch` config field + `--arch` CLI flag on `game build` and `deploy ec2`
- All 4 Epic cross-compile toolchain installers already ship the aarch64 sysroot — no new downloads needed

## Changes

**Config** (`internal/config/config.go`):
- `Arch` field on `GameConfig` with `NormalizeArch()` accepting amd64/arm64/x86_64/aarch64
- `ServerPlatformDir()`, `BinariesPlatformDir()`, `UEPlatformName()` helpers for UE naming conventions

**Game builder** (`internal/game/builder.go`):
- `-platform=LinuxArm64` for arm64 builds (was hardcoded `-platform=Linux`)
- `ensureTargetArchitecture()` sets `TargetArchitecture=AArch64` in DefaultEngine.ini

**Wrapper** (`internal/wrapper/wrapper.go`):
- `EnsureBinary()` takes arch param, builds with `GOARCH=<arch>`
- Per-arch cache directories so amd64 and arm64 binaries coexist

**EC2 deployer** (`internal/ec2fleet/deployer.go`):
- Arch-aware binary path detection in `ZipAndUpload()` (`Binaries/LinuxArm64/` for arm64)

**Shared helpers** (4 files):
- All `resolveServerBuildDir()` copies updated to use `config.ServerPlatformDir()`

**Cache/Status/MCP**:
- Cache keys include arch to prevent stale hits across architectures
- `CheckServerBuild()` uses arch-aware paths
- `arch` parameter added to `ludus_game_build` and `ludus_deploy_ec2` MCP tools

## User workflow
```bash
ludus game build --arch arm64              # cross-compile ARM64 server
ludus deploy ec2 --arch arm64 --instance-type c7g.large  # deploy to Graviton
```

## Test plan
- [x] `go build` (Windows) passes
- [x] `GOOS=linux go build` passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass
- [ ] `ludus game build --arch arm64 --verbose --dry-run` — verify `-platform=LinuxArm64` in RunUAT args
- [ ] Full E2E: build ARM64 server + deploy to Graviton fleet + connect client (post-merge)