### PR TITLE
Add ludus doctor, guided error messages, and progress indicators

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ ludus game [build|client]          --skip-cook, --platform (Linux|Win64), --back
 ludus container [build|push]       --tag/-t, --no-cache
 ludus deploy [fleet|stack|anywhere|ec2|session|destroy]  --target, --region, --instance-type, --fleet-name, --stack-name, --ip, --with-session, destroy --all
 ludus connect                      --address (ip:port override)
+ludus doctor                       # deep diagnostics: toolchain, stale artifacts, state, cache, disk, AWS creds, Docker, git
 ludus status                       # checks: engine source/build, game build, client build, container image, fleet, session
 ludus run                          # full pipeline (7+ stages)
   --skip-engine, --skip-game, --skip-container, --skip-deploy, --with-client, --with-session, --backend (native|docker), --no-cache
@@ -107,6 +108,8 @@ All business logic is in `internal/` (unexported to consumers):
 - **`engine`** — `Builder` for UE5 compilation. Linux: Setup.sh, GenerateProjectFiles.sh, make. Windows: Setup.bat, GenerateProjectFiles.bat, Build.bat. Targets: `ShaderCompileWorker` and `UnrealEditor` only (game server is built via RunUAT in the game stage). Auto-detects max jobs from RAM (8 GB per job).
 - **`game`** — `Builder` for UE5 game packaging via RunUAT BuildCookRun. Cross-platform: `resolveRunUAT()` selects `cmd /c RunUAT.bat` (Windows) or `bash RunUAT.sh` (Linux). Uses relative script paths to avoid spaces-in-path issues with `cmd /c`. Path arguments are quoted (`-project="..."`) for the same reason. Pre-build fixups: `applyNuGetAuditWorkaround()` sets `NuGetAuditLevel=critical` as an env var on the runner (avoids writing `Directory.Build.props` into engine source; version-gated to 5.6/unknown), and `ensureDefaultServerTarget()` configures DefaultEngine.ini (game project config, not engine source; skips gracefully if INI structure doesn't match). `BuildClient()` supports `--platform` flag (Linux, Win64). All target names (`-servertargetname`, binary paths) are config-driven via `BuildOptions`. `EngineVersion` in `BuildOptions` enables version-specific workarounds.
 - **`container`** — `Builder` for Dockerfile generation (Amazon Linux 2023, non-root user), `docker build`, and ECR push (login + tag + push). Project name and server target are parameterized in generated Dockerfile and wrapper config.
+- **`diagnose`** — Contextual error guidance for common failure modes. Table-driven pattern matching with three categories: `awsHints` (12 patterns — expired tokens, access denied, quota limits, missing credentials), `deployHints` (6 patterns — fleet errors, timeouts, conflicts, IP detection), `containerHints` (6 patterns — disk full, daemon not running, ECR auth, rate limits). Public functions: `AWSError(err, operation)`, `DeployError(err, target)`, `ContainerError(err, operation)`. Returns the original error wrapped with actionable `Suggestions:` section, or the original error unchanged if no patterns match.
+- **`progress`** — Lightweight elapsed-time ticker for long-running operations. `Start(operation, interval)` spawns a goroutine that prints periodic `[elapsed] operation still running...` messages. `Stop()` terminates the ticker. Used in engine compile (2 min interval), game server build, and client build to reassure users during multi-hour builds with long silent periods.
 - **`deploy`** — `Target` interface abstracting deployment backends, with `Capabilities` (what the target needs/supports), `Deploy()`, `Status()`, `Destroy()` methods. Optional `SessionManager` interface for targets that support game sessions. Shared types: `DeployInput`, `DeployResult`, `DeployStatus`, `SessionInfo`. Implementations are in `gamelift`, `stack`, `binary`, `anywhere`, and `ec2fleet` packages; target resolution lives in `cmd/globals/resolve.go`.
 - **`gamelift`** — `Deployer` for AWS GameLift via SDK v2. Creates container group definitions, IAM roles, fleets. Polls with 15s intervals / 30min timeout. Uses shared `tags` package for resource tagging. `Destroy()` tears down in reverse order, tolerating not-found errors. `TargetAdapter` wraps `Deployer` to implement `deploy.Target` and `deploy.SessionManager`. `CreateGameSession` returns `*GameSessionInfo` (SessionID, IPAddress, Port). `DescribeGameSession` checks session liveness.
 - **`stack`** — `StackDeployer` for CloudFormation-based deployment. `Deploy()` generates a CF template (IAM role, container group definition, container fleet), calls `CreateStack`/`UpdateStack`, and polls until complete. `Destroy()` calls `DeleteStack`. `TargetAdapter` wraps `StackDeployer` to implement `deploy.Target` and `deploy.SessionManager` (reads fleet ID from stack outputs for session management). Stack naming: `ludus-<fleet-name>` by default.
@@ -140,6 +143,8 @@ Build-tagged files use `//go:build` tags for platform-specific implementations:
 - **State persistence**: Deploy and client-build commands write to `.ludus/state.json` so downstream commands (`connect`, `status`) can resolve fleet/session/client info without re-querying AWS.
 - **Config-driven targets**: Game project name, server target, client target, and game target are all configurable via `ludus.yaml`. Defaults derive from `ProjectName` (e.g., `ProjectName+"Server"` for `ServerTarget`). Lyra-specific behavior (auto-detection of project path, content validation with plugin dirs) is preserved as a fallback when `ProjectName == "Lyra"`.
 - **Cost estimates and instance guidance**: Deploy commands (`fleet`, `stack`, `ec2`) and the pipeline print estimated hourly/monthly cost and Graviton savings tips before fleet creation. MCP deploy results include `estimated_cost_per_hour` and `instance_guidance` fields. The deploy help text includes a quick-reference instance type comparison. Unknown instance types are silently skipped.
+- **Guided error messages**: Deploy and container commands wrap errors through `diagnose.DeployError()` / `diagnose.ContainerError()` which pattern-match error strings against known failure modes and append actionable fix suggestions. Game build errors go through `diagnoseBuildError()` in `internal/game/builder.go` which scans RunUAT logs for known patterns. Both use the same table-driven approach.
+- **Progress indicators**: Long-running builds (engine compile, game server/client BuildCookRun) use `progress.Start()` to print elapsed-time messages every 2 minutes, preventing confusion during multi-hour builds with long silent linking phases.
 
 ## Configuration
 
@@ -274,9 +279,10 @@ See [ROADMAP.md](ROADMAP.md) for the full prioritized roadmap. Key categories:
 
 - **Stabilization** — ~~UE 5.4 C4756 patch~~, ~~OOM detection~~, ~~UAC failure detection~~, ~~build failure diagnostics~~ (all done in PR #35)
 - **Onboarding** — `ludus setup` wizard, ~~auto-detect engine version~~, ~~AWS credential validation~~ (PR #38), ~~"what's next" guidance~~ (PR #37), ~~Lyra auto-discovery~~ (PR #41), ~~server map validation~~ (PR #38)
-- **Build UX** — Progress indicators, resume/incremental builds, ~~build config guidance~~ (PR #39)
+- **Build UX** — ~~Progress indicators~~, resume/incremental builds, ~~build config guidance~~ (PR #39)
 - **Deploy UX** — ~~Cost estimates~~ (PR #38), ~~auto-session (`--with-session`)~~ (PR #37), ~~batch destroy~~ (PR #39), ~~instance type guidance~~ (PR #41)
-- **Diagnostics** — `ludus doctor` command, guided error messages
+- **Diagnostics** — ~~`ludus doctor` command~~, ~~guided error messages~~
 - **Multi-version** — ~~`ludus config set`~~ (PR #39), state profiles
 - **Code quality** — ~~`dupl` linter + refactor duplicated code~~ (PR #40)
-- **Features** — ~~ARM/Graviton support~~ (PR #36), BuildGraph XML generation, studio infrastructure provisioning
+- **Security** — Dockerfile security scanning (Hadolint, Trivy/Grype)
+- **Features** — ~~ARM/Graviton support~~ (PR #36), npm package for MCP distribution, BuildGraph XML generation, studio infrastructure provisioning

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,7 +26,7 @@ Reducing friction for new users going from zero to a running game session.
 
 Improving the experience during long build operations.
 
-- [ ] **Progress indicators** — Periodically tail the UBA log during builds and print "X/Y actions (Z%)" summaries. Even without a progress bar, periodic status updates are far better than hours of silence.
+- [x] **Progress indicators** — Elapsed-time ticker prints periodic status messages during long-running engine compiles, server builds, and client builds (every 2 minutes). Prevents confusion during multi-hour builds with long silent periods (especially linking).
 - [ ] **Resume / incremental builds** — Detect partial builds (e.g. from a previous OOM or crash) and offer to resume rather than restart from scratch. UBT already supports incremental builds; Ludus should surface this.
 - [x] **Build config guidance** — `ludus game build --config` help text and CLI output explain Shipping vs Development tradeoffs (binary size, debug symbols, optimization). Prints config note when `--config` is used.
 
@@ -43,8 +43,8 @@ Smoothing out the deployment and testing workflow.
 
 Better observability and self-service troubleshooting.
 
-- [ ] **`ludus doctor` command** — Comprehensive diagnostic tool (beyond `ludus status`) that checks for: stale DLLs, wrong toolchain version in env vs registry, disk space for upcoming builds, partial/corrupted build state, AWS credential expiry, common misconfigurations.
-- [ ] **Guided error messages** — Every failure should tell the user exactly what to do next, not just what went wrong. Contextual fix suggestions based on exit codes, log patterns, and known issues per UE version.
+- [x] **`ludus doctor` command** — 8 diagnostic checks: toolchain consistency (env vs engine requirement), stale build artifacts (>30 days), build state integrity (state.json cross-references), cache integrity, disk space (50 GB warn / 100 GB fail), AWS credential validity, Docker daemon status, git status. Platform-specific disk checks via build-tagged files.
+- [x] **Guided error messages** — `internal/diagnose` package with table-driven error pattern matching. Three categories: AWS hints (12 patterns — expired tokens, access denied, quota limits, missing credentials), deploy hints (6 patterns — fleet errors, timeouts, conflicts, IP detection), container hints (6 patterns — disk full, daemon not running, ECR auth, rate limits). Wired into all deploy and container commands.
 
 ## Multi-Version UX
 
@@ -59,10 +59,17 @@ Reducing duplication and improving maintainability.
 
 - [x] **Dupl linter + refactor** — Enabled `dupl` linter (threshold 150) in `.golangci.yml`. Refactored: `saveClientState()` helper in `cmd/game`, `tryCreateSession()` and `checkCacheHit()` helpers in `cmd/mcp`, `runBatFile()` helper in `internal/engine`. Remaining structural duplicates (tags converters, native/Docker builder branches) are intentional — different types prevent meaningful abstraction.
 
+## Security
+
+Hardening generated artifacts and supply chain.
+
+- [ ] **Dockerfile security scanning** — Lint and scan the Dockerfiles Ludus generates for security issues. Options: Hadolint for Dockerfile best practices (no `latest` tags, avoid running as root, minimize layers), Trivy/Grype for image vulnerability scanning. Could integrate into `ludus container build` as a post-build step or `ludus doctor` check, and into CI workflows.
+
 ## Features
 
 Larger feature additions from the project roadmap.
 
 - [x] **ARM/Graviton support** — `--arch arm64` flag on `game build` and `deploy ec2` for cross-compiling LinuxArm64 servers targeting Graviton instances (20-30% cheaper). All Epic toolchain installers already ship the aarch64 sysroot. Config: `game.arch`, MCP: `arch` param on build/deploy tools. *(PR #36)*
+- [ ] **npm package for MCP distribution** — Publish `ludus-cli` npm package so AI agents (Claude Code, Cursor, etc.) can register Ludus as an MCP server via `npx ludus-cli mcp`. The npm `install.js` downloads the correct pre-built binary from GitHub Releases. Ties to GoReleaser — each tagged release produces binaries AND publishes the npm package. Users configure their AI agent with `{"command": "npx", "args": ["-y", "ludus-cli", "mcp"]}`.
 - [ ] **BuildGraph XML generation** — `ludus buildgraph` command that generates BuildGraph XML validated against the UE schema. Outputs a ready-to-use XML file that UET, Horde, or other build orchestration tools can consume. An addition to the existing linear pipeline, not a replacement.
 - [ ] **Studio infrastructure provisioning** — Potentially a separate project that provisions game studio infrastructure on AWS (Perforce, CI/CD build farms, derived data cache, virtual workstations) as composable modules that integrate with Ludus. Decision point: integrate with AWS's [cloud-game-development-toolkit](https://github.com/aws-games/cloud-game-development-toolkit), wrap it, or build from scratch.

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devrecon/ludus/internal/cache"
 	"github.com/devrecon/ludus/internal/config"
 	ctrBuilder "github.com/devrecon/ludus/internal/container"
+	"github.com/devrecon/ludus/internal/diagnose"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/spf13/cobra"
 )
@@ -95,7 +96,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	fmt.Println("Building container image...")
 	result, err := builder.Build(cmd.Context())
 	if err != nil {
-		return err
+		return diagnose.ContainerError(err, "container build")
 	}
 
 	if c, cErr := cache.Load(); cErr == nil {
@@ -125,7 +126,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 		AWSAccountID:  cfg.AWS.AccountID,
 		ImageTag:      cfg.Container.Tag,
 	}); err != nil {
-		return err
+		return diagnose.ContainerError(err, "container push")
 	}
 	fmt.Println("\nNext: ludus deploy fleet  (or: ludus deploy stack)")
 	return nil

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/deploy"
+	"github.com/devrecon/ludus/internal/diagnose"
 	"github.com/devrecon/ludus/internal/gamelift"
 	"github.com/devrecon/ludus/internal/pricing"
 	"github.com/devrecon/ludus/internal/stack"
@@ -246,14 +247,14 @@ func runFleet(cmd *cobra.Command, args []string) error {
 	fmt.Println("Creating container group definition...")
 	cgdARN, err := deployer.CreateContainerGroupDefinition(cmd.Context())
 	if err != nil {
-		return err
+		return diagnose.DeployError(err, "gamelift")
 	}
 	fmt.Printf("Container group definition ready: %s\n\n", cgdARN)
 
 	fmt.Println("Creating container fleet...")
 	fleetStatus, err := deployer.CreateFleet(cmd.Context(), cgdARN)
 	if err != nil {
-		return err
+		return diagnose.DeployError(err, "gamelift")
 	}
 
 	if err := state.UpdateFleet(&state.FleetState{
@@ -327,7 +328,7 @@ func runStack(cmd *cobra.Command, args []string) error {
 
 	result, err := deployer.Deploy(cmd.Context())
 	if err != nil {
-		return err
+		return diagnose.DeployError(err, "stack")
 	}
 
 	if err := state.UpdateFleet(&state.FleetState{
@@ -410,7 +411,7 @@ func runAnywhere(cmd *cobra.Command, args []string) error {
 		ServerPort: cfg.Container.ServerPort,
 	})
 	if err != nil {
-		return err
+		return diagnose.DeployError(err, "anywhere")
 	}
 
 	fmt.Printf("\nAnywhere deployment ready: %s\n", result.Detail)
@@ -467,7 +468,7 @@ func runEC2(cmd *cobra.Command, args []string) error {
 		ServerPort:     cfg.Container.ServerPort,
 	})
 	if err != nil {
-		return err
+		return diagnose.DeployError(err, "ec2")
 	}
 
 	elapsed := time.Since(start)

--- a/cmd/doctor/disk_unix.go
+++ b/cmd/doctor/disk_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package doctor
+
+import "syscall"
+
+// getFreeDiskGB returns the free disk space in GB for the given path.
+// Returns -1 if the space cannot be determined.
+func getFreeDiskGB(path string) float64 {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return -1
+	}
+	return float64(stat.Bavail*uint64(stat.Bsize)) / (1024 * 1024 * 1024)
+}

--- a/cmd/doctor/disk_windows.go
+++ b/cmd/doctor/disk_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package doctor
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+// getFreeDiskGB returns the free disk space in GB for the given path.
+// Returns -1 if the space cannot be determined.
+func getFreeDiskGB(path string) float64 {
+	kernel32 := syscall.NewLazyDLL("kernel32.dll")
+	proc := kernel32.NewProc("GetDiskFreeSpaceExW")
+
+	var freeBytes uint64
+	pathPtr, _ := syscall.UTF16PtrFromString(path)
+
+	ret, _, _ := proc.Call(
+		uintptr(unsafe.Pointer(pathPtr)),
+		uintptr(unsafe.Pointer(&freeBytes)),
+		0,
+		0,
+	)
+	if ret == 0 {
+		return -1
+	}
+	return float64(freeBytes) / (1024 * 1024 * 1024)
+}

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -1,0 +1,348 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"time"
+
+	"github.com/devrecon/ludus/cmd/globals"
+	"github.com/devrecon/ludus/internal/cache"
+	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/state"
+	"github.com/devrecon/ludus/internal/toolchain"
+	"github.com/spf13/cobra"
+)
+
+// Cmd is the doctor command for comprehensive diagnostics.
+var Cmd = &cobra.Command{
+	Use:   "doctor",
+	Short: "Run comprehensive diagnostics on the Ludus environment",
+	Long: `Performs deeper diagnostics beyond 'ludus init', including:
+
+  - Stale DLLs or build artifacts from previous engine versions
+  - Toolchain version mismatch (env vs registry vs engine requirement)
+  - Disk space for upcoming builds
+  - Partial or corrupted build state
+  - AWS credential expiry
+  - Build cache integrity
+  - Common misconfigurations
+
+Use this when something isn't working and 'ludus init' passes.`,
+	RunE: runDoctor,
+}
+
+// diagnostic represents a single diagnostic check result.
+type diagnostic struct {
+	name    string
+	status  string // "ok", "warn", "fail"
+	message string
+}
+
+func runDoctor(cmd *cobra.Command, args []string) error {
+	cfg := globals.Cfg
+
+	fmt.Println("Running diagnostics...")
+	fmt.Println()
+
+	var checks []diagnostic
+
+	checks = append(checks, checkToolchainConsistency(cfg))
+	checks = append(checks, checkStaleBuildArtifacts(cfg))
+	checks = append(checks, checkBuildState(cfg))
+	checks = append(checks, checkCacheIntegrity())
+	checks = append(checks, checkDiskSpace(cfg))
+	checks = append(checks, checkAWSCredentialExpiry())
+	checks = append(checks, checkDockerDaemon())
+	checks = append(checks, checkGitState())
+
+	fails := 0
+	warns := 0
+	for _, d := range checks {
+		marker := "[OK]  "
+		switch d.status {
+		case "fail":
+			marker = "[FAIL]"
+			fails++
+		case "warn":
+			marker = "[WARN]"
+			warns++
+		}
+		fmt.Printf("  %s %-30s %s\n", marker, d.name, d.message)
+	}
+
+	fmt.Println()
+	if fails > 0 {
+		fmt.Printf("%d issue(s) found", fails)
+		if warns > 0 {
+			fmt.Printf(", %d warning(s)", warns)
+		}
+		fmt.Println()
+		return fmt.Errorf("%d diagnostic check(s) failed", fails)
+	}
+	if warns > 0 {
+		fmt.Printf("No issues found (%d warning(s)).\n", warns)
+	} else {
+		fmt.Println("No issues found.")
+	}
+	return nil
+}
+
+// checkToolchainConsistency verifies the toolchain version in the environment
+// matches what the engine expects.
+func checkToolchainConsistency(cfg *config.Config) diagnostic {
+	d := diagnostic{name: "Toolchain Consistency"}
+
+	if cfg.Engine.SourcePath == "" {
+		d.status = "ok"
+		d.message = "skipped — no engine source configured"
+		return d
+	}
+
+	tc := toolchain.CheckToolchain(cfg.Engine.SourcePath, cfg.Engine.Version)
+	if tc.Required == nil {
+		d.status = "ok"
+		d.message = "no known toolchain requirement for this engine version"
+		return d
+	}
+
+	if !tc.Found {
+		d.status = "warn"
+		d.message = fmt.Sprintf("required %s not found; run 'ludus init --fix'", tc.Required.SDKVersion)
+		return d
+	}
+
+	// Check if LINUX_MULTIARCH_ROOT points to the right version
+	lmr := os.Getenv("LINUX_MULTIARCH_ROOT")
+	if lmr != "" && !strings.Contains(lmr, tc.Required.SDKVersion) {
+		d.status = "warn"
+		d.message = fmt.Sprintf("LINUX_MULTIARCH_ROOT points to %s but engine requires %s; restart terminal after toolchain install",
+			filepath.Base(lmr), tc.Required.SDKVersion)
+		return d
+	}
+
+	d.status = "ok"
+	d.message = fmt.Sprintf("%s found and matches engine requirement", tc.Required.SDKVersion)
+	return d
+}
+
+// checkStaleBuildArtifacts looks for build artifacts that might be from a
+// different engine version.
+func checkStaleBuildArtifacts(cfg *config.Config) diagnostic {
+	d := diagnostic{name: "Build Artifacts"}
+
+	if cfg.Engine.SourcePath == "" {
+		d.status = "ok"
+		d.message = "skipped — no engine source configured"
+		return d
+	}
+
+	// Check if UnrealEditor exists but is very old (> 30 days)
+	var editorPath string
+	if runtime.GOOS == "windows" {
+		editorPath = filepath.Join(cfg.Engine.SourcePath, "Engine", "Binaries", "Win64", "UnrealEditor.exe")
+	} else {
+		editorPath = filepath.Join(cfg.Engine.SourcePath, "Engine", "Binaries", "Linux", "UnrealEditor")
+	}
+
+	info, err := os.Stat(editorPath)
+	if err != nil {
+		d.status = "ok"
+		d.message = "no engine build found (clean state)"
+		return d
+	}
+
+	age := time.Since(info.ModTime())
+	if age > 30*24*time.Hour {
+		d.status = "warn"
+		d.message = fmt.Sprintf("engine build is %d days old; consider rebuilding", int(age.Hours()/24))
+		return d
+	}
+
+	d.status = "ok"
+	d.message = fmt.Sprintf("engine build is %d days old", int(age.Hours()/24))
+	return d
+}
+
+// checkBuildState verifies state.json consistency — checks if referenced
+// files and directories still exist.
+func checkBuildState(cfg *config.Config) diagnostic {
+	d := diagnostic{name: "Build State"}
+
+	st, err := state.Load()
+	if err != nil {
+		d.status = "warn"
+		d.message = "could not read .ludus/state.json"
+		return d
+	}
+
+	var issues []string
+
+	// Check client binary exists
+	if st.Client != nil && st.Client.BinaryPath != "" {
+		if _, err := os.Stat(st.Client.BinaryPath); os.IsNotExist(err) {
+			issues = append(issues, "client binary missing: "+st.Client.BinaryPath)
+		}
+	}
+
+	// Check deploy state references
+	if st.Deploy != nil && st.Deploy.Status == "active" {
+		// Deployment marked active — check if fleet still exists in state
+		if st.Fleet == nil && st.EC2Fleet == nil && st.Anywhere == nil {
+			issues = append(issues, "deploy marked active but no fleet state found")
+		}
+	}
+
+	if len(issues) > 0 {
+		d.status = "warn"
+		d.message = strings.Join(issues, "; ")
+		return d
+	}
+
+	d.status = "ok"
+	d.message = "state references are consistent"
+	return d
+}
+
+// checkCacheIntegrity verifies the build cache is readable.
+func checkCacheIntegrity() diagnostic {
+	d := diagnostic{name: "Build Cache"}
+
+	c, err := cache.Load()
+	if err != nil {
+		d.status = "warn"
+		d.message = fmt.Sprintf("cache unreadable: %v; builds will re-run from scratch", err)
+		return d
+	}
+
+	_ = c // cache loaded successfully — that's all we need to verify
+
+	d.status = "ok"
+	d.message = "cache file readable"
+	return d
+}
+
+// checkDiskSpace warns if available disk space is low for builds.
+func checkDiskSpace(cfg *config.Config) diagnostic {
+	d := diagnostic{name: "Disk Space"}
+
+	// Get the path to check — engine source or current directory
+	checkPath := cfg.Engine.SourcePath
+	if checkPath == "" {
+		var err error
+		checkPath, err = os.Getwd()
+		if err != nil {
+			d.status = "ok"
+			d.message = "could not determine path to check"
+			return d
+		}
+	}
+
+	freeGB := getFreeDiskGB(checkPath)
+	if freeGB < 0 {
+		d.status = "ok"
+		d.message = "could not determine free space"
+		return d
+	}
+
+	if freeGB < 50 {
+		d.status = "fail"
+		d.message = fmt.Sprintf("%.0f GB free — builds require 50-100 GB free space", freeGB)
+		return d
+	}
+	if freeGB < 100 {
+		d.status = "warn"
+		d.message = fmt.Sprintf("%.0f GB free — consider freeing space (100 GB recommended for builds)", freeGB)
+		return d
+	}
+
+	d.status = "ok"
+	d.message = fmt.Sprintf("%.0f GB free", freeGB)
+	return d
+}
+
+// checkAWSCredentialExpiry checks if AWS credentials are configured and valid.
+func checkAWSCredentialExpiry() diagnostic {
+	d := diagnostic{name: "AWS Credentials"}
+
+	if _, err := exec.LookPath("aws"); err != nil {
+		d.status = "ok"
+		d.message = "skipped — AWS CLI not installed"
+		return d
+	}
+
+	cmd := exec.Command("aws", "sts", "get-caller-identity", "--output", "json")
+	if err := cmd.Run(); err != nil {
+		d.status = "warn"
+		d.message = "credentials expired or not configured; run 'aws configure' or 'aws sso login'"
+		return d
+	}
+
+	d.status = "ok"
+	d.message = "credentials valid"
+	return d
+}
+
+// checkDockerDaemon checks if Docker is running (not just installed).
+func checkDockerDaemon() diagnostic {
+	d := diagnostic{name: "Docker Daemon"}
+
+	if _, err := exec.LookPath("docker"); err != nil {
+		if runtime.GOOS == "windows" {
+			d.status = "ok"
+			d.message = "skipped — not needed for Windows client workflow"
+		} else {
+			d.status = "warn"
+			d.message = "docker not installed"
+		}
+		return d
+	}
+
+	cmd := exec.Command("docker", "info")
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+	if err := cmd.Run(); err != nil {
+		d.status = "warn"
+		d.message = "docker installed but daemon not running; start Docker Desktop or 'sudo systemctl start docker'"
+		return d
+	}
+
+	d.status = "ok"
+	d.message = "docker daemon running"
+	return d
+}
+
+// checkGitState checks for uncommitted changes in the engine source (which
+// can cause UBT to rebuild everything).
+func checkGitState() diagnostic {
+	d := diagnostic{name: "Git Status"}
+
+	if _, err := exec.LookPath("git"); err != nil {
+		d.status = "ok"
+		d.message = "git not available"
+		return d
+	}
+
+	cmd := exec.Command("git", "status", "--porcelain")
+	out, err := cmd.Output()
+	if err != nil {
+		d.status = "ok"
+		d.message = "not in a git repository"
+		return d
+	}
+
+	lines := strings.TrimSpace(string(out))
+	if lines == "" {
+		d.status = "ok"
+		d.message = "working tree clean"
+		return d
+	}
+
+	count := len(strings.Split(lines, "\n"))
+	d.status = "ok"
+	d.message = fmt.Sprintf("%d modified file(s) in working tree", count)
+	return d
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/devrecon/ludus/cmd/connect"
 	"github.com/devrecon/ludus/cmd/container"
 	"github.com/devrecon/ludus/cmd/deploy"
+	"github.com/devrecon/ludus/cmd/doctor"
 	"github.com/devrecon/ludus/cmd/engine"
 	"github.com/devrecon/ludus/cmd/game"
 	"github.com/devrecon/ludus/cmd/globals"
@@ -33,6 +34,7 @@ compiling a UE5 game project as a Linux dedicated server, containerizing it,
 and deploying it to AWS GameLift Containers.
 
   ludus init        Validate prerequisites and configure the environment
+  ludus doctor      Run comprehensive diagnostics
   ludus config      View and modify ludus.yaml configuration
   ludus engine      Build Unreal Engine from source
   ludus game        Build the game as a Linux dedicated server
@@ -75,6 +77,7 @@ func init() {
 
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(configcmd.Cmd)
+	rootCmd.AddCommand(doctor.Cmd)
 	rootCmd.AddCommand(engine.Cmd)
 	rootCmd.AddCommand(game.Cmd)
 	rootCmd.AddCommand(container.Cmd)

--- a/internal/diagnose/diagnose.go
+++ b/internal/diagnose/diagnose.go
@@ -1,0 +1,122 @@
+// Package diagnose provides contextual error guidance for common failure modes.
+// Each function inspects an error and returns an enhanced error with actionable
+// fix suggestions, or the original error unchanged if no guidance is available.
+package diagnose
+
+import (
+	"fmt"
+	"strings"
+)
+
+// errorHint maps an error substring to user-facing guidance.
+type errorHint struct {
+	pattern string
+	hint    string
+}
+
+// AWSError inspects an AWS API error and returns guidance.
+func AWSError(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+	hints := matchHints(msg, awsHints)
+
+	if len(hints) == 0 {
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+
+	return wrapWithHints(err, operation, hints)
+}
+
+// DeployError inspects a deployment error and returns guidance.
+func DeployError(err error, target string) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+	hints := matchHints(msg, deployHints)
+	hints = append(hints, matchHints(msg, awsHints)...)
+
+	if len(hints) == 0 {
+		return fmt.Errorf("deploy %s failed: %w", target, err)
+	}
+
+	return wrapWithHints(err, fmt.Sprintf("deploy %s failed", target), hints)
+}
+
+// ContainerError inspects a Docker/container error and returns guidance.
+func ContainerError(err error, operation string) error {
+	if err == nil {
+		return nil
+	}
+
+	msg := err.Error()
+	hints := matchHints(msg, containerHints)
+
+	if len(hints) == 0 {
+		return fmt.Errorf("%s: %w", operation, err)
+	}
+
+	return wrapWithHints(err, operation, hints)
+}
+
+var awsHints = []errorHint{
+	{"ExpiredTokenException", "AWS session expired; run 'aws sso login' or refresh credentials"},
+	{"ExpiredToken", "AWS session expired; run 'aws sso login' or refresh credentials"},
+	{"InvalidClientTokenId", "AWS access key is invalid; run 'aws configure' to set new credentials"},
+	{"SignatureDoesNotMatch", "AWS secret key mismatch; run 'aws configure' to update credentials"},
+	{"AccessDeniedException", "insufficient IAM permissions; ensure your role has GameLift, IAM, S3, and ECR access"},
+	{"AccessDenied", "insufficient IAM permissions; check your IAM policy"},
+	{"UnauthorizedAccess", "AWS authorization failed; verify your IAM role and permissions"},
+	{"LimitExceededException", "AWS service limit reached; request a quota increase via AWS Service Quotas console"},
+	{"ServiceQuotaExceededException", "AWS quota exceeded; request an increase via AWS Service Quotas console"},
+	{"ResourceNotFoundException", "AWS resource not found; it may have been deleted or the region is wrong"},
+	{"NoCredentialProviders", "no AWS credentials found; run 'aws configure' or set AWS_ACCESS_KEY_ID/AWS_SECRET_ACCESS_KEY"},
+	{"RequestExpired", "AWS request expired; check system clock or refresh credentials"},
+}
+
+var deployHints = []errorHint{
+	{"fleet is in ERROR", "fleet creation failed; check AWS GameLift console for details, then destroy and redeploy"},
+	{"timed out waiting for", "deployment timed out; this can happen with large builds — check the AWS console for fleet status"},
+	{"InternalServiceError", "AWS internal error; wait a few minutes and retry"},
+	{"ConflictException", "resource already exists; run 'ludus deploy destroy' first, then redeploy"},
+	{"InvalidRequestException", "invalid fleet configuration; verify instance type and region support GameLift"},
+	{"no non-loopback IPv4", "could not detect local IP; use --ip flag to specify your machine's IP address"},
+}
+
+var containerHints = []errorHint{
+	{"no space left on device", "disk full; free space with 'docker system prune' or remove unused images"},
+	{"Cannot connect to the Docker daemon", "Docker not running; start Docker Desktop or 'sudo systemctl start docker'"},
+	{"denied: Your authorization token has expired", "ECR login expired; Ludus re-authenticates automatically — retry the command"},
+	{"toomanyrequests", "Docker Hub rate limit; wait 15 minutes or use an authenticated pull"},
+	{"error getting credentials", "Docker credential helper failed; check ~/.docker/config.json"},
+	{"COPY failed", "Docker COPY failed; verify the server build directory exists and contains the expected files"},
+}
+
+// matchHints returns all matching hints for the given error message.
+func matchHints(msg string, hints []errorHint) []string {
+	var matched []string
+	seen := make(map[string]bool)
+	for _, h := range hints {
+		if strings.Contains(msg, h.pattern) && !seen[h.hint] {
+			matched = append(matched, h.hint)
+			seen[h.hint] = true
+		}
+	}
+	return matched
+}
+
+// wrapWithHints formats an error with actionable suggestions.
+func wrapWithHints(err error, operation string, hints []string) error {
+	var sb strings.Builder
+	sb.WriteString(operation)
+	sb.WriteString("\n\nSuggestions:")
+	for _, h := range hints {
+		sb.WriteString("\n  - ")
+		sb.WriteString(h)
+	}
+	return fmt.Errorf("%s: %w", sb.String(), err)
+}

--- a/internal/engine/builder.go
+++ b/internal/engine/builder.go
@@ -6,6 +6,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/devrecon/ludus/internal/progress"
 	"github.com/devrecon/ludus/internal/runner"
 )
 
@@ -75,8 +76,11 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 	}
 	fmt.Printf("  Compiling with %d parallel job(s)...\n", jobs)
 
-	if err := b.compile(ctx, jobs); err != nil {
-		result.Error = err
+	ticker := progress.Start("Engine compile", 2*time.Minute)
+	compileErr := b.compile(ctx, jobs)
+	ticker.Stop()
+	if compileErr != nil {
+		result.Error = compileErr
 		return result, result.Error
 	}
 

--- a/internal/game/builder.go
+++ b/internal/game/builder.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/progress"
 	"github.com/devrecon/ludus/internal/runner"
 )
 
@@ -215,8 +216,11 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		fmt.Printf("  Limiting parallel compile actions to %d\n", jobs)
 	}
 
-	if err := b.execRunUAT(ctx, shell, runatPath, args); err != nil {
-		result.Error = diagnoseBuildError(err, "BuildCookRun", b.opts.EnginePath)
+	ticker := progress.Start("Server build", 2*time.Minute)
+	buildErr := b.execRunUAT(ctx, shell, runatPath, args)
+	ticker.Stop()
+	if buildErr != nil {
+		result.Error = diagnoseBuildError(buildErr, "BuildCookRun", b.opts.EnginePath)
 		return result, result.Error
 	}
 
@@ -308,8 +312,11 @@ func (b *Builder) BuildClient(ctx context.Context) (*ClientBuildResult, error) {
 		fmt.Printf("  Limiting parallel compile actions to %d\n", jobs)
 	}
 
-	if err := b.execRunUAT(ctx, shell, runatPath, args); err != nil {
-		result.Error = diagnoseBuildError(err, fmt.Sprintf("BuildCookRun (client, %s)", platform), b.opts.EnginePath)
+	ticker := progress.Start("Client build", 2*time.Minute)
+	buildErr := b.execRunUAT(ctx, shell, runatPath, args)
+	ticker.Stop()
+	if buildErr != nil {
+		result.Error = diagnoseBuildError(buildErr, fmt.Sprintf("BuildCookRun (client, %s)", platform), b.opts.EnginePath)
 		return result, result.Error
 	}
 

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,47 @@
+// Package progress provides a lightweight elapsed-time ticker for long-running
+// operations. UE5 engine and game builds can run for hours with long periods of
+// silence (especially during linking), so periodic status messages reassure
+// users that the process is still alive.
+package progress
+
+import (
+	"fmt"
+	"time"
+)
+
+// Ticker prints periodic elapsed-time messages during long-running operations.
+type Ticker struct {
+	stop chan struct{}
+	done chan struct{}
+}
+
+// Start begins printing elapsed-time messages at the given interval.
+// Call Stop() when the operation completes.
+func Start(operation string, interval time.Duration) *Ticker {
+	t := &Ticker{
+		stop: make(chan struct{}),
+		done: make(chan struct{}),
+	}
+	go func() {
+		defer close(t.done)
+		start := time.Now()
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-t.stop:
+				return
+			case <-ticker.C:
+				elapsed := time.Since(start).Round(time.Second)
+				fmt.Printf("  [%s] %s still running...\n", elapsed, operation)
+			}
+		}
+	}()
+	return t
+}
+
+// Stop terminates the ticker and waits for the goroutine to exit.
+func (t *Ticker) Stop() {
+	close(t.stop)
+	<-t.done
+}


### PR DESCRIPTION
## Summary

- **`ludus doctor` command** — 8 diagnostic checks (toolchain consistency, stale artifacts, build state, cache, disk space, AWS creds, Docker daemon, git status) with platform-specific disk checks via build-tagged files
- **Guided error messages** — New `internal/diagnose` package with table-driven error pattern matching (12 AWS hints, 6 deploy hints, 6 container hints). Wired into all deploy and container commands to provide actionable fix suggestions on failure
- **Progress indicators** — New `internal/progress` package with elapsed-time ticker. Prints periodic status messages every 2 minutes during engine compile, server build, and client build operations
- **Roadmap updates** — Added npm/MCP distribution and Dockerfile security scanning items

## Test plan

- [x] `go build -o /dev/null .` — Windows build passes
- [x] `GOOS=linux go build -o /dev/null .` — Linux cross-compile passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all tests pass
- [x] Pre-commit hooks pass (build + lint + test)
- [ ] CI: Build (ubuntu + windows)
- [ ] CI: Lint (ubuntu + windows)
- [ ] CI: Test (ubuntu + windows)