### PR TITLE
Fix container builds for GameLift: disable provenance, add push --tag

### DIFF
--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -17,6 +17,7 @@ import (
 
 var (
 	tag      string
+	pushTag  string
 	noCache  bool
 	archFlag string
 )
@@ -54,6 +55,8 @@ func init() {
 	buildCmd.Flags().StringVarP(&tag, "tag", "t", "latest", "image tag")
 	buildCmd.Flags().BoolVar(&noCache, "no-cache", false, "build without Docker cache")
 	buildCmd.Flags().StringVar(&archFlag, "arch", "", `target CPU architecture: amd64, arm64 (default: from ludus.yaml)`)
+
+	pushCmd.Flags().StringVarP(&pushTag, "tag", "t", "", "image tag to push (default: from ludus.yaml or latest)")
 
 	Cmd.AddCommand(buildCmd)
 	Cmd.AddCommand(pushCmd)
@@ -143,9 +146,14 @@ func runPush(cmd *cobra.Command, args []string) error {
 	cfg := globals.Cfg
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)
 
+	imageTag := pushTag
+	if imageTag == "" {
+		imageTag = cfg.Container.Tag
+	}
+
 	builder := ctrBuilder.NewBuilder(ctrBuilder.BuildOptions{
 		ImageName:  cfg.Container.ImageName,
-		Tag:        cfg.Container.Tag,
+		Tag:        imageTag,
 		ServerPort: cfg.Container.ServerPort,
 	}, r)
 
@@ -154,7 +162,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 		ECRRepository: cfg.AWS.ECRRepository,
 		AWSRegion:     cfg.AWS.Region,
 		AWSAccountID:  cfg.AWS.AccountID,
-		ImageTag:      cfg.Container.Tag,
+		ImageTag:      imageTag,
 	}); err != nil {
 		return diagnose.ContainerError(err, "container push")
 	}

--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -308,7 +308,10 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		platform = "linux/arm64"
 	}
 
-	args := []string{"build", "--platform", platform, "-t", imageTag}
+	// --provenance=false prevents BuildKit from creating an OCI manifest index
+	// with attestation manifests. GameLift requires a simple single-platform
+	// image manifest and cannot parse multi-manifest OCI indexes.
+	args := []string{"build", "--platform", platform, "--provenance=false", "-t", imageTag}
 	if b.opts.NoCache {
 		args = append(args, "--no-cache")
 	}


### PR DESCRIPTION
## Summary
- **Disable BuildKit provenance attestation** (`--provenance=false`): Docker BuildKit creates OCI manifest indexes with attestation manifests by default. GameLift cannot parse these multi-manifest images, failing with "OS and Architecture are not supported". This produces a simple single-platform Docker manifest that GameLift accepts.
- **Add `--tag/-t` flag to `container push`**: Previously push always used the config tag (default `latest`), ignoring custom tags from build. Now `ludus container build -t 5.7.3 && ludus container push -t 5.7.3` works end-to-end.

## Test plan
- [x] `go build`, `go vet`, `golangci-lint`, `go test` — all pass
- [x] ARM64 container rebuilt with `--provenance=false` — ECR shows `application/vnd.docker.distribution.manifest.v2+json` (not OCI index)
- [x] GameLift container group definition: READY (was FAILED before fix)
- [x] GameLift container fleet on c7g.large (Graviton): ACTIVE
- [x] Game session created: `54.214.142.66:32768`
- [ ] Win64 client connection to ARM64 container fleet — pending