### PR TITLE
Surface hadolint/trivy findings in doctor and MCP status

### DIFF
--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -43,6 +43,7 @@ type diagnostic struct {
 	name    string
 	status  string // "ok", "warn", "fail"
 	message string
+	details []string // optional per-finding detail lines
 }
 
 func runDoctor(cmd *cobra.Command, args []string) error {
@@ -76,6 +77,9 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 			warns++
 		}
 		fmt.Printf("  %s %-30s %s\n", marker, d.name, d.message)
+		for _, detail := range d.details {
+			fmt.Printf("         %-30s   %s\n", "", detail)
+		}
 	}
 
 	fmt.Println()
@@ -336,6 +340,7 @@ func checkDockerfileSecurity(cfg *config.Config) []diagnostic {
 	gameDiag := diagnostic{name: "Game Dockerfile"}
 	gameDiag.status = "ok"
 	gameDiag.message = gameResult.Summary()
+	gameDiag.details = gameResult.FindingsDetail()
 	if !gameResult.HadolintAvailable {
 		gameDiag.message += "; install hadolint for extended checks"
 	}
@@ -361,6 +366,7 @@ func checkDockerfileSecurity(cfg *config.Config) []diagnostic {
 	engineDiag := diagnostic{name: "Engine Dockerfile"}
 	engineDiag.status = "ok"
 	engineDiag.message = engineResult.Summary()
+	engineDiag.details = engineResult.FindingsDetail()
 	if !engineResult.HadolintAvailable {
 		engineDiag.message += "; install hadolint for extended checks"
 	}
@@ -384,6 +390,7 @@ func checkDockerfileSecurity(cfg *config.Config) []diagnostic {
 	default:
 		imageDiag.status = "warn"
 		imageDiag.message = imageResult.Summary()
+		imageDiag.details = imageResult.FindingsDetail()
 	}
 	checks = append(checks, imageDiag)
 

--- a/cmd/mcp/tools_status.go
+++ b/cmd/mcp/tools_status.go
@@ -6,20 +6,39 @@ import (
 	"os"
 
 	"github.com/devrecon/ludus/cmd/globals"
+	"github.com/devrecon/ludus/internal/config"
+	ctrBuilder "github.com/devrecon/ludus/internal/container"
+	"github.com/devrecon/ludus/internal/dflint"
+	"github.com/devrecon/ludus/internal/dockerbuild"
 	internalstatus "github.com/devrecon/ludus/internal/status"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type statusInput struct{}
 
+type securityFinding struct {
+	Source  string `json:"source"`
+	Rule    string `json:"rule"`
+	Level   string `json:"level"`
+	Message string `json:"message"`
+	Line    int    `json:"line,omitempty"`
+}
+
+type securityScan struct {
+	Target   string            `json:"target"`
+	Summary  string            `json:"summary"`
+	Findings []securityFinding `json:"findings,omitempty"`
+}
+
 type statusResult struct {
-	Stages []internalstatus.StageStatus `json:"stages"`
+	Stages   []internalstatus.StageStatus `json:"stages"`
+	Security []securityScan               `json:"security,omitempty"`
 }
 
 func registerStatusTool(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "ludus_status",
-		Description: "Check status of all pipeline stages: engine source, engine build, game server build, container image, client build, deploy target, and game session.",
+		Description: "Check status of all pipeline stages (engine, game, container, deploy, session) and run security scans (hadolint Dockerfile lint + trivy image vulnerability scan).",
 	}, handleStatus)
 }
 
@@ -32,10 +51,56 @@ func handleStatus(ctx context.Context, _ *mcp.CallToolRequest, _ statusInput) (*
 	}
 
 	stages := internalstatus.CheckAll(ctx, cfg, target)
+	security := runSecurityScans(cfg)
 
 	return &mcp.CallToolResult{
 		Content: []mcp.Content{
-			&mcp.TextContent{Text: jsonString(statusResult{Stages: stages})},
+			&mcp.TextContent{Text: jsonString(statusResult{Stages: stages, Security: security})},
 		},
 	}, nil, nil
+}
+
+func runSecurityScans(cfg *config.Config) []securityScan {
+	var scans []securityScan
+
+	// Lint game server Dockerfile
+	gameBuilder := ctrBuilder.NewBuilder(ctrBuilder.BuildOptions{
+		ServerPort:   cfg.Container.ServerPort,
+		ProjectName:  cfg.Game.ProjectName,
+		ServerTarget: cfg.Game.ResolvedServerTarget(),
+		Arch:         cfg.Game.ResolvedArch(),
+	}, nil)
+	gameResult := dflint.LintDockerfile(gameBuilder.GenerateDockerfile())
+	scans = append(scans, lintResultToScan("Game Dockerfile", gameResult))
+
+	// Lint engine Dockerfile
+	engineResult := dflint.LintDockerfile(dockerbuild.GenerateEngineDockerfile(dockerbuild.DockerfileOptions{
+		MaxJobs:   cfg.Engine.MaxJobs,
+		BaseImage: cfg.Engine.DockerBaseImage,
+	}))
+	scans = append(scans, lintResultToScan("Engine Dockerfile", engineResult))
+
+	// Scan container image with trivy
+	imageRef := fmt.Sprintf("%s:%s", cfg.Container.ImageName, cfg.Container.Tag)
+	imageResult := dflint.LintImage(imageRef)
+	scans = append(scans, lintResultToScan("Container Image ("+imageRef+")", imageResult))
+
+	return scans
+}
+
+func lintResultToScan(target string, result *dflint.LintResult) securityScan {
+	scan := securityScan{
+		Target:  target,
+		Summary: result.Summary(),
+	}
+	for _, f := range result.Findings {
+		scan.Findings = append(scan.Findings, securityFinding{
+			Source:  f.Source,
+			Rule:    f.Rule,
+			Level:   string(f.Level),
+			Message: f.Message,
+			Line:    f.Line,
+		})
+	}
+	return scan
 }

