### PR TITLE
Enable dupl linter and refactor duplicated code

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -12,6 +12,7 @@ linters:
     - misspell
     - unconvert
     - gosec
+    - dupl
 
   settings:
     gosec:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -185,7 +185,7 @@ GitHub Actions CI (`.github/workflows/ci.yml`) runs on push/PR to `main`:
 - **Build** — `go build` + `go vet` on both OSes
 - **Test** — `go test` on both OSes
 
-Lint config (`.golangci.yml`, v2 format) enables: errcheck, govet, ineffassign, staticcheck, unused, gocritic, misspell, unconvert, gosec, gofmt. Gosec exclusions: G104 (unhandled errors — best-effort cleanup), G115 (integer overflow — bounded values), G204 (subprocess with variable — intentional), G301 (directory permissions 0755), G304 (file inclusion via variable — intentional), G306 (WriteFile 0644), G702 (command injection taint — same as G204), G703 (path traversal taint — same as G304). Errcheck exclusions via `std-error-handling` preset (defer Close, fmt.Fprint, os.Remove).
+Lint config (`.golangci.yml`, v2 format) enables: errcheck, govet, ineffassign, staticcheck, unused, gocritic, misspell, unconvert, gosec, dupl, gofmt. Dupl uses the default threshold (150 tokens) to detect copy-paste code blocks. Gosec exclusions: G104 (unhandled errors — best-effort cleanup), G115 (integer overflow — bounded values), G204 (subprocess with variable — intentional), G301 (directory permissions 0755), G304 (file inclusion via variable — intentional), G306 (WriteFile 0644), G702 (command injection taint — same as G204), G703 (path traversal taint — same as G304). Errcheck exclusions via `std-error-handling` preset (defer Close, fmt.Fprint, os.Remove).
 
 Run lint locally (golangci-lint v2 required — v1 does not support Go 1.24):
 ```bash
@@ -278,5 +278,5 @@ See [ROADMAP.md](ROADMAP.md) for the full prioritized roadmap. Key categories:
 - **Deploy UX** — ~~Cost estimates~~ (PR #38), ~~auto-session (`--with-session`)~~ (PR #37), ~~batch destroy~~, instance type guidance
 - **Diagnostics** — `ludus doctor` command, guided error messages
 - **Multi-version** — ~~`ludus config set`~~, state profiles
-- **Code quality** — `dupl` linter + refactor duplicated code (resolveServerBuildDir, Docker/native build branches)
+- **Code quality** — ~~`dupl` linter + refactor duplicated code~~
 - **Features** — ~~ARM/Graviton support~~ (PR #36), BuildGraph XML generation, studio infrastructure provisioning

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,7 @@ Better support for testing across multiple UE versions.
 
 Reducing duplication and improving maintainability.
 
-- [ ] **Dupl linter + refactor** — Enable the [`dupl`](https://golangci-lint.run/docs/linters/configuration/#dupl) linter in `.golangci.yml` to detect duplicated code blocks. Run it once to identify hotspots (e.g., the 4 copies of `resolveServerBuildDir`, repeated Docker/native build branches in `cmd/game` and `cmd/pipeline`), refactor to shared helpers or design patterns, then enforce going forward. Do NOT enable in CI until existing duplicates are resolved.
+- [x] **Dupl linter + refactor** — Enabled `dupl` linter (threshold 150) in `.golangci.yml`. Refactored: `saveClientState()` helper in `cmd/game`, `tryCreateSession()` and `checkCacheHit()` helpers in `cmd/mcp`, `runBatFile()` helper in `internal/engine`. Remaining structural duplicates (tags converters, native/Docker builder branches) are intentional — different types prevent meaningful abstraction.
 
 ## Features
 

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -16,6 +16,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
+// saveClientState persists client build info to state.
+func saveClientState(result *gameBuilder.ClientBuildResult) {
+	if err := state.UpdateClient(&state.ClientState{
+		BinaryPath: result.ClientBinary,
+		OutputDir:  result.OutputDir,
+		Platform:   result.Platform,
+		BuiltAt:    time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		fmt.Printf("Warning: failed to write state: %v\n", err)
+	}
+}
+
 // printBuildConfigGuidance prints a note about the build configuration.
 func printBuildConfigGuidance(cfg string) {
 	switch strings.ToLower(cfg) {
@@ -314,14 +326,7 @@ func runClientBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if err := state.UpdateClient(&state.ClientState{
-		BinaryPath: result.ClientBinary,
-		OutputDir:  result.OutputDir,
-		Platform:   result.Platform,
-		BuiltAt:    time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		fmt.Printf("Warning: failed to write state: %v\n", err)
-	}
+	saveClientState(result)
 
 	if c, cErr := cache.Load(); cErr == nil {
 		c.Set(cache.StageGameClient, clientHash, time.Now().UTC().Format(time.RFC3339))
@@ -373,14 +378,7 @@ func runDockerClientBuild(cmd *cobra.Command) error {
 		return err
 	}
 
-	if err := state.UpdateClient(&state.ClientState{
-		BinaryPath: result.ClientBinary,
-		OutputDir:  result.OutputDir,
-		Platform:   result.Platform,
-		BuiltAt:    time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		fmt.Printf("Warning: failed to write state: %v\n", err)
-	}
+	saveClientState(result)
 
 	if c, cErr := cache.Load(); cErr == nil {
 		c.Set(cache.StageGameClient, clientHash, time.Now().UTC().Format(time.RFC3339))

--- a/cmd/mcp/helpers.go
+++ b/cmd/mcp/helpers.go
@@ -1,10 +1,78 @@
 package mcp
 
 import (
+	"context"
 	"path/filepath"
 
+	"github.com/devrecon/ludus/internal/cache"
 	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/deploy"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+// sessionReceiver is implemented by MCP result types that can receive session info.
+type sessionReceiver interface {
+	setSession(id, ip string, port int)
+}
+
+func (r *deployFleetResult) setSession(id, ip string, port int) {
+	r.SessionID = id
+	r.SessionIP = ip
+	r.SessionPort = port
+}
+
+func (r *deployStackResult) setSession(id, ip string, port int) {
+	r.SessionID = id
+	r.SessionIP = ip
+	r.SessionPort = port
+}
+
+func (r *deployAnywhereResult) setSession(id, ip string, port int) {
+	r.SessionID = id
+	r.SessionIP = ip
+	r.SessionPort = port
+}
+
+func (r *deployEC2Result) setSession(id, ip string, port int) {
+	r.SessionID = id
+	r.SessionIP = ip
+	r.SessionPort = port
+}
+
+// tryCreateSession creates a game session via the target's SessionManager if
+// withSession is true. Session info is written to the result via sessionReceiver.
+func tryCreateSession(ctx context.Context, target deploy.Target, withSession bool, result sessionReceiver) {
+	if !withSession {
+		return
+	}
+	sm, ok := target.(deploy.SessionManager)
+	if !ok {
+		return
+	}
+	si, err := sm.CreateSession(ctx, 8)
+	if err == nil && si != nil {
+		result.setSession(si.SessionID, si.IPAddress, si.Port)
+	}
+}
+
+// checkCacheHit returns an early MCP result if the cache stage is up to date.
+// Returns nil if cache missed or disabled. The cachedResult should be a struct
+// with Success/Output fields that serializes to JSON (e.g. gameBuildResult, engineResult).
+func checkCacheHit(noCache bool, stage cache.StageKey, hash string, cachedResult any) *mcpsdk.CallToolResult {
+	if noCache {
+		return nil
+	}
+	c, err := cache.Load()
+	if err != nil {
+		return nil
+	}
+	if !c.IsHit(stage, hash) {
+		return nil
+	}
+	return &mcpsdk.CallToolResult{
+		Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: jsonString(cachedResult)}},
+	}
+}
 
 // resolveServerBuildDir determines the server build directory from config,
 // matching the logic in cmd/container and cmd/pipeline.

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -221,18 +221,7 @@ func handleDeployFleet(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 		result.FleetID = st.Fleet.FleetID
 	}
 
-	// Auto-session if requested
-	if input.WithSession {
-		sm, ok := target.(deploy.SessionManager)
-		if ok {
-			si, err := sm.CreateSession(ctx, 8)
-			if err == nil && si != nil {
-				result.SessionID = si.SessionID
-				result.SessionIP = si.IPAddress
-				result.SessionPort = si.Port
-			}
-		}
-	}
+	tryCreateSession(ctx, target, input.WithSession, &result)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -310,16 +299,7 @@ func handleDeployStack(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 		result.EstimatedCostPerHour = cost
 	}
 
-	// Auto-session if requested
-	if input.WithSession {
-		adapter := stack.NewTargetAdapter(deployer)
-		si, err := adapter.CreateSession(ctx, 8)
-		if err == nil && si != nil {
-			result.SessionID = si.SessionID
-			result.SessionIP = si.IPAddress
-			result.SessionPort = si.Port
-		}
-	}
+	tryCreateSession(ctx, stack.NewTargetAdapter(deployer), input.WithSession, &result)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -384,18 +364,7 @@ func handleDeployAnywhere(ctx context.Context, _ *mcp.CallToolRequest, input dep
 		result.PID = st.Anywhere.PID
 	}
 
-	// Auto-session if requested
-	if input.WithSession {
-		sm, ok := target.(deploy.SessionManager)
-		if ok {
-			si, err := sm.CreateSession(ctx, 8)
-			if err == nil && si != nil {
-				result.SessionID = si.SessionID
-				result.SessionIP = si.IPAddress
-				result.SessionPort = si.Port
-			}
-		}
-	}
+	tryCreateSession(ctx, target, input.WithSession, &result)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
@@ -465,18 +434,7 @@ func handleDeployEC2(ctx context.Context, _ *mcp.CallToolRequest, input deployEC
 		result.BuildID = st.EC2Fleet.BuildID
 	}
 
-	// Auto-session if requested
-	if input.WithSession {
-		sm, ok := target.(deploy.SessionManager)
-		if ok {
-			si, err := sm.CreateSession(ctx, 8)
-			if err == nil && si != nil {
-				result.SessionID = si.SessionID
-				result.SessionIP = si.IPAddress
-				result.SessionPort = si.Port
-			}
-		}
-	}
+	tryCreateSession(ctx, target, input.WithSession, &result)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{

--- a/cmd/mcp/tools_engine.go
+++ b/cmd/mcp/tools_engine.go
@@ -111,14 +111,9 @@ func handleEngineBuild(ctx context.Context, _ *mcp.CallToolRequest, input engine
 	}
 
 	engineHash := cache.EngineKey(cfg)
-	if !input.NoCache {
-		c, err := cache.Load()
-		if err == nil && c.IsHit(cache.StageEngine, engineHash) {
-			result := engineResult{Success: true, EnginePath: cfg.Engine.SourcePath, Output: "Engine build is up to date (cached), skipping."}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: jsonString(result)}},
-			}, nil, nil
-		}
+	if hit := checkCacheHit(input.NoCache, cache.StageEngine, engineHash,
+		engineResult{Success: true, EnginePath: cfg.Engine.SourcePath, Output: "Engine build is up to date (cached), skipping."}); hit != nil {
+		return hit, nil, nil
 	}
 
 	r := runner.NewRunner(true, input.DryRun || globals.DryRun)
@@ -175,14 +170,9 @@ func handleDockerEngineBuild(ctx context.Context, input engineBuildInput) (*mcp.
 	cfg := globals.Cfg
 
 	engineHash := cache.EngineKey(cfg)
-	if !input.NoCache {
-		c, err := cache.Load()
-		if err == nil && c.IsHit(cache.StageEngine, engineHash) {
-			result := engineResult{Success: true, EnginePath: cfg.Engine.SourcePath, Output: "Engine Docker build is up to date (cached), skipping."}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: jsonString(result)}},
-			}, nil, nil
-		}
+	if hit := checkCacheHit(input.NoCache, cache.StageEngine, engineHash,
+		engineResult{Success: true, EnginePath: cfg.Engine.SourcePath, Output: "Engine Docker build is up to date (cached), skipping."}); hit != nil {
+		return hit, nil, nil
 	}
 
 	r := runner.NewRunner(true, input.DryRun || globals.DryRun)

--- a/cmd/mcp/tools_game.go
+++ b/cmd/mcp/tools_game.go
@@ -114,14 +114,9 @@ func handleGameBuild(ctx context.Context, _ *mcp.CallToolRequest, input gameBuil
 
 	engineHash := cache.EngineKey(cfg)
 	serverHash := cache.GameServerKey(cfg, engineHash)
-	if !input.NoCache {
-		c, err := cache.Load()
-		if err == nil && c.IsHit(cache.StageGameServer, serverHash) {
-			result := gameBuildResult{Success: true, Output: "Game server build is up to date (cached), skipping."}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: jsonString(result)}},
-			}, nil, nil
-		}
+	if hit := checkCacheHit(input.NoCache, cache.StageGameServer, serverHash,
+		gameBuildResult{Success: true, Output: "Game server build is up to date (cached), skipping."}); hit != nil {
+		return hit, nil, nil
 	}
 
 	opts := makeGameBuildOpts(cfg, input.SkipCook, "")
@@ -171,14 +166,9 @@ func handleDockerGameBuild(ctx context.Context, input gameBuildInput) (*mcp.Call
 
 	engineHash := cache.EngineKey(cfg)
 	serverHash := cache.GameServerKey(cfg, engineHash)
-	if !input.NoCache {
-		c, err := cache.Load()
-		if err == nil && c.IsHit(cache.StageGameServer, serverHash) {
-			result := gameBuildResult{Success: true, Output: "Game server build is up to date (cached), skipping."}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: jsonString(result)}},
-			}, nil, nil
-		}
+	if hit := checkCacheHit(input.NoCache, cache.StageGameServer, serverHash,
+		gameBuildResult{Success: true, Output: "Game server build is up to date (cached), skipping."}); hit != nil {
+		return hit, nil, nil
 	}
 
 	r := runner.NewRunner(true, input.DryRun || globals.DryRun)
@@ -262,14 +252,9 @@ func handleGameClient(ctx context.Context, _ *mcp.CallToolRequest, input gameCli
 
 	engineHash := cache.EngineKey(cfg)
 	clientHash := cache.GameClientKey(cfg, engineHash, platform)
-	if !input.NoCache {
-		c, err := cache.Load()
-		if err == nil && c.IsHit(cache.StageGameClient, clientHash) {
-			result := gameBuildResult{Success: true, Output: "Game client build is up to date (cached), skipping."}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: jsonString(result)}},
-			}, nil, nil
-		}
+	if hit := checkCacheHit(input.NoCache, cache.StageGameClient, clientHash,
+		gameBuildResult{Success: true, Output: "Game client build is up to date (cached), skipping."}); hit != nil {
+		return hit, nil, nil
 	}
 
 	opts := makeGameBuildOpts(cfg, input.SkipCook, platform)
@@ -326,14 +311,9 @@ func handleDockerGameClient(ctx context.Context, input gameClientInput, platform
 
 	engineHash := cache.EngineKey(cfg)
 	clientHash := cache.GameClientKey(cfg, engineHash, platform)
-	if !input.NoCache {
-		c, err := cache.Load()
-		if err == nil && c.IsHit(cache.StageGameClient, clientHash) {
-			result := gameBuildResult{Success: true, Output: "Game client build is up to date (cached), skipping."}
-			return &mcp.CallToolResult{
-				Content: []mcp.Content{&mcp.TextContent{Text: jsonString(result)}},
-			}, nil, nil
-		}
+	if hit := checkCacheHit(input.NoCache, cache.StageGameClient, clientHash,
+		gameBuildResult{Success: true, Output: "Game client build is up to date (cached), skipping."}); hit != nil {
+		return hit, nil, nil
 	}
 
 	r := runner.NewRunner(true, input.DryRun || globals.DryRun)

--- a/internal/engine/builder_windows.go
+++ b/internal/engine/builder_windows.go
@@ -47,24 +47,24 @@ func (b *Builder) runBat(ctx context.Context, batPath string, args ...string) er
 	return cmd.Run()
 }
 
+// runBatFile runs a .bat file from the engine source directory, checking that
+// it exists first. Used by Setup and GenerateProjectFiles.
+func (b *Builder) runBatFile(ctx context.Context, name string) error {
+	batPath := filepath.Join(b.opts.SourcePath, name)
+	if _, err := os.Stat(batPath); os.IsNotExist(err) {
+		return fmt.Errorf("%s not found at %s", name, batPath)
+	}
+	return b.runBat(ctx, batPath)
+}
+
 // Setup runs Setup.bat to download engine dependencies.
 func (b *Builder) Setup(ctx context.Context) error {
-	setupPath := filepath.Join(b.opts.SourcePath, "Setup.bat")
-	if _, err := os.Stat(setupPath); os.IsNotExist(err) {
-		return fmt.Errorf("Setup.bat not found at %s", setupPath)
-	}
-
-	return b.runBat(ctx, setupPath)
+	return b.runBatFile(ctx, "Setup.bat")
 }
 
 // GenerateProjectFiles runs GenerateProjectFiles.bat.
 func (b *Builder) GenerateProjectFiles(ctx context.Context) error {
-	genPath := filepath.Join(b.opts.SourcePath, "GenerateProjectFiles.bat")
-	if _, err := os.Stat(genPath); os.IsNotExist(err) {
-		return fmt.Errorf("GenerateProjectFiles.bat not found at %s", genPath)
-	}
-
-	return b.runBat(ctx, genPath)
+	return b.runBatFile(ctx, "GenerateProjectFiles.bat")
 }
 
 // compile builds ShaderCompileWorker and UnrealEditor using Build.bat.


### PR DESCRIPTION
## Summary
- Enabled `dupl` linter (default threshold 150) in `.golangci.yml` to catch future copy-paste duplication
- Refactored 4 duplication hotspots identified by running dupl at threshold 50:
  - **`cmd/game`**: Extract `saveClientState()` helper (was duplicated in `runClientBuild` and `runDockerClientBuild`)
  - **`cmd/mcp/tools_deploy.go`**: Extract `tryCreateSession()` via `sessionReceiver` interface (was 4 identical copies)
  - **`cmd/mcp/tools_engine.go` + `tools_game.go`**: Extract `checkCacheHit()` helper (was 6 identical copies)
  - **`internal/engine/builder_windows.go`**: Extract `runBatFile()` helper (Setup/GenerateProjectFiles were identical except filename)
- Intentionally skipped structural duplicates: tags converters (different AWS SDK types), native/Docker builder branches (different builder constructors), test cases, anywhere destroy steps

## Test plan
- [x] `go build` passes (Windows + Linux cross-compile)
- [x] `golangci-lint run ./...` — 0 issues (including dupl)
- [x] `golangci-lint run --enable dupl ./...` — 0 issues at default threshold
- [x] `go test ./...` — all pass