### PR TITLE
Rename game build --config to --build-config

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -33,7 +33,7 @@ ludus setup                        # interactive wizard
 ludus init [--fix]                 # validate/fix prerequisites
 ludus config [set|get]             # dot-notation config access
 ludus engine [build|setup|push]    # --jobs, --backend, --no-cache
-ludus game [build|client]          # --arch, --skip-cook, --platform, --backend, --config, --jobs
+ludus game [build|client]          # --arch, --skip-cook, --platform, --backend, --build-config, --jobs
 ludus container [build|push]       # --tag, --no-cache, --arch
 ludus deploy [fleet|stack|anywhere|ec2|session|destroy]  # --target, --region, --instance-type, --with-session
 ludus connect                      # launch client

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -90,9 +90,9 @@ var buildCmd = &cobra.Command{
 
 Use --backend docker to build inside a pre-built engine Docker image.
 
-Build configurations (--config):
+Build configurations (--build-config):
   Development  Faster builds, includes debug symbols, larger binaries (~2-3 GB).
-               Good for iteration and debugging. Default if --config is not specified.
+               Good for iteration and debugging. Default if --build-config is not specified.
   Shipping     Optimized for production: smaller binaries (~1-1.5 GB), no debug
                symbols, no console commands, stripped logging. Use for final deployment.`,
 	RunE: runBuild,
@@ -117,7 +117,7 @@ func init() {
 	buildCmd.Flags().BoolVar(&skipCook, "skip-cook", false, "skip content cooking (use previously cooked content)")
 	buildCmd.Flags().StringVar(&backend, "backend", "", `build backend: "native" or "docker" (default: from ludus.yaml)`)
 	buildCmd.Flags().BoolVar(&noCache, "no-cache", false, "disable build caching (forces rebuild even if inputs are unchanged)")
-	buildCmd.Flags().StringVar(&serverConfig, "config", "", `build configuration: "Development" or "Shipping" (default: Development)`)
+	buildCmd.Flags().StringVar(&serverConfig, "build-config", "", `build configuration: "Development" or "Shipping" (default: Development)`)
 	buildCmd.Flags().IntVarP(&maxJobs, "jobs", "j", 0, "max parallel compile actions (0 = auto-detect from RAM, halved for cross-compile)")
 	buildCmd.Flags().StringVar(&archFlag, "arch", "", `target CPU architecture: amd64, arm64 (default: from ludus.yaml)`)
 	clientCmd.Flags().BoolVar(&skipCookClient, "skip-cook", false, "skip content cooking (use previously cooked content)")


### PR DESCRIPTION
## Summary

- Renames `ludus game build --config` to `--build-config` to resolve the flag name conflict with the global `--config` persistent flag (config file path)
- Updates help text and CLAUDE.md command reference

The global `--config` flag (defined in `cmd/root/root.go`) sets the config file path. The game build command also had a local `--config` flag for selecting Development/Shipping build configuration. Cobra allows local flags to shadow persistent flags, but this creates ambiguity — users couldn't tell which `--config` applied.

**Note**: MCP tools use `"config"` as a JSON field name (`json:"config"`), which is unaffected — JSON parameters don't collide with CLI flags.

## Test plan

- [x] `go build` compiles
- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] Pre-commit hooks (build + lint + test) pass
- [ ] `ludus game build --build-config Shipping --dry-run` uses the new flag name
- [ ] `ludus --config custom.yaml game build --build-config Shipping --dry-run` both flags work independently