### PR TITLE
Auto-resolve game project path from engine source

### DIFF
--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -84,6 +84,9 @@ Use --profile to manage multiple configurations (e.g., different UE versions):
 			}
 		}
 
+		// Auto-resolve project path from engine source if not set
+		cfg.Game.ResolveProjectPath(cfg.Engine.SourcePath)
+
 		return nil
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -141,6 +141,21 @@ type ContentValidationConfig struct {
 	PluginContentDirs []string `yaml:"pluginContentDirs"`
 }
 
+// ResolveProjectPath fills in ProjectPath if empty by checking known locations.
+// For Lyra, it checks <engineSourcePath>/Samples/Games/Lyra/Lyra.uproject.
+// For other projects, the user must set game.projectPath explicitly.
+func (g *GameConfig) ResolveProjectPath(engineSourcePath string) {
+	if g.ProjectPath != "" || engineSourcePath == "" {
+		return
+	}
+	if g.ProjectName == "Lyra" || g.ProjectName == "" {
+		candidate := filepath.Join(engineSourcePath, "Samples", "Games", "Lyra", "Lyra.uproject")
+		if _, err := os.Stat(candidate); err == nil {
+			g.ProjectPath = candidate
+		}
+	}
+}
+
 // ResolvedServerTarget returns the server target name, defaulting to ProjectName + "Server".
 func (g *GameConfig) ResolvedServerTarget() string {
 	if g.ServerTarget != "" {


### PR DESCRIPTION
## Summary

- Adds `GameConfig.ResolveProjectPath()` method that auto-detects the `.uproject` file from the engine source tree when `game.projectPath` is not set in config
- Called in `PersistentPreRunE` so all commands benefit (not just build commands)
- For Lyra (the default project), resolves to `<engineSource>/Samples/Games/Lyra/Lyra.uproject`
- For custom projects, users still set `game.projectPath` explicitly — no change in behavior

### Before
```
$ ludus buildgraph --stdout
Error: game project path is required
```

### After
```
$ ludus buildgraph --stdout
<?xml version="1.0" encoding="UTF-8"?>
<BuildGraph>
  <Option Name="ProjectPath" DefaultValue="F:\...\Lyra\Lyra.uproject" ...
  ...
```

## Test plan

- [x] `go build` compiles
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass
- [x] Pre-commit hooks pass
- [x] `ludus buildgraph --stdout` works without explicit `game.projectPath` in ludus.yaml
- [ ] CI checks pass