### PR TITLE
Fix arch mismatch bugs in container build and fleet deploy

### DIFF
--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -83,6 +83,11 @@ func resolveServerBuildDir() string {
 func runBuild(cmd *cobra.Command, args []string) error {
 	cfg := globals.Cfg
 
+	// Apply arch flag to config so resolveServerBuildDir sees it
+	if archFlag != "" {
+		cfg.Game.Arch = archFlag
+	}
+
 	serverBuildDir := resolveServerBuildDir()
 	containerHash := cache.ContainerKey(cfg, serverBuildDir)
 

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -167,6 +167,13 @@ func makeDeployer(cmd *cobra.Command) (*gamelift.Deployer, error) {
 		fn = cfg.GameLift.FleetName
 	}
 
+	// Auto-default instance type based on server architecture
+	arch := cfg.Game.ResolvedArch()
+	if instArch := pricing.InstanceArch(it); instArch != "" && instArch != arch {
+		it = pricing.DefaultInstanceType(arch)
+		fmt.Printf("Note: Switching instance type to %s to match %s server architecture\n", it, arch)
+	}
+
 	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
 		cfg.AWS.AccountID, r, cfg.AWS.ECRRepository, cfg.Container.Tag)
 
@@ -290,6 +297,15 @@ func runStack(cmd *cobra.Command, args []string) error {
 	fn := fleetName
 	if fn == "" {
 		fn = cfg.GameLift.FleetName
+	}
+
+	// Auto-default instance type based on server architecture
+	arch := cfg.Game.ResolvedArch()
+	if instArch := pricing.InstanceArch(cfg.GameLift.InstanceType); instArch != "" && instArch != arch {
+		defaultIT := pricing.DefaultInstanceType(arch)
+		fmt.Printf("Note: Switching instance type from %s (%s) to %s (%s) to match server architecture\n",
+			cfg.GameLift.InstanceType, instArch, defaultIT, arch)
+		cfg.GameLift.InstanceType = defaultIT
 	}
 
 	sn := stackName

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -249,6 +249,12 @@ func handleDeployStack(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 		cfg.GameLift.FleetName = input.FleetName
 	}
 
+	// Auto-default instance type based on server architecture
+	arch := cfg.Game.ResolvedArch()
+	if instArch := pricing.InstanceArch(cfg.GameLift.InstanceType); instArch != "" && instArch != arch {
+		cfg.GameLift.InstanceType = pricing.DefaultInstanceType(arch)
+	}
+
 	sn := input.StackName
 	if sn == "" {
 		sn = fmt.Sprintf("ludus-%s", cfg.GameLift.FleetName)


### PR DESCRIPTION
## Summary

Three bugs found during code review that would break ARM64 container → GameLift fleet deployments:

1. **`container build --arch` ignored by build dir resolution** — CLI flag wasn't applied to `cfg.Game.Arch` before `resolveServerBuildDir()`, so `container build --arch arm64` would look in `LinuxServer/` instead of `LinuxArm64Server/`
2. **`deploy fleet` and `deploy stack` bypass instance type auto-default** — `makeDeployer()` and `runStack()` construct deployers directly, never hitting the arch check in `resolve.go`. Would deploy arm64 images to x86 `c6i.large` instances.
3. **MCP `handleDeployStack` same bypass** — creates stack deployer directly without arch check

## Test plan

- [x] `go build` + `go vet` + `golangci-lint` — clean
- [x] `go test ./...` — all pass
- [x] `container build --arch arm64 --dry-run` — now resolves `LinuxArm64Server` (was `LinuxServer`)
- [x] `container build --dry-run` — still resolves `LinuxServer` (backward compat)
- [ ] CI (build + lint + test on ubuntu + windows)