### PR TITLE
Add auto-detect version, --with-session, and what's-next guidance

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -6,19 +6,19 @@ Prioritized list of planned work, organized by category. Items are roughly order
 
 Bugs and rough edges discovered during cross-version E2E testing (UE 5.4–5.7 on Windows).
 
-- [ ] **UE 5.4 C4756 overflow patch** — MSVC 14.38 + Windows SDK 26100 triggers `C4756` (overflow in constant arithmetic) treated as error in UE 5.4. Needs a version-gated auto-patch in `ludus init --fix`, similar to the existing INITGUID fix for 5.6.
-- [ ] **OOM detection / maxJobs halving for cross-compile** — Cross-compilation loads both Win64 and Linux toolchains simultaneously; `maxJobs` auto-detect (based on RAM / 8 GB) should halve during game server builds to avoid OOM. Currently users must manually set `engine.maxJobs` lower.
-- [ ] **UAC failure detection** — Content cooking silently fails with exit code `0xC0E90002` when UAC blocks a subprocess. Need to detect this specific exit code and provide actionable guidance (run as administrator or adjust UAC settings).
-- [ ] **Build failure diagnostics** — Parse cook and UBA logs for common failure patterns (missing content, DLL load errors, OOM kills, missing SDK components) and surface actionable fix suggestions instead of generic "ExitCode=25" errors.
+- [x] **UE 5.4 C4756 overflow patch** — `ludus init --fix` auto-patches UE 5.4 source files where NAN/INFINITY macros trigger C4756. Version-gated to 5.4 + SDK >= 26100. *(PR #35)*
+- [x] **OOM detection / maxJobs halving for cross-compile** — `-j/--jobs` flag on `game build` and `game client`. Auto-detects RAM and halves parallelism for cross-compile (16GB/job vs 8GB/job). *(PR #35)*
+- [x] **UAC failure detection** — Detects exit code `0xC0E90002` and provides 3 actionable remediation steps. *(PR #35)*
+- [x] **Build failure diagnostics** — Scans RunUAT Log.txt for 7 known error patterns (missing content, OOM, DLL failures, NuGet, C4756, toolchain) with actionable hints. *(PR #35)*
 
 ## Onboarding / First-Run UX
 
 Reducing friction for new users going from zero to a running game session.
 
 - [ ] **`ludus setup` interactive wizard** — Guided first-run experience that: scans for engine source directories (e.g. `F:\Source Code\UnrealEngine-*`), auto-reads `Build.version` for the engine version, finds Lyra Launcher downloads in common paths (`Documents\Unreal Projects\LyraStarterGame*`), validates AWS credentials, and writes a complete `ludus.yaml`. Eliminates the need to manually create config.
-- [ ] **Auto-detect engine version** — Drop the `engine.version` config requirement. `toolchain.ParseBuildVersion()` already reads `Engine/Build/Build.version` JSON from every engine source tree. If version is empty in config, read it automatically.
+- [x] **Auto-detect engine version** — Drop the `engine.version` config requirement. `toolchain.ParseBuildVersion()` already reads `Engine/Build/Build.version` JSON from every engine source tree. If version is empty in config, read it automatically.
 - [ ] **AWS credential validation** — `ludus init` should check `aws sts get-caller-identity` and warn if credentials aren't configured or have expired, before the user gets deep into a multi-hour pipeline.
-- [ ] **"What's next" guidance** — After each command succeeds, print the next step in the pipeline. After `init`: "Run `ludus engine build`". After engine build: "Run `ludus game build`". After deploy: "Run `ludus deploy session`". Etc.
+- [x] **"What's next" guidance** — After each command succeeds, print the next step in the pipeline. After `init`: "Run `ludus engine build`". After engine build: "Run `ludus game build`". After deploy: "Run `ludus deploy session`". Etc.
 - [ ] **Lyra content auto-discovery** — Scan common paths (Epic Games Launcher vault cache, `Documents\Unreal Projects\LyraStarterGame*`) to auto-populate `game.contentSourcePath` in the setup wizard or suggest it during `ludus init`.
 - [ ] **Server map validation** — Verify the configured `serverMap` exists in the project's cooked content or source assets before starting a multi-hour cook, instead of failing late in the pipeline.
 
@@ -35,7 +35,7 @@ Improving the experience during long build operations.
 Smoothing out the deployment and testing workflow.
 
 - [ ] **Cost estimate before deploy** — Before creating a fleet, show the estimated hourly cost for the selected instance type and region. Prevents bill shock for new users.
-- [ ] **Auto-session (`--with-session`)** — `ludus deploy ec2 --with-session` that creates a game session immediately after the fleet goes active, saving a manual step.
+- [x] **Auto-session (`--with-session`)** — `ludus deploy ec2 --with-session` that creates a game session immediately after the fleet goes active, saving a manual step.
 - [ ] **Batch destroy** — `ludus deploy destroy --all` that reads all versioned state files (`state-ue54.json`, etc.) and tears down all fleets in one command.
 - [ ] **Instance type guidance** — Recommend instance types based on game characteristics (CPU-bound vs memory-bound) and provide cost/performance comparisons.
 
@@ -57,6 +57,6 @@ Better support for testing across multiple UE versions.
 
 Larger feature additions from the project roadmap.
 
-- [ ] **ARM/Graviton support** — EC2 fleet deployment on Graviton instances for 20-30% cost savings. GameLift has supported Graviton since late 2023 with 130+ ARM instance types (c7g, c8g, m7g, r7g, etc.). UE5 already supports `LinuxArm64Server` as a build target. Implementation needs: ARM64 cross-compile toolchain for Windows (Epic ships `LinuxArm64` platform support but no official Windows→ARM cross-compile installer), `-platform=LinuxArm64` in BuildCookRun args, ARM-compatible Game Server Wrapper build, and `--arch arm64` flag in `ludus deploy ec2`.
+- [x] **ARM/Graviton support** — `--arch arm64` flag on `game build` and `deploy ec2` for cross-compiling LinuxArm64 servers targeting Graviton instances (20-30% cheaper). All Epic toolchain installers already ship the aarch64 sysroot. Config: `game.arch`, MCP: `arch` param on build/deploy tools. *(PR #36)*
 - [ ] **BuildGraph XML generation** — `ludus buildgraph` command that generates BuildGraph XML validated against the UE schema. Outputs a ready-to-use XML file that UET, Horde, or other build orchestration tools can consume. An addition to the existing linear pipeline, not a replacement.
 - [ ] **Studio infrastructure provisioning** — Potentially a separate project that provisions game studio infrastructure on AWS (Perforce, CI/CD build farms, derived data cache, virtual workstations) as composable modules that integrate with Ludus. Decision point: integrate with AWS's [cloud-game-development-toolkit](https://github.com/aws-games/cloud-game-development-toolkit), wrap it, or build from scratch.

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -104,6 +104,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Container image built: %s (%.0fs)\n", result.ImageTag, result.Duration)
+	fmt.Println("\nNext: ludus container push")
 	return nil
 }
 
@@ -118,10 +119,14 @@ func runPush(cmd *cobra.Command, args []string) error {
 	}, r)
 
 	fmt.Println("Pushing container image to ECR...")
-	return builder.Push(cmd.Context(), ctrBuilder.PushOptions{
+	if err := builder.Push(cmd.Context(), ctrBuilder.PushOptions{
 		ECRRepository: cfg.AWS.ECRRepository,
 		AWSRegion:     cfg.AWS.Region,
 		AWSAccountID:  cfg.AWS.AccountID,
 		ImageTag:      cfg.Container.Tag,
-	})
+	}); err != nil {
+		return err
+	}
+	fmt.Println("\nNext: ludus deploy fleet  (or: ludus deploy stack)")
+	return nil
 }

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"time"
@@ -23,6 +24,7 @@ var (
 	stackName    string
 	anywhereIP   string
 	ec2Arch      string
+	withSession  bool
 )
 
 // Cmd is the top-level deploy command group.
@@ -121,6 +123,11 @@ func init() {
 	anywhereCmd.Flags().StringVar(&anywhereIP, "ip", "", "local IP address override (default: auto-detect)")
 	ec2Cmd.Flags().StringVar(&ec2Arch, "arch", "", `target CPU architecture: amd64, arm64 (default: from ludus.yaml)`)
 
+	fleetCmd.Flags().BoolVar(&withSession, "with-session", false, "create a game session after deployment")
+	stackCmd.Flags().BoolVar(&withSession, "with-session", false, "create a game session after deployment")
+	anywhereCmd.Flags().BoolVar(&withSession, "with-session", false, "create a game session after deployment")
+	ec2Cmd.Flags().BoolVar(&withSession, "with-session", false, "create a game session after deployment")
+
 	Cmd.AddCommand(fleetCmd)
 	Cmd.AddCommand(stackCmd)
 	Cmd.AddCommand(anywhereCmd)
@@ -185,6 +192,28 @@ func resolveTarget(cmd *cobra.Command) (deploy.Target, error) {
 	return globals.ResolveTarget(cmd.Context(), cfg, targetFlag)
 }
 
+// maybeCreateSession creates a game session if --with-session was passed.
+func maybeCreateSession(ctx context.Context, sm deploy.SessionManager) error {
+	if !withSession {
+		return nil
+	}
+	fmt.Println("\nCreating game session...")
+	info, err := sm.CreateSession(ctx, 8)
+	if err != nil {
+		return fmt.Errorf("session creation failed: %w", err)
+	}
+	if err := state.UpdateSession(&state.SessionState{
+		SessionID: info.SessionID,
+		IPAddress: info.IPAddress,
+		Port:      info.Port,
+	}); err != nil {
+		fmt.Printf("Warning: failed to write session state: %v\n", err)
+	}
+	fmt.Printf("Game session created: %s\n", info.SessionID)
+	fmt.Printf("Connect: %s:%d\n", info.IPAddress, info.Port)
+	return nil
+}
+
 func runFleet(cmd *cobra.Command, args []string) error {
 	deployer, err := makeDeployer(cmd)
 	if err != nil {
@@ -213,6 +242,14 @@ func runFleet(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("\nFleet deployed: %s (status: %s)\n", fleetStatus.FleetID, fleetStatus.Status)
+	if err := maybeCreateSession(cmd.Context(), gamelift.NewTargetAdapter(deployer)); err != nil {
+		return err
+	}
+	if !withSession {
+		fmt.Println("\nNext: ludus deploy session")
+	} else {
+		fmt.Println("\nNext: ludus connect")
+	}
 	return nil
 }
 
@@ -287,6 +324,14 @@ func runStack(cmd *cobra.Command, args []string) error {
 		fmt.Printf("Fleet ID: %s\n", result.FleetID)
 	}
 	fmt.Printf("Duration: %s\n", elapsed.Round(time.Second))
+	if err := maybeCreateSession(cmd.Context(), stack.NewTargetAdapter(deployer)); err != nil {
+		return err
+	}
+	if !withSession {
+		fmt.Println("\nNext: ludus deploy session")
+	} else {
+		fmt.Println("\nNext: ludus connect")
+	}
 	return nil
 }
 
@@ -308,6 +353,7 @@ func runSession(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Game session created: %s\n", info.SessionID)
+	fmt.Println("\nNext: ludus connect")
 	return nil
 }
 
@@ -338,7 +384,16 @@ func runAnywhere(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("\nAnywhere deployment ready: %s\n", result.Detail)
-	fmt.Println("Run 'ludus deploy session' to create a game session.")
+	if sm, ok := target.(deploy.SessionManager); ok {
+		if err := maybeCreateSession(cmd.Context(), sm); err != nil {
+			return err
+		}
+	}
+	if !withSession {
+		fmt.Println("\nNext: ludus deploy session")
+	} else {
+		fmt.Println("\nNext: ludus connect")
+	}
 	return nil
 }
 
@@ -381,7 +436,16 @@ func runEC2(cmd *cobra.Command, args []string) error {
 	elapsed := time.Since(start)
 	fmt.Printf("\nEC2 fleet deployed: %s\n", result.Detail)
 	fmt.Printf("Duration: %s\n", elapsed.Round(time.Second))
-	fmt.Println("Run 'ludus deploy session' to create a game session.")
+	if sm, ok := target.(deploy.SessionManager); ok {
+		if err := maybeCreateSession(cmd.Context(), sm); err != nil {
+			return err
+		}
+	}
+	if !withSession {
+		fmt.Println("\nNext: ludus deploy session")
+	} else {
+		fmt.Println("\nNext: ludus connect")
+	}
 	return nil
 }
 

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -149,7 +149,11 @@ func runSetup(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Running engine setup...")
-	return builder.Setup(cmd.Context())
+	if err := builder.Setup(cmd.Context()); err != nil {
+		return err
+	}
+	fmt.Println("\nNext: ludus engine build")
+	return nil
 }
 
 func runBuild(cmd *cobra.Command, args []string) error {
@@ -186,6 +190,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("Engine build complete in %.0fs at %s\n", result.Duration, result.EnginePath)
+	fmt.Println("\nNext: ludus game build")
 	return nil
 }
 
@@ -227,6 +232,7 @@ func runDockerBuild(cmd *cobra.Command) error {
 	}
 
 	fmt.Printf("Engine Docker image built in %.0fs: %s\n", result.Duration, result.ImageTag)
+	fmt.Println("\nNext: ludus game build --backend docker")
 	return nil
 }
 
@@ -264,10 +270,14 @@ func runPush(cmd *cobra.Command, args []string) error {
 	repoName := imageName
 
 	fmt.Printf("Pushing engine image %s to ECR...\n", imageTag)
-	return builder.Push(cmd.Context(), dockerbuild.PushOptions{
+	if err := builder.Push(cmd.Context(), dockerbuild.PushOptions{
 		ECRRepository: repoName,
 		AWSRegion:     cfg.AWS.Region,
 		AWSAccountID:  cfg.AWS.AccountID,
 		ImageTag:      imageTag,
-	})
+	}); err != nil {
+		return err
+	}
+	fmt.Println("\nNext: ludus game build --backend docker")
+	return nil
 }

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -2,6 +2,7 @@ package game
 
 import (
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/devrecon/ludus/cmd/globals"
@@ -14,6 +15,19 @@ import (
 	"github.com/devrecon/ludus/internal/toolchain"
 	"github.com/spf13/cobra"
 )
+
+// nextAfterServerBuild returns the "Next:" hint based on the deploy target.
+func nextAfterServerBuild() string {
+	t := strings.ToLower(globals.Cfg.Deploy.Target)
+	switch t {
+	case "gamelift", "stack":
+		return "ludus container build"
+	case "ec2", "anywhere", "binary":
+		return fmt.Sprintf("ludus deploy %s", t)
+	default:
+		return "ludus container build  (or: ludus deploy <target>)"
+	}
+}
 
 var (
 	skipCook       bool
@@ -183,6 +197,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("%s server build complete in %.0fs\n", cfg.Game.ProjectName, result.Duration)
 	fmt.Printf("Output: %s\n", result.OutputDir)
+	fmt.Printf("\nNext: %s\n", nextAfterServerBuild())
 	return nil
 }
 
@@ -231,6 +246,7 @@ func runDockerBuild(cmd *cobra.Command) error {
 
 	fmt.Printf("%s server build complete in %.0fs\n", cfg.Game.ProjectName, result.Duration)
 	fmt.Printf("Output: %s\n", result.OutputDir)
+	fmt.Printf("\nNext: %s\n", nextAfterServerBuild())
 	return nil
 }
 
@@ -293,6 +309,7 @@ func runClientBuild(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s client build complete in %.0fs\n", cfg.Game.ProjectName, result.Duration)
 	fmt.Printf("Output: %s\n", result.OutputDir)
 	fmt.Printf("Binary: %s\n", result.ClientBinary)
+	fmt.Println("\nNext: ludus connect")
 	return nil
 }
 
@@ -351,5 +368,6 @@ func runDockerClientBuild(cmd *cobra.Command) error {
 	fmt.Printf("%s client build complete in %.0fs\n", cfg.Game.ProjectName, result.Duration)
 	fmt.Printf("Output: %s\n", result.OutputDir)
 	fmt.Printf("Binary: %s\n", result.ClientBinary)
+	fmt.Println("\nNext: ludus connect")
 	return nil
 }

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -18,6 +18,7 @@ type deployFleetInput struct {
 	Region       string `json:"region,omitempty" jsonschema:"AWS region override"`
 	InstanceType string `json:"instance_type,omitempty" jsonschema:"EC2 instance type override"`
 	FleetName    string `json:"fleet_name,omitempty" jsonschema:"GameLift fleet name override"`
+	WithSession  bool   `json:"with_session,omitempty" jsonschema:"Create a game session after deployment"`
 	DryRun       bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
 
@@ -30,14 +31,16 @@ type deployStackInput struct {
 	InstanceType string `json:"instance_type,omitempty" jsonschema:"EC2 instance type override"`
 	FleetName    string `json:"fleet_name,omitempty" jsonschema:"GameLift fleet name override"`
 	StackName    string `json:"stack_name,omitempty" jsonschema:"CloudFormation stack name override"`
+	WithSession  bool   `json:"with_session,omitempty" jsonschema:"Create a game session after deployment"`
 	DryRun       bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
 
 type deployAnywhereInput struct {
-	Region    string `json:"region,omitempty" jsonschema:"AWS region override"`
-	FleetName string `json:"fleet_name,omitempty" jsonschema:"GameLift fleet name override"`
-	IPAddress string `json:"ip_address,omitempty" jsonschema:"Local IP address override (default: auto-detect)"`
-	DryRun    bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
+	Region      string `json:"region,omitempty" jsonschema:"AWS region override"`
+	FleetName   string `json:"fleet_name,omitempty" jsonschema:"GameLift fleet name override"`
+	IPAddress   string `json:"ip_address,omitempty" jsonschema:"Local IP address override (default: auto-detect)"`
+	WithSession bool   `json:"with_session,omitempty" jsonschema:"Create a game session after deployment"`
+	DryRun      bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
 
 type deployEC2Input struct {
@@ -45,6 +48,7 @@ type deployEC2Input struct {
 	InstanceType string `json:"instance_type,omitempty" jsonschema:"EC2 instance type override"`
 	FleetName    string `json:"fleet_name,omitempty" jsonschema:"GameLift fleet name override"`
 	Arch         string `json:"arch,omitempty" jsonschema:"Target CPU architecture: amd64 or arm64 (default: from config)"`
+	WithSession  bool   `json:"with_session,omitempty" jsonschema:"Create a game session after deployment"`
 	DryRun       bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
 
@@ -58,6 +62,9 @@ type deployFleetResult struct {
 	Status          string  `json:"status,omitempty"`
 	Detail          string  `json:"detail,omitempty"`
 	DurationSeconds float64 `json:"duration_seconds,omitempty"`
+	SessionID       string  `json:"session_id,omitempty"`
+	SessionIP       string  `json:"session_ip,omitempty"`
+	SessionPort     int     `json:"session_port,omitempty"`
 	Output          string  `json:"output,omitempty"`
 	Error           string  `json:"error,omitempty"`
 }
@@ -77,18 +84,24 @@ type deployStackResult struct {
 	FleetID         string  `json:"fleet_id,omitempty"`
 	Status          string  `json:"status,omitempty"`
 	DurationSeconds float64 `json:"duration_seconds,omitempty"`
+	SessionID       string  `json:"session_id,omitempty"`
+	SessionIP       string  `json:"session_ip,omitempty"`
+	SessionPort     int     `json:"session_port,omitempty"`
 	Output          string  `json:"output,omitempty"`
 	Error           string  `json:"error,omitempty"`
 }
 
 type deployAnywhereResult struct {
-	Success   bool   `json:"success"`
-	FleetID   string `json:"fleet_id,omitempty"`
-	IPAddress string `json:"ip_address,omitempty"`
-	Port      int    `json:"port,omitempty"`
-	PID       int    `json:"pid,omitempty"`
-	Output    string `json:"output,omitempty"`
-	Error     string `json:"error,omitempty"`
+	Success     bool   `json:"success"`
+	FleetID     string `json:"fleet_id,omitempty"`
+	IPAddress   string `json:"ip_address,omitempty"`
+	Port        int    `json:"port,omitempty"`
+	PID         int    `json:"pid,omitempty"`
+	SessionID   string `json:"session_id,omitempty"`
+	SessionIP   string `json:"session_ip,omitempty"`
+	SessionPort int    `json:"session_port,omitempty"`
+	Output      string `json:"output,omitempty"`
+	Error       string `json:"error,omitempty"`
 }
 
 type deployEC2Result struct {
@@ -97,6 +110,9 @@ type deployEC2Result struct {
 	BuildID         string  `json:"build_id,omitempty"`
 	Status          string  `json:"status,omitempty"`
 	DurationSeconds float64 `json:"duration_seconds,omitempty"`
+	SessionID       string  `json:"session_id,omitempty"`
+	SessionIP       string  `json:"session_ip,omitempty"`
+	SessionPort     int     `json:"session_port,omitempty"`
 	Output          string  `json:"output,omitempty"`
 	Error           string  `json:"error,omitempty"`
 }
@@ -198,6 +214,19 @@ func handleDeployFleet(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 		result.FleetID = st.Fleet.FleetID
 	}
 
+	// Auto-session if requested
+	if input.WithSession {
+		sm, ok := target.(deploy.SessionManager)
+		if ok {
+			si, err := sm.CreateSession(ctx, 8)
+			if err == nil && si != nil {
+				result.SessionID = si.SessionID
+				result.SessionIP = si.IPAddress
+				result.SessionPort = si.Port
+			}
+		}
+	}
+
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: jsonString(result)},
@@ -270,6 +299,18 @@ func handleDeployStack(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 	}
 
 	result.Success = true
+
+	// Auto-session if requested
+	if input.WithSession {
+		adapter := stack.NewTargetAdapter(deployer)
+		si, err := adapter.CreateSession(ctx, 8)
+		if err == nil && si != nil {
+			result.SessionID = si.SessionID
+			result.SessionIP = si.IPAddress
+			result.SessionPort = si.Port
+		}
+	}
+
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
 			&mcp.TextContent{Text: jsonString(result)},
@@ -331,6 +372,19 @@ func handleDeployAnywhere(ctx context.Context, _ *mcp.CallToolRequest, input dep
 		result.IPAddress = st.Anywhere.IPAddress
 		result.Port = st.Anywhere.ServerPort
 		result.PID = st.Anywhere.PID
+	}
+
+	// Auto-session if requested
+	if input.WithSession {
+		sm, ok := target.(deploy.SessionManager)
+		if ok {
+			si, err := sm.CreateSession(ctx, 8)
+			if err == nil && si != nil {
+				result.SessionID = si.SessionID
+				result.SessionIP = si.IPAddress
+				result.SessionPort = si.Port
+			}
+		}
 	}
 
 	return &mcp.CallToolResult{
@@ -396,6 +450,19 @@ func handleDeployEC2(ctx context.Context, _ *mcp.CallToolRequest, input deployEC
 	if st.EC2Fleet != nil {
 		result.FleetID = st.EC2Fleet.FleetID
 		result.BuildID = st.EC2Fleet.BuildID
+	}
+
+	// Auto-session if requested
+	if input.WithSession {
+		sm, ok := target.(deploy.SessionManager)
+		if ok {
+			si, err := sm.CreateSession(ctx, 8)
+			if err == nil && si != nil {
+				result.SessionID = si.SessionID
+				result.SessionIP = si.IPAddress
+				result.SessionPort = si.Port
+			}
+		}
 	}
 
 	return &mcp.CallToolResult{

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -27,6 +27,7 @@ var (
 	skipContainer bool
 	skipDeploy    bool
 	withClient    bool
+	withSession   bool
 	backend       string
 	noCache       bool
 )
@@ -56,6 +57,7 @@ func init() {
 	Cmd.Flags().BoolVar(&skipContainer, "skip-container", false, "skip container build and push (use existing image)")
 	Cmd.Flags().BoolVar(&skipDeploy, "skip-deploy", false, "skip deployment (build only)")
 	Cmd.Flags().BoolVar(&withClient, "with-client", false, "also build a standalone Linux game client")
+	Cmd.Flags().BoolVar(&withSession, "with-session", false, "create a game session after deployment")
 	Cmd.Flags().StringVar(&backend, "backend", "", `build backend: "native" or "docker" (default: from ludus.yaml)`)
 	Cmd.Flags().BoolVar(&noCache, "no-cache", false, "disable build caching (force rebuild of all stages)")
 }
@@ -403,6 +405,30 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 				return nil
 			},
 		},
+		{
+			name: "Create game session",
+			skip: skipDeploy || !withSession || !caps.SupportsSession,
+			fn: func(ctx context.Context) error {
+				sm, ok := target.(deploy.SessionManager)
+				if !ok {
+					return fmt.Errorf("target %q does not support game sessions", target.Name())
+				}
+				info, err := sm.CreateSession(ctx, 8)
+				if err != nil {
+					return err
+				}
+				if err := state.UpdateSession(&state.SessionState{
+					SessionID: info.SessionID,
+					IPAddress: info.IPAddress,
+					Port:      info.Port,
+				}); err != nil {
+					fmt.Printf("    Warning: failed to write session state: %v\n", err)
+				}
+				fmt.Printf("    Game session created: %s\n", info.SessionID)
+				fmt.Printf("    Connect: %s:%d\n", info.IPAddress, info.Port)
+				return nil
+			},
+		},
 	}
 
 	// Dry-run mode: print the plan, then execute with runner in dry-run mode
@@ -432,5 +458,10 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Println("Pipeline complete.")
+	if withSession {
+		fmt.Println("\nNext: ludus connect")
+	} else if !skipDeploy {
+		fmt.Println("\nNext: ludus deploy session")
+	}
 	return nil
 }

--- a/cmd/root/init.go
+++ b/cmd/root/init.go
@@ -77,5 +77,6 @@ func runInit(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Println("All prerequisites passed.")
 	}
+	fmt.Println("\nNext: ludus engine build")
 	return nil
 }

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -1,6 +1,9 @@
 package root
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/devrecon/ludus/cmd/ci"
 	"github.com/devrecon/ludus/cmd/connect"
 	"github.com/devrecon/ludus/cmd/container"
@@ -12,6 +15,7 @@ import (
 	"github.com/devrecon/ludus/cmd/pipeline"
 	"github.com/devrecon/ludus/cmd/status"
 	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/toolchain"
 	"github.com/devrecon/ludus/internal/version"
 	"github.com/spf13/cobra"
 )
@@ -42,6 +46,17 @@ and deploying it to AWS GameLift Containers.
 			return err
 		}
 		globals.Cfg = cfg
+
+		// Auto-detect engine version from Build.version if not set in config
+		if cfg.Engine.SourcePath != "" && cfg.Engine.Version == "" {
+			if bv, err := toolchain.ParseBuildVersion(cfg.Engine.SourcePath); err == nil {
+				cfg.Engine.Version = fmt.Sprintf("%d.%d.%d", bv.MajorVersion, bv.MinorVersion, bv.PatchVersion)
+				if globals.Verbose {
+					fmt.Fprintf(os.Stderr, "Auto-detected engine version: %s\n", cfg.Engine.Version)
+				}
+			}
+		}
+
 		return nil
 	},
 }


### PR DESCRIPTION
## Summary

Three quick-win UX improvements that reduce friction for new and returning users:

- **Auto-detect engine version**: When `engine.version` is not set in `ludus.yaml`, automatically reads `Engine/Build/Build.version` JSON from the engine source tree and populates the version. Removes a manual config step that caused subtle issues when forgotten.
- **`--with-session` flag**: Added to `deploy fleet`, `deploy stack`, `deploy anywhere`, `deploy ec2`, and `run` (pipeline). Creates a game session immediately after deployment, eliminating the most common manual follow-up step. Also added to all 4 MCP deploy tools with `with_session` parameter.
- **"What's next" guidance**: Every command now prints a `Next:` hint after success, guiding users through the pipeline (e.g., after `init` → "Next: ludus engine build", after `game build` → "Next: ludus container build" or "ludus deploy ec2" depending on configured target).

## Files changed

| File | Changes |
|------|---------|
| `cmd/root/root.go` | Auto-detect engine version in PersistentPreRunE |
| `cmd/deploy/deploy.go` | `--with-session` flag, `maybeCreateSession()` helper, next hints |
| `cmd/pipeline/pipeline.go` | `--with-session` flag, "Create game session" pipeline stage, next hints |
| `cmd/mcp/tools_deploy.go` | `with_session` on all deploy inputs, session fields in results |
| `cmd/root/init.go` | Next hint after init |
| `cmd/engine/engine.go` | Next hints after setup/build/push |
| `cmd/game/game.go` | Next hints after server/client builds (target-aware) |
| `cmd/container/container.go` | Next hints after build/push |
| `ROADMAP.md` | Checked off 3 completed items |

## Test plan

- [x] `go build -o /dev/null .` — compiles on Windows
- [x] `GOOS=linux go build -o /dev/null .` — cross-compiles for Linux
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [ ] `ludus init --verbose` with `engine.version` omitted — verify "Auto-detected engine version" on stderr
- [ ] `ludus deploy ec2 --with-session --dry-run` — verify session creation step appears
- [ ] Run various commands with `--dry-run` — verify "Next:" hints appear