### PR TITLE
Add ludus setup wizard and state profiles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,8 +40,9 @@ Each subcommand lives in its own package under `cmd/` and exports a `Cmd *cobra.
 
 Command hierarchy:
 ```
+ludus setup                         # interactive wizard — scans for engines, detects version, writes ludus.yaml
 ludus init                          --fix (auto-remediate on Windows)
-ludus config [set|get]             set/get config values in ludus.yaml via dot-notation
+ludus config [set|get]             set/get config values in ludus.yaml via dot-notation (profile-aware)
 ludus engine [build|setup|push]    --jobs/-j (0=auto), --backend (native|docker), --no-cache, --base-image
 ludus game [build|client]          --skip-cook, --platform (Linux|Win64), --backend (native|docker), --no-cache, --config (Development|Shipping)
 ludus container [build|push]       --tag/-t, --no-cache
@@ -58,9 +59,9 @@ ludus ci runner [install|status|uninstall]  # self-hosted runner management
   --dir, --labels, --name, --repo, --service, --delete
 ```
 
-Global persistent flags (`cmd/root/root.go`): `--config`, `--verbose/-v`, `--json`, `--dry-run`.
+Global persistent flags (`cmd/root/root.go`): `--config`, `--verbose/-v`, `--json`, `--dry-run`, `--profile`.
 
-Global mutable state lives in `cmd/globals/globals.go`: `Cfg`, `Verbose`, `JSONOutput`, `DryRun`.
+Global mutable state lives in `cmd/globals/globals.go`: `Cfg`, `Verbose`, `JSONOutput`, `DryRun`, `Profile`.
 
 ### MCP server (`cmd/mcp/`)
 
@@ -119,7 +120,7 @@ All business logic is in `internal/` (unexported to consumers):
 - **`anywhere`** — `Deployer` and `TargetAdapter` implement `deploy.Target` + `deploy.SessionManager` for GameLift Anywhere. `Deploy()` creates a custom location, Anywhere fleet, registers the local machine as a compute, builds the Game Server Wrapper, and launches the server locally. `CreateSession()` creates game sessions with the required `Location` parameter. `Destroy()` stops the server, deregisters compute, deletes fleet and location. State tracked in `AnywhereState` (PID, compute name, fleet/location ARNs). `DetectLocalIP()` auto-detects the machine's non-loopback IPv4.
 - **`ec2fleet`** — `Deployer` and `TargetAdapter` implement `deploy.Target` + `deploy.SessionManager` for GameLift Managed EC2. `Deploy()` zips the server build with the Game Server Wrapper, uploads to S3, creates a GameLift Build, then creates an EC2 fleet with runtime configuration. No Docker required. `Destroy()` deletes fleet, build, S3 object, and IAM role. State tracked in `EC2FleetState` (FleetID, BuildID, S3Bucket, S3Key). Uses STS for auto-deriving S3 bucket name (`ludus-builds-<account-id>`).
 - **`wrapper`** — Shared package for the Amazon GameLift Game Server Wrapper binary. `EnsureBinary()` clones the wrapper repo, builds it, and caches at `~/.cache/ludus/game-server-wrapper/`. Used by `container` (for Docker builds), `anywhere` (for local server launch), and `ec2fleet` (included in build zip).
-- **`state`** — Persistent state in `.ludus/state.json`. Tracks fleet (ID, stack name, status), session (ID, IP, port), client build (binary path, platform, output dir), deploy (target name, status, detail), engine image (image tag, version, built-at), and EC2 fleet (fleet ID, build ID, S3 bucket/key). Read-modify-write via `Load()`/`Save()` with typed update helpers (`UpdateFleet`, `UpdateSession`, `UpdateClient`, `UpdateDeploy`, `UpdateEngineImage`, `UpdateEC2Fleet`, `ClearSession`, `ClearFleet`, `ClearEC2Fleet`).
+- **`state`** — Persistent state with profile support. Default profile: `.ludus/state.json`. Named profiles: `.ludus/profiles/<name>.json`. `SetProfile(name)` activates a profile (called from root command's `PersistentPreRunE`). `Load()`/`Save()` automatically use the active profile. Tracks fleet, session, client build, deploy, engine image, anywhere, and EC2 fleet state. Read-modify-write via typed update helpers (`UpdateFleet`, `UpdateSession`, `UpdateClient`, `UpdateDeploy`, `UpdateEngineImage`, `UpdateEC2Fleet`, `ClearSession`, `ClearFleet`, `ClearEC2Fleet`). `ListProfiles()` returns all named profiles. `DeleteProfile(name)` removes a profile's state file.
 - **`status`** — Extracted from `cmd/status/status.go`. `StageStatus` type and check functions (`CheckEngineSource`, `CheckEngineBuild`, `CheckServerBuild`, `CheckContainerImage`, `CheckClientBuild`, `CheckDeployTarget`, `CheckGameSession`). `CheckAll(ctx, cfg, target)` runs all checks and returns `[]StageStatus`. Used by both `cmd/status` (CLI display) and `cmd/mcp` (MCP tool).
 
 ### Platform-specific code
@@ -140,7 +141,8 @@ Build-tagged files use `//go:build` tags for platform-specific implementations:
 - **Config override**: Deploy subcommands accept `--target`, `--region`, `--instance-type`, `--fleet-name`, `--stack-name`, `--ip`, `--with-session` flags that override `ludus.yaml` values.
 - **Auto-detect engine version**: `PersistentPreRunE` in `root.go` auto-populates `cfg.Engine.Version` from `Engine/Build/Build.version` when the source path is set but version is empty, so users don't need to set `engine.version` in `ludus.yaml`.
 - **What's-next guidance**: Every command prints a `Next:` hint after success output, guiding users to the next pipeline step. Deploy hints are gated on `!withSession` (session already created). Game build hints are target-aware (container build for gamelift/stack, deploy for ec2/anywhere/binary).