--- a/internal/dflint/lint.go
+++ b/internal/dflint/lint.go
@@ -50,6 +50,20 @@ func (r *LintResult) HasWarnings() bool {
 	return false
 }
 
+// FindingsDetail returns a formatted string per finding for display.
+func (r *LintResult) FindingsDetail() []string {
+	var lines []string
+	for _, f := range r.Findings {
+		prefix := string(f.Level)
+		loc := ""
+		if f.Line > 0 {
+			loc = fmt.Sprintf(" (line %d)", f.Line)
+		}
+		lines = append(lines, fmt.Sprintf("[%s] %s%s: %s", prefix, f.Rule, loc, f.Message))
+	}
+	return lines
+}
+
 // Summary returns a human-readable summary of findings.
 func (r *LintResult) Summary() string {
 	if len(r.Findings) == 0 {


### PR DESCRIPTION
## Summary

- `ludus doctor` now prints each hadolint/trivy finding with rule, severity, and message beneath the summary line (previously only showed counts like "1 error(s), 2 warning(s)")
- MCP `ludus_status` tool now includes a `security` section with structured findings from hadolint Dockerfile lint and trivy image vulnerability scans, so AI agents can see and act on security issues
- Added `FindingsDetail()` method to `dflint.LintResult` for reusable finding formatting

### Before
```
  [WARN] Container Image                1 error(s), 2 warning(s)
```

### After
```
  [WARN] Container Image                1 error(s), 2 warning(s)
                                          [error] CVE-2025-68121: crypto/tls: Unexpected session resumption (stdlib)
                                          [warning] CVE-2026-24051: OpenTelemetry Go SDK PATH Hijacking (go.opentelemetry.io/otel/sdk)
                                          [warning] CVE-2025-22869: Denial of Service in golang.org/x/crypto/ssh (golang.org/x/crypto)
```

## Test plan

- [x] `go build` compiles
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass
- [x] Pre-commit hooks pass
- [x] `ludus doctor` shows detailed findings for Game Dockerfile, Engine Dockerfile, and Container Image
- [ ] MCP `ludus_status` returns `security` array with findings in JSON