### PR TITLE
Fix ARM64 container pipeline gaps: arch threading, QEMU detection, MCP tag

### DIFF
--- a/cmd/mcp/tools_container.go
+++ b/cmd/mcp/tools_container.go
@@ -18,7 +18,8 @@ type containerBuildInput struct {
 }
 
 type containerPushInput struct {
-	DryRun bool `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
+	Tag    string `json:"tag,omitempty" jsonschema:"Docker image tag to push (default: from config or latest)"`
+	DryRun bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
 
 type containerResult struct {
@@ -102,26 +103,32 @@ func handleContainerPush(ctx context.Context, _ *mcp.CallToolRequest, input cont
 	cfg := globals.Cfg
 	r := runner.NewRunner(true, input.DryRun || globals.DryRun)
 
+	tag := input.Tag
+	if tag == "" {
+		tag = cfg.Container.Tag
+	}
+
 	serverBuildDir := resolveServerBuildDir(cfg)
 
 	b := container.NewBuilder(container.BuildOptions{
 		ServerBuildDir: serverBuildDir,
 		ImageName:      cfg.Container.ImageName,
-		Tag:            cfg.Container.Tag,
+		Tag:            tag,
 		ServerPort:     cfg.Container.ServerPort,
 		ProjectName:    cfg.Game.ProjectName,
 		ServerTarget:   cfg.Game.ResolvedServerTarget(),
+		Arch:           cfg.Game.ResolvedArch(),
 	}, r)
 
 	var result containerResult
-	result.ImageTag = fmt.Sprintf("%s:%s", cfg.Container.ImageName, cfg.Container.Tag)
+	result.ImageTag = fmt.Sprintf("%s:%s", cfg.Container.ImageName, tag)
 
 	captured, err := withCapture(func() error {
 		return b.Push(ctx, container.PushOptions{
 			ECRRepository: cfg.AWS.ECRRepository,
 			AWSRegion:     cfg.AWS.Region,
 			AWSAccountID:  cfg.AWS.AccountID,
-			ImageTag:      cfg.Container.Tag,
+			ImageTag:      tag,
 		})
 	})
 	result.Output = captured.Stdout + captured.Stderr

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -394,9 +394,12 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 			skip: skipContainer || !caps.NeedsContainerPush,
 			fn: func(ctx context.Context) error {
 				builder := ctrBuilder.NewBuilder(ctrBuilder.BuildOptions{
-					ImageName:  cfg.Container.ImageName,
-					Tag:        cfg.Container.Tag,
-					ServerPort: cfg.Container.ServerPort,
+					ImageName:    cfg.Container.ImageName,
+					Tag:          cfg.Container.Tag,
+					ServerPort:   cfg.Container.ServerPort,
+					ProjectName:  cfg.Game.ProjectName,
+					ServerTarget: cfg.Game.ResolvedServerTarget(),
+					Arch:         arch,
 				}, r)
 				return builder.Push(ctx, ctrBuilder.PushOptions{
 					ECRRepository: cfg.AWS.ECRRepository,

--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 
@@ -245,6 +247,23 @@ Manifest_*.txt
 `
 }
 
+// checkDockerPlatformSupport verifies that Docker can build for the given platform.
+// Cross-architecture builds (e.g. arm64 on an amd64 host) require QEMU user-mode
+// emulation registered via binfmt_misc.
+func checkDockerPlatformSupport(platform string) error {
+	out, err := exec.Command("docker", "buildx", "inspect", "--bootstrap").CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("docker buildx not available: %w", err)
+	}
+	if strings.Contains(string(out), platform) {
+		return nil
+	}
+	return fmt.Errorf("Docker cannot build for %s on this machine.\n"+
+		"  Cross-architecture builds require QEMU emulation. Install it with:\n"+
+		"    docker run --rm --privileged tonistiigi/binfmt --install arm64\n"+
+		"  Then retry the build", platform)
+}
+
 // Build creates the Docker image for the dedicated server.
 func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 	start := time.Now()
@@ -306,6 +325,14 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 	platform := "linux/amd64"
 	if arch == "arm64" {
 		platform = "linux/arm64"
+	}
+
+	// Cross-arch builds (e.g. building arm64 on amd64) require QEMU emulation.
+	if arch != runtime.GOARCH {
+		if err := checkDockerPlatformSupport(platform); err != nil {
+			result.Error = err
+			return result, err
+		}
 	}
 
 	// --provenance=false prevents BuildKit from creating an OCI manifest index


### PR DESCRIPTION
## Summary
Holes discovered during ARM64 container fleet E2E testing (UE 5.7.3 on c7g.large Graviton):

- **Pipeline push stage** missing `Arch`/`ProjectName`/`ServerTarget` in BuildOptions — wrapper binary could mismatch on push
- **MCP `ludus_container_push`** missing `tag` and `arch` params — AI agents couldn't push custom-tagged or arm64 images
- **QEMU detection** for cross-arch builds — `container build --arch arm64` on amd64 host now checks Docker platform support and prints the `tonistiigi/binfmt` install command if missing

## Files changed
| File | Fix |
|------|-----|
| `cmd/pipeline/pipeline.go` | Pass Arch/ProjectName/ServerTarget to push-stage builder |
| `cmd/mcp/tools_container.go` | Add `tag` param to push input, pass `Arch` to builder |
| `internal/container/builder.go` | Add `checkDockerPlatformSupport()` before cross-arch builds |

## Test plan
- [x] `go build`, `go vet`, `golangci-lint`, `go test` — all pass
- [x] `ludus container build --arch arm64 --dry-run` — QEMU check passes (binfmt installed)
- [x] Full ARM64 container fleet E2E already passed before these fixes (PRs #52, #53)