-- **State persistence**: Deploy and client-build commands write to `.ludus/state.json` so downstream commands (`connect`, `status`) can resolve fleet/session/client info without re-querying AWS.
+- **State persistence**: Deploy and client-build commands write to `.ludus/state.json` (or `.ludus/profiles/<profile>.json`) so downstream commands (`connect`, `status`) can resolve fleet/session/client info without re-querying AWS.
+- **Profiles**: `--profile <name>` isolates both config and state per workflow. Config loading tries `ludus-<profile>.yaml` first, falls back to `ludus.yaml`. State uses `.ludus/profiles/<name>.json`. `ludus --profile ue57-ec2 setup` creates a profile-specific config; all subsequent commands with `--profile ue57-ec2` use it. Default (no profile) preserves existing behavior.
 - **Config-driven targets**: Game project name, server target, client target, and game target are all configurable via `ludus.yaml`. Defaults derive from `ProjectName` (e.g., `ProjectName+"Server"` for `ServerTarget`). Lyra-specific behavior (auto-detection of project path, content validation with plugin dirs) is preserved as a fallback when `ProjectName == "Lyra"`.
 - **Cost estimates and instance guidance**: Deploy commands (`fleet`, `stack`, `ec2`) and the pipeline print estimated hourly/monthly cost and Graviton savings tips before fleet creation. MCP deploy results include `estimated_cost_per_hour` and `instance_guidance` fields. The deploy help text includes a quick-reference instance type comparison. Unknown instance types are silently skipped.
 - **Guided error messages**: Deploy and container commands wrap errors through `diagnose.DeployError()` / `diagnose.ContainerError()` which pattern-match error strings against known failure modes and append actionable fix suggestions. Game build errors go through `diagnoseBuildError()` in `internal/game/builder.go` which scans RunUAT logs for known patterns. Both use the same table-driven approach.
@@ -278,11 +280,11 @@ Requires `NPM_TOKEN` secret in the GitHub repo for npm publish. `GITHUB_TOKEN` i
 See [ROADMAP.md](ROADMAP.md) for the full prioritized roadmap. Key categories:
 
 - **Stabilization** — ~~UE 5.4 C4756 patch~~, ~~OOM detection~~, ~~UAC failure detection~~, ~~build failure diagnostics~~ (all done in PR #35)
-- **Onboarding** — `ludus setup` wizard, ~~auto-detect engine version~~, ~~AWS credential validation~~ (PR #38), ~~"what's next" guidance~~ (PR #37), ~~Lyra auto-discovery~~ (PR #41), ~~server map validation~~ (PR #38)
+- **Onboarding** — ~~`ludus setup` wizard~~, ~~auto-detect engine version~~, ~~AWS credential validation~~ (PR #38), ~~"what's next" guidance~~ (PR #37), ~~Lyra auto-discovery~~ (PR #41), ~~server map validation~~ (PR #38)
 - **Build UX** — ~~Progress indicators~~ (PR #42), resume/incremental builds, ~~build config guidance~~ (PR #39)
 - **Deploy UX** — ~~Cost estimates~~ (PR #38), ~~auto-session (`--with-session`)~~ (PR #37), ~~batch destroy~~ (PR #39), ~~instance type guidance~~ (PR #41)
 - **Diagnostics** — ~~`ludus doctor` command~~ (PR #42), ~~guided error messages~~ (PR #42)
-- **Multi-version** — ~~`ludus config set`~~ (PR #39), state profiles
+- **Multi-version** — ~~`ludus config set`~~ (PR #39), ~~state profiles~~
 - **Code quality** — ~~`dupl` linter + refactor duplicated code~~ (PR #40)
 - **Security** — Dockerfile security scanning (Hadolint, Trivy/Grype)
 - **Features** — ~~ARM/Graviton support~~ (PR #36), npm package for MCP distribution, BuildGraph XML generation, studio infrastructure provisioning

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -15,7 +15,7 @@ Bugs and rough edges discovered during cross-version E2E testing (UE 5.4–5.7 o
 
 Reducing friction for new users going from zero to a running game session.
 
-- [ ] **`ludus setup` interactive wizard** — Guided first-run experience that: scans for engine source directories (e.g. `F:\Source Code\UnrealEngine-*`), auto-reads `Build.version` for the engine version, finds Lyra Launcher downloads in common paths (`Documents\Unreal Projects\LyraStarterGame*`), validates AWS credentials, and writes a complete `ludus.yaml`. Eliminates the need to manually create config.
+- [x] **`ludus setup` interactive wizard** — Guided first-run setup that: scans for engine source directories (common paths + drive roots on Windows), auto-reads `Build.version` for the engine version, discovers Lyra Launcher downloads, auto-detects AWS account ID via `sts get-caller-identity`, prompts for deploy target and instance type, and writes a complete `ludus.yaml`. Profile-aware: `ludus --profile ue57 setup` writes `ludus-ue57.yaml`.
 - [x] **Auto-detect engine version** — Drop the `engine.version` config requirement. `toolchain.ParseBuildVersion()` already reads `Engine/Build/Build.version` JSON from every engine source tree. If version is empty in config, read it automatically.
 - [x] **AWS credential validation** — `ludus init` checks `aws sts get-caller-identity` and warns if credentials aren't configured or expired. Warning-only so engine/game builds aren't blocked.
 - [x] **"What's next" guidance** — After each command succeeds, print the next step in the pipeline. After `init`: "Run `ludus engine build`". After engine build: "Run `ludus game build`". After deploy: "Run `ludus deploy session`". Etc.
@@ -51,7 +51,7 @@ Better observability and self-service troubleshooting.
 Better support for testing across multiple UE versions.
 
 - [x] **`ludus config set` command** — `ludus config set key value` and `ludus config get key` for quick config updates from the CLI. Reads/writes `ludus.yaml` via Viper with type-aware value parsing. Creates the file if missing.
-- [ ] **State profiles** — Current single `state.json` is fragile for multi-version workflows. Support named state profiles or version-tagged state files natively, so switching between UE versions doesn't require manual state backup/restore.
+- [x] **State profiles** — `--profile <name>` flag on all commands. Default profile uses `.ludus/state.json` (backward compatible); named profiles use `.ludus/profiles/<name>.json`. Config is also profile-aware: `ludus --profile ue57 config set` writes to `ludus-ue57.yaml`. `ludus --profile ue57 run` loads `ludus-ue57.yaml` if it exists, with state isolated per profile. `state.ListProfiles()` and `state.DeleteProfile()` for profile management.
 
 ## Code Quality
 

--- a/cmd/configcmd/configcmd.go
+++ b/cmd/configcmd/configcmd.go
@@ -6,6 +6,7 @@ import (
 	"strconv"
 	"strings"
 
+	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -54,19 +55,29 @@ func init() {
 	Cmd.AddCommand(getCmd)
 }
 
+// resolveConfigFile returns the config file path for the active profile.
+// Default profile uses "ludus.yaml"; named profiles use "ludus-<profile>.yaml".
+func resolveConfigFile() string {
+	if globals.Profile != "" {
+		return "ludus-" + globals.Profile + ".yaml"
+	}
+	return "ludus.yaml"
+}
+
 func runSet(cmd *cobra.Command, args []string) error {
 	key := args[0]
 	value := args[1]
+	cfgFile := resolveConfigFile()
 
 	v := viper.New()
 	v.SetConfigType("yaml")
-	v.SetConfigFile("ludus.yaml")
+	v.SetConfigFile(cfgFile)
 
 	// Read existing config if it exists
 	if err := v.ReadInConfig(); err != nil {
 		if !os.IsNotExist(err) {
 			if _, ok := err.(viper.ConfigFileNotFoundError); !ok {
-				return fmt.Errorf("reading ludus.yaml: %w", err)
+				return fmt.Errorf("reading %s: %w", cfgFile, err)
 			}
 		}
 	}
@@ -74,8 +85,8 @@ func runSet(cmd *cobra.Command, args []string) error {
 	// Convert numeric and boolean strings to their typed values
 	v.Set(key, parseValue(value))
 
-	if err := v.WriteConfigAs("ludus.yaml"); err != nil {
-		return fmt.Errorf("writing ludus.yaml: %w", err)
+	if err := v.WriteConfigAs(cfgFile); err != nil {
+		return fmt.Errorf("writing %s: %w", cfgFile, err)
 	}
 
 	fmt.Printf("Set %s = %s\n", key, value)
@@ -84,23 +95,24 @@ func runSet(cmd *cobra.Command, args []string) error {
 
 func runGet(cmd *cobra.Command, args []string) error {
 	key := args[0]
+	cfgFile := resolveConfigFile()
 
 	v := viper.New()
 	v.SetConfigType("yaml")
-	v.SetConfigFile("ludus.yaml")
+	v.SetConfigFile(cfgFile)
 
 	if err := v.ReadInConfig(); err != nil {
 		if os.IsNotExist(err) {
-			return fmt.Errorf("ludus.yaml not found; run 'ludus config set' to create one")
+			return fmt.Errorf("%s not found; run 'ludus config set' or 'ludus setup' to create one", cfgFile)
 		}
 		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			return fmt.Errorf("ludus.yaml not found; run 'ludus config set' to create one")
+			return fmt.Errorf("%s not found; run 'ludus config set' or 'ludus setup' to create one", cfgFile)
 		}
-		return fmt.Errorf("reading ludus.yaml: %w", err)
+		return fmt.Errorf("reading %s: %w", cfgFile, err)
 	}
 
 	if !v.IsSet(key) {
-		return fmt.Errorf("key %q not found in ludus.yaml", key)
+		return fmt.Errorf("key %q not found in %s", key, cfgFile)
 	}
 
 	val := v.Get(key)

--- a/cmd/globals/globals.go
+++ b/cmd/globals/globals.go
@@ -13,3 +13,7 @@ var JSONOutput bool
 
 // DryRun indicates whether dry-run mode is enabled.
 var DryRun bool
+
+// Profile is the state profile name for multi-version workflows.
+// Default is "" (uses .ludus/state.json). Non-empty uses .ludus/profiles/<name>.json.
+var Profile string

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -15,8 +15,10 @@ import (
 	"github.com/devrecon/ludus/cmd/globals"
 	ludusmcp "github.com/devrecon/ludus/cmd/mcp"
 	"github.com/devrecon/ludus/cmd/pipeline"
+	"github.com/devrecon/ludus/cmd/setup"
 	"github.com/devrecon/ludus/cmd/status"
 	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/state"
 	"github.com/devrecon/ludus/internal/toolchain"
 	"github.com/devrecon/ludus/internal/version"
 	"github.com/spf13/cobra"
@@ -33,6 +35,7 @@ var rootCmd = &cobra.Command{
 compiling a UE5 game project as a Linux dedicated server, containerizing it,
 and deploying it to AWS GameLift Containers.
 
+  ludus setup       Interactive setup wizard (first-time configuration)
   ludus init        Validate prerequisites and configure the environment
   ludus doctor      Run comprehensive diagnostics
   ludus config      View and modify ludus.yaml configuration
@@ -43,9 +46,28 @@ and deploying it to AWS GameLift Containers.
   ludus connect     Launch the game client and connect to a game session
   ludus status      Check status of all pipeline stages
   ludus run         Run the full pipeline end-to-end
-  ludus ci          Generate CI workflows and manage runners`,
+  ludus ci          Generate CI workflows and manage runners
+
+Use --profile to manage multiple configurations (e.g., different UE versions):
+  ludus --profile ue57-ec2 setup
+  ludus --profile ue57-ec2 run`,
 	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
-		cfg, err := config.Load(cfgFile)
+		// Activate state profile before any state I/O
+		state.SetProfile(globals.Profile)
+
+		// Try profile-specific config first: ludus-<profile>.yaml
+		cfgPath := cfgFile
+		if cfgPath == "" && globals.Profile != "" {
+			profileCfg := "ludus-" + globals.Profile + ".yaml"
+			if _, err := os.Stat(profileCfg); err == nil {
+				cfgPath = profileCfg
+				if globals.Verbose {
+					fmt.Fprintf(os.Stderr, "Using profile config: %s\n", profileCfg)
+				}
+			}
+		}
+
+		cfg, err := config.Load(cfgPath)
 		if err != nil {
 			return err
 		}
@@ -74,8 +96,10 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&globals.Verbose, "verbose", "v", false, "verbose output")
 	rootCmd.PersistentFlags().BoolVar(&globals.JSONOutput, "json", false, "output in JSON format")
 	rootCmd.PersistentFlags().BoolVar(&globals.DryRun, "dry-run", false, "print commands without executing")
+	rootCmd.PersistentFlags().StringVar(&globals.Profile, "profile", "", "state profile for multi-version workflows (e.g., ue57-ec2)")
 
 	rootCmd.AddCommand(initCmd)
+	rootCmd.AddCommand(setup.Cmd)
 	rootCmd.AddCommand(configcmd.Cmd)
 	rootCmd.AddCommand(doctor.Cmd)
 	rootCmd.AddCommand(engine.Cmd)

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -1,0 +1,475 @@
+package setup
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"github.com/devrecon/ludus/cmd/globals"
+	"github.com/devrecon/ludus/internal/toolchain"
+	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
+)
+
+// Cmd is the setup wizard command.
+var Cmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Interactive setup wizard for first-time configuration",
+	Long: `Guided setup that scans your system, auto-detects settings, and writes
+a complete ludus.yaml configuration file.
+
+Steps:
+  1. Locate Unreal Engine source directory
+  2. Auto-detect engine version from Build.version
+  3. Configure game project (Lyra or custom)
+  4. Choose deployment target
+  5. Configure AWS settings (optional)
+  6. Write ludus.yaml
+
+Use --profile to create a profile-specific config (ludus-<profile>.yaml).`,
+	RunE: runSetup,
+}
+
+var scanner *bufio.Scanner
+
+func init() {
+	scanner = bufio.NewScanner(os.Stdin)
+}
+
+// prompt displays a question with an optional default and reads user input.
+func prompt(question, defaultVal string) string {
+	if defaultVal != "" {
+		fmt.Printf("%s [%s]: ", question, defaultVal)
+	} else {
+		fmt.Printf("%s: ", question)
+	}
+	scanner.Scan()
+	answer := strings.TrimSpace(scanner.Text())
+	if answer == "" {
+		return defaultVal
+	}
+	return answer
+}
+
+// promptChoice displays a question with numbered choices and returns the selected value.
+func promptChoice(question string, choices []string, defaultIdx int) string {
+	fmt.Println(question)
+	for i, c := range choices {
+		marker := "  "
+		if i == defaultIdx {
+			marker = "* "
+		}
+		fmt.Printf("  %s%d) %s\n", marker, i+1, c)
+	}
+	fmt.Printf("Choice [%d]: ", defaultIdx+1)
+	scanner.Scan()
+	answer := strings.TrimSpace(scanner.Text())
+	if answer == "" {
+		return choices[defaultIdx]
+	}
+	// Parse number
+	for i, c := range choices {
+		if answer == fmt.Sprintf("%d", i+1) || strings.EqualFold(answer, c) {
+			return c
+		}
+	}
+	return choices[defaultIdx]
+}
+
+// confirm asks a yes/no question.
+func confirm(question string) bool {
+	fmt.Printf("%s [Y/n]: ", question)
+	scanner.Scan()
+	answer := strings.ToLower(strings.TrimSpace(scanner.Text()))
+	return answer == "" || answer == "y" || answer == "yes"
+}
+
+func runSetup(cmd *cobra.Command, args []string) error {
+	fmt.Println("Ludus Setup Wizard")
+	fmt.Println("==================")
+	fmt.Println()
+
+	// Determine output config file name
+	cfgFile := "ludus.yaml"
+	if globals.Profile != "" {
+		cfgFile = "ludus-" + globals.Profile + ".yaml"
+	}
+
+	// Check if config already exists
+	if _, err := os.Stat(cfgFile); err == nil {
+		if !confirm(fmt.Sprintf("%s already exists. Overwrite?", cfgFile)) {
+			fmt.Println("Setup cancelled.")
+			return nil
+		}
+	}
+
+	// Step 1: Engine source path
+	fmt.Println("Step 1: Unreal Engine Source")
+	fmt.Println("----------------------------")
+	enginePath := promptEnginePath()
+	if enginePath == "" {
+		fmt.Println("\nNo engine source path provided. You can set it later:")
+		fmt.Printf("  ludus config set engine.sourcePath /path/to/UnrealEngine\n\n")
+	}
+
+	// Step 2: Auto-detect engine version
+	var engineVersion string
+	if enginePath != "" {
+		if bv, err := toolchain.ParseBuildVersion(enginePath); err == nil {
+			engineVersion = fmt.Sprintf("%d.%d.%d", bv.MajorVersion, bv.MinorVersion, bv.PatchVersion)
+			fmt.Printf("\nDetected engine version: %s\n", engineVersion)
+		} else {
+			fmt.Println("\nCould not auto-detect engine version from Build.version.")
+			engineVersion = prompt("Engine version (e.g., 5.7.3)", "")
+		}
+	}
+
+	// Step 3: Game project
+	fmt.Println()
+	fmt.Println("Step 2: Game Project")
+	fmt.Println("--------------------")
+	projectName, projectPath, contentSourcePath := promptGameProject(enginePath)
+
+	// Step 4: Deploy target
+	fmt.Println()
+	fmt.Println("Step 3: Deployment Target")
+	fmt.Println("-------------------------")
+	targets := []string{"gamelift", "stack", "ec2", "anywhere", "binary"}
+	deployTarget := promptChoice("Select deployment target:", targets, 0)
+
+	// Step 5: AWS settings
+	fmt.Println()
+	fmt.Println("Step 4: AWS Configuration")
+	fmt.Println("-------------------------")
+	region, accountID := promptAWS()
+
+	// Step 6: Instance type
+	instanceType := "c6i.large"
+	if deployTarget != "binary" && deployTarget != "anywhere" {
+		fmt.Println()
+		instanceType = prompt("GameLift instance type", "c6i.large")
+	}
+
+	// Summary
+	fmt.Println()
+	fmt.Println("Configuration Summary")
+	fmt.Println("=====================")
+	if enginePath != "" {
+		fmt.Printf("  Engine source:  %s\n", enginePath)
+	}
+	if engineVersion != "" {
+		fmt.Printf("  Engine version: %s\n", engineVersion)
+	}
+	fmt.Printf("  Project:        %s\n", projectName)
+	if projectPath != "" {
+		fmt.Printf("  Project path:   %s\n", projectPath)
+	}
+	if contentSourcePath != "" {
+		fmt.Printf("  Content source: %s\n", contentSourcePath)
+	}
+	fmt.Printf("  Deploy target:  %s\n", deployTarget)
+	if region != "" {
+		fmt.Printf("  AWS region:     %s\n", region)
+	}
+	if accountID != "" {
+		fmt.Printf("  AWS account:    %s\n", accountID)
+	}
+	if deployTarget != "binary" && deployTarget != "anywhere" {
+		fmt.Printf("  Instance type:  %s\n", instanceType)
+	}
+	fmt.Printf("  Config file:    %s\n", cfgFile)
+	fmt.Println()
+
+	if !confirm("Write configuration?") {
+		fmt.Println("Setup cancelled.")
+		return nil
+	}
+
+	// Write config using Viper (same pattern as configcmd)
+	v := viper.New()
+	v.SetConfigType("yaml")
+	v.SetConfigFile(cfgFile)
+
+	if enginePath != "" {
+		v.Set("engine.sourcePath", enginePath)
+	}
+	if engineVersion != "" {
+		v.Set("engine.version", engineVersion)
+	}
+
+	v.Set("game.projectName", projectName)
+	if projectPath != "" {
+		v.Set("game.projectPath", projectPath)
+	}
+	if contentSourcePath != "" {
+		v.Set("game.contentSourcePath", contentSourcePath)
+	}
+	v.Set("game.serverMap", "L_Expanse")
+
+	v.Set("deploy.target", deployTarget)
+
+	if region != "" {
+		v.Set("aws.region", region)
+	} else {
+		v.Set("aws.region", "us-east-1")
+	}
+	if accountID != "" {
+		v.Set("aws.accountId", accountID)
+	}
+	v.Set("aws.ecrRepository", "ludus-server")
+
+	v.Set("gamelift.fleetName", "ludus-fleet")
+	v.Set("gamelift.instanceType", instanceType)
+	v.Set("gamelift.containerGroupName", "ludus-container-group")
+
+	v.Set("container.imageName", "ludus-server")
+	v.Set("container.tag", "latest")
+	v.Set("container.serverPort", 7777)
+
+	if err := v.WriteConfigAs(cfgFile); err != nil {
+		return fmt.Errorf("writing %s: %w", cfgFile, err)
+	}
+
+	fmt.Printf("\nConfiguration written to %s\n", cfgFile)
+	fmt.Println("\nNext: ludus init")
+	return nil
+}
+
+// promptEnginePath scans for engine directories and lets the user pick or type a path.
+func promptEnginePath() string {
+	candidates := scanEnginePaths()
+
+	if len(candidates) > 0 {
+		fmt.Println("Found engine source directories:")
+		for i, c := range candidates {
+			version := ""
+			if bv, err := toolchain.ParseBuildVersion(c); err == nil {
+				version = fmt.Sprintf(" (v%d.%d.%d)", bv.MajorVersion, bv.MinorVersion, bv.PatchVersion)
+			}
+			fmt.Printf("  %d) %s%s\n", i+1, c, version)
+		}
+		fmt.Printf("  %d) Enter a different path\n", len(candidates)+1)
+		fmt.Printf("  %d) Skip (configure later)\n", len(candidates)+2)
+		fmt.Printf("Choice [1]: ")
+		scanner.Scan()
+		answer := strings.TrimSpace(scanner.Text())
+		if answer == "" {
+			answer = "1"
+		}
+		for i, c := range candidates {
+			if answer == fmt.Sprintf("%d", i+1) {
+				return c
+			}
+		}
+		if answer == fmt.Sprintf("%d", len(candidates)+1) {
+			return prompt("Engine source path", "")
+		}
+		// Skip
+		return ""
+	}
+
+	return prompt("Engine source path (or press Enter to skip)", "")
+}
+
+// scanEnginePaths looks for Unreal Engine source directories in common locations.
+func scanEnginePaths() []string {
+	var candidates []string
+	seen := make(map[string]bool)
+
+	addIfEngine := func(path string) {
+		abs, err := filepath.Abs(path)
+		if err != nil {
+			return
+		}
+		if seen[abs] {
+			return
+		}
+		// Check for Setup.bat (Windows) or Setup.sh (Linux) as engine marker
+		var marker string
+		if runtime.GOOS == "windows" {
+			marker = filepath.Join(abs, "Setup.bat")
+		} else {
+			marker = filepath.Join(abs, "Setup.sh")
+		}
+		if _, err := os.Stat(marker); err == nil {
+			candidates = append(candidates, abs)
+			seen[abs] = true
+		}
+	}
+
+	// Check additional working directories from the environment (if passed in)
+	// Scan parent directories of CWD for UnrealEngine-* patterns
+	cwd, _ := os.Getwd()
+	if cwd != "" {
+		parent := filepath.Dir(cwd)
+		scanGlob(parent, "UnrealEngine*", addIfEngine)
+	}
+
+	// Common locations
+	home, _ := os.UserHomeDir()
+	if home != "" {
+		scanGlob(filepath.Join(home, "Documents", "Source"), "UnrealEngine*", addIfEngine)
+		scanGlob(filepath.Join(home, "Source"), "UnrealEngine*", addIfEngine)
+	}
+
+	if runtime.GOOS == "windows" {
+		// Scan drive roots
+		for _, drive := range []string{"C:", "D:", "E:", "F:"} {
+			scanGlob(filepath.Join(drive, string(os.PathSeparator), "Source Code"), "UnrealEngine*", addIfEngine)
+			scanGlob(filepath.Join(drive, string(os.PathSeparator), "Source"), "UnrealEngine*", addIfEngine)
+			scanGlob(filepath.Join(drive, string(os.PathSeparator)), "UnrealEngine*", addIfEngine)
+		}
+	} else {
+		scanGlob("/opt", "UnrealEngine*", addIfEngine)
+		scanGlob("/usr/local/src", "UnrealEngine*", addIfEngine)
+	}
+
+	return candidates
+}
+
+// scanGlob searches for directories matching pattern inside dir and calls fn for each.
+func scanGlob(dir, pattern string, fn func(string)) {
+	matches, err := filepath.Glob(filepath.Join(dir, pattern))
+	if err != nil {
+		return
+	}
+	for _, m := range matches {
+		info, err := os.Stat(m)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		fn(m)
+	}
+}
+
+// promptGameProject asks about the game project configuration.
+func promptGameProject(enginePath string) (projectName, projectPath, contentSourcePath string) {
+	projectName = prompt("Project name", "Lyra")
+
+	if projectName == "Lyra" && enginePath != "" {
+		// Check if Lyra content is already in place
+		lyraDir := filepath.Join(enginePath, "Samples", "Games", "Lyra")
+		uproject := filepath.Join(lyraDir, "Lyra.uproject")
+		if _, err := os.Stat(uproject); err == nil {
+			fmt.Printf("  Found Lyra at %s\n", lyraDir)
+		}
+
+		// Try to discover downloaded Lyra content
+		contentSourcePath = discoverLyraContent()
+		if contentSourcePath != "" {
+			fmt.Printf("  Found Lyra content download at %s\n", contentSourcePath)
+			if !confirm("  Use this as content source?") {
+				contentSourcePath = ""
+			}
+		}
+		if contentSourcePath == "" {
+			contentSourcePath = prompt("  Lyra content source path (or press Enter to skip)", "")
+		}
+	} else {
+		// Custom project
+		projectPath = prompt("Path to .uproject file", "")
+		if projectPath != "" {
+			// Validate
+			if _, err := os.Stat(projectPath); os.IsNotExist(err) {
+				fmt.Printf("  Warning: %s not found\n", projectPath)
+			}
+		}
+	}
+
+	return projectName, projectPath, contentSourcePath
+}
+
+// discoverLyraContent scans common paths for downloaded Lyra content.
+// Mirrors the logic in internal/prereq/checker.go.
+func discoverLyraContent() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+
+	var candidates []string
+	candidates = append(candidates,
+		filepath.Join(home, "Documents", "Unreal Projects", "LyraStarterGame"),
+		filepath.Join(home, "Documents", "Unreal Projects", "Lyra Starter Game"),
+	)
+
+	if runtime.GOOS == "windows" {
+		if oneDrive := os.Getenv("OneDrive"); oneDrive != "" {
+			candidates = append(candidates,
+				filepath.Join(oneDrive, "Documents", "Unreal Projects", "LyraStarterGame"),
+				filepath.Join(oneDrive, "Documents", "Unreal Projects", "Lyra Starter Game"),
+			)
+		}
+	}
+
+	for _, c := range candidates {
+		if isLyraProject(c) {
+			return c
+		}
+	}
+
+	// Try versioned directories
+	docsDir := filepath.Join(home, "Documents", "Unreal Projects")
+	matches, _ := filepath.Glob(filepath.Join(docsDir, "LyraStarterGame*"))
+	for _, m := range matches {
+		if isLyraProject(m) {
+			return m
+		}
+	}
+
+	return ""
+}
+
+// isLyraProject checks if a directory looks like a Lyra project download.
+func isLyraProject(path string) bool {
+	if _, err := os.Stat(filepath.Join(path, "Lyra.uproject")); err == nil {
+		return true
+	}
+	if _, err := os.Stat(filepath.Join(path, "Content", "DefaultGameData.uasset")); err == nil {
+		return true
+	}
+	return false
+}
+
+// promptAWS asks about AWS configuration.
+func promptAWS() (region, accountID string) {
+	region = prompt("AWS region", "us-east-1")
+
+	// Try to auto-detect account ID
+	accountID = detectAWSAccountID()
+	if accountID != "" {
+		fmt.Printf("  Detected AWS account: %s\n", accountID)
+		if !confirm("  Use this account?") {
+			accountID = prompt("  AWS account ID", "")
+		}
+	} else {
+		fmt.Println("  Could not detect AWS account (AWS CLI not configured or not installed).")
+		accountID = prompt("  AWS account ID (or press Enter to skip)", "")
+	}
+
+	return region, accountID
+}
+
+// detectAWSAccountID runs aws sts get-caller-identity to detect the account.
+func detectAWSAccountID() string {
+	if _, err := exec.LookPath("aws"); err != nil {
+		return ""
+	}
+	cmd := exec.Command("aws", "sts", "get-caller-identity", "--output", "json")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	var identity struct {
+		Account string `json:"Account"`
+	}
+	if json.Unmarshal(out, &identity) != nil {
+		return ""
+	}
+	return identity.Account
+}

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -2,8 +2,11 @@ package state
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 )
 
 const stateDir = ".ludus"
@@ -83,11 +86,32 @@ type AnywhereState struct {
 	StartedAt    string `json:"startedAt"`
 }
 
-func statePath() string {
-	return filepath.Join(stateDir, stateFile)
+// activeProfile holds the current profile name. Empty string means the default
+// profile (.ludus/state.json). Set via SetProfile().
+var activeProfile string
+
+// SetProfile sets the active state profile. Empty string means the default profile.
+func SetProfile(name string) {
+	activeProfile = name
 }
 
-// Load reads .ludus/state.json, returning an empty State if the file is missing.
+// ActiveProfile returns the current profile name ("" for default).
+func ActiveProfile() string {
+	return activeProfile
+}
+
+func statePath() string {
+	return statePathForProfile(activeProfile)
+}
+
+func statePathForProfile(profile string) string {
+	if profile == "" {
+		return filepath.Join(stateDir, stateFile)
+	}
+	return filepath.Join(stateDir, "profiles", profile+".json")
+}
+
+// Load reads the state file for the active profile, returning an empty State if missing.
 func Load() (*State, error) {
 	data, err := os.ReadFile(statePath())
 	if err != nil {
@@ -104,9 +128,10 @@ func Load() (*State, error) {
 	return s, nil
 }
 
-// Save writes state to .ludus/state.json with indentation, creating the directory if needed.
+// Save writes state to the active profile's file with indentation, creating directories as needed.
 func Save(s *State) error {
-	if err := os.MkdirAll(stateDir, 0755); err != nil {
+	p := statePath()
+	if err := os.MkdirAll(filepath.Dir(p), 0755); err != nil {
 		return err
 	}
 
@@ -115,7 +140,45 @@ func Save(s *State) error {
 		return err
 	}
 
-	return os.WriteFile(statePath(), data, 0644)
+	return os.WriteFile(p, data, 0644)
+}
+
+// ListProfiles returns the names of all state profiles (excluding the default).
+func ListProfiles() ([]string, error) {
+	dir := filepath.Join(stateDir, "profiles")
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	var profiles []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		if strings.HasSuffix(name, ".json") {
+			profiles = append(profiles, strings.TrimSuffix(name, ".json"))
+		}
+	}
+	sort.Strings(profiles)
+	return profiles, nil
+}
+
+// DeleteProfile removes a named profile's state file. Returns an error if the
+// profile doesn't exist.
+func DeleteProfile(name string) error {
+	if name == "" {
+		return fmt.Errorf("cannot delete the default profile")
+	}
+	p := statePathForProfile(name)
+	if _, err := os.Stat(p); os.IsNotExist(err) {
+		return fmt.Errorf("profile %q does not exist", name)
+	}
+	return os.Remove(p)
 }
 
 // UpdateFleet loads state, updates the fleet block, and saves.


### PR DESCRIPTION
## Summary

- **`ludus setup` interactive wizard** — Guided first-run that scans for engine source directories (sibling dirs, common paths, drive roots on Windows), auto-detects engine version from `Build.version`, discovers Lyra content downloads (Documents, OneDrive variants), auto-detects AWS account ID via `sts get-caller-identity`, prompts for deploy target and instance type, writes a complete `ludus.yaml`
- **State profiles** (`--profile <name>`) — Isolates both config and state per workflow. Config tries `ludus-<profile>.yaml` first, falls back to `ludus.yaml`. State uses `.ludus/profiles/<name>.json`. Profile management: `ListProfiles()`, `DeleteProfile()`. Backward compatible: default (no profile) uses existing paths
- **Profile-aware config commands** — `ludus --profile ue57 config set/get` reads/writes `ludus-ue57.yaml`

## Test plan

- [x] `go build -o /dev/null .` — Windows build passes
- [x] `GOOS=linux go build -o /dev/null .` — Linux cross-compile passes
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all tests pass
- [x] Pre-commit hooks pass (build + lint + test)
- [ ] CI: Build (ubuntu + windows)
- [ ] CI: Lint (ubuntu + windows)
- [ ] CI: Test (ubuntu + windows)