### PR TITLE
Harden npm package security

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,9 @@ jobs:
           node-version: "20"
           registry-url: "https://registry.npmjs.org"
 
+      - name: Embed binary checksums into npm package
+        run: node scripts/embed-checksums.js dist/checksums.txt npm/package.json
+
       - name: Publish npm package
         working-directory: npm
         env:
@@ -42,4 +45,4 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           npm version "$VERSION" --no-git-tag-version
-          npm publish --access public --tag beta
+          npm publish --access public

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,33 +55,17 @@ Files: `mcp.go`, `register.go`, `capture.go`, `helpers.go`, `buildmgr.go`, `tool
 
 ### Implementation layer (`internal/`)
 
-| Package | Purpose |
-|---------|---------|
-| `config` | `Config` struct, `Load()` from `ludus.yaml` via Viper, `Defaults()`, arch helpers (`NormalizeArch`, `ServerPlatformDir`, `BinariesPlatformDir`) |
-| `runner` | Shell executor with `Verbose`/`DryRun` modes, `Env` override |
-| `prereq` | Prerequisite checker (`RunAll()` → `[]CheckResult`), platform-specific via build tags |
-| `toolchain` | Engine version detection, cross-compile toolchain lookup (5.4→v22, 5.5→v23, 5.6→v25, 5.7→v26) |
-| `cache` | Build caching per stage to `.ludus/cache.json`, hash-based skip |
-| `engine` | UE5 engine compilation (Setup, GenerateProjectFiles, Build) |
-| `game` | Game packaging via RunUAT BuildCookRun, cross-platform path handling |
-| `container` | Dockerfile generation, `docker build` (arch-aware `--platform`, `--provenance=false`), ECR push, QEMU detection for cross-arch builds |
-| `dockerbuild` | Docker-based build backend for engine and game |
-| `deploy` | `Target` interface + `SessionManager`, resolved via `cmd/globals/resolve.go` |
-| `gamelift` | Container fleet deployer (SDK v2): CGD, IAM role, fleet |
-| `stack` | CloudFormation deployer: atomic IAM + CGD + fleet |
-| `ec2fleet` | Managed EC2 deployer: S3 upload, Build, fleet (no Docker) |
-| `anywhere` | Local Anywhere fleet: custom location, compute registration, local server |
-| `binary` | Simple file export to output directory |
-| `buildgraph` | BuildGraph XML generation: schema structs, DAG generator from config |
-| `wrapper` | GameLift Game Server Wrapper binary (clone, build, cache per arch) |
-| `state` | `.ludus/state.json` with profile support, typed update helpers |
-| `tags` | AWS resource tagging with format converters |
-| `pricing` | Instance pricing, arch detection, Graviton savings tips |
-| `diagnose` | Table-driven error pattern matching with actionable suggestions |
-| `dflint` | Dockerfile security lint + Trivy image scan |
-| `status` | Pipeline stage status checks |
-| `progress` | Elapsed-time ticker for long builds |
-| `ci` | GitHub Actions workflow generation, runner agent management |
+Most packages are named for what they do (`engine`, `game`, `cache`, `state`, `tags`, `ci`, etc.). Key non-obvious ones:
+
+| Package | Why it's non-obvious |
+|---------|---------------------|
+| `config` | Arch helpers (`NormalizeArch`, `ServerPlatformDir`, `BinariesPlatformDir`) live here, not just config loading |
+| `prereq` | Platform-specific via build tags — `checker_windows.go`/`checker_unix.go` |
+| `toolchain` | Cross-compile toolchain mapping: 5.4→v22, 5.5→v23, 5.6→v25, 5.7→v26 |
+| `container` | Handles `--platform`, `--provenance=false`, QEMU detection, binary name resolution |
+| `deploy` | `Target` interface — factory in `cmd/globals/resolve.go`, not here |
+| `wrapper` | GameLift Game Server Wrapper (Go binary, PID 1 in container) — clone, build, cache per arch |
+| `dockerbuild` | Builds engine/game *inside* Docker — separate from `container` which builds *the container image* |
 
 ### Key patterns
 
@@ -130,7 +114,7 @@ Backward compat: `lyra:` key auto-migrates to `game:` with deprecation warning.
 
 GitHub Actions CI runs on push/PR to `main`: lint + build + test on both Ubuntu and Windows.
 
-Lint config: `.golangci.yml` (v2 format). Key gosec exclusions: G104, G115, G204, G301, G304, G306.
+Lint config: `.golangci.yml` (v2 format). Key gosec exclusions: G104, G115, G204, G301, G304, G306, G702, G703.
 
 Pre-commit hooks: `.hooks/pre-commit`. Activate: `git config core.hooksPath .hooks`
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -4,9 +4,11 @@
 const fs = require("fs");
 const path = require("path");
 const https = require("https");
-const { execSync } = require("child_process");
+const crypto = require("crypto");
+const { spawnSync } = require("child_process");
 
 const REPO = "jpvelasco/ludus";
+const MAX_REDIRECTS = 5;
 
 const PLATFORM_MAP = {
   linux: "linux",
@@ -23,7 +25,21 @@ function getPackageVersion() {
   const pkg = JSON.parse(
     fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
   );
-  return pkg.version;
+  const version = pkg.version;
+
+  // Validate semver format to prevent URL injection
+  if (!/^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$/.test(version)) {
+    throw new Error(`Invalid version format: ${version}`);
+  }
+
+  return version;
+}
+
+function getExpectedChecksum(archiveName) {
+  const pkg = JSON.parse(
+    fs.readFileSync(path.join(__dirname, "package.json"), "utf8")
+  );
+  return pkg.binaryChecksums?.[archiveName] || null;
 }
 
 function getArchiveName(version, platform, arch) {
@@ -36,12 +52,16 @@ function getArchiveName(version, platform, arch) {
   return `ludus_${version}_${os}_${cpu}.${ext}`;
 }
 
-function download(url) {
+function download(url, redirectCount = 0) {
   return new Promise((resolve, reject) => {
+    if (redirectCount > MAX_REDIRECTS) {
+      return reject(new Error(`Too many redirects (max ${MAX_REDIRECTS})`));
+    }
+
     https
       .get(url, (res) => {
         if (res.statusCode >= 300 && res.statusCode < 400 && res.headers.location) {
-          return download(res.headers.location).then(resolve, reject);
+          return download(res.headers.location, redirectCount + 1).then(resolve, reject);
         }
         if (res.statusCode !== 200) {
           return reject(new Error(`Download failed: HTTP ${res.statusCode} for ${url}`));
@@ -55,7 +75,42 @@ function download(url) {
   });
 }
 
-async function extract(buffer, archiveName, binDir) {
+function verifyChecksum(buffer, archiveName) {
+  const expected = getExpectedChecksum(archiveName);
+  if (!expected) {
+    console.log("ludus-cli: no checksum available, skipping verification");
+    return;
+  }
+
+  const actual = crypto.createHash("sha256").update(buffer).digest("hex");
+  if (actual !== expected) {
+    throw new Error(
+      `Checksum mismatch for ${archiveName}\n` +
+        `  Expected: ${expected}\n` +
+        `  Actual:   ${actual}`
+    );
+  }
+  console.log("ludus-cli: checksum verified (SHA-256)");
+}
+
+// Escape a string for use inside PowerShell single quotes.
+// PowerShell single-quoted strings only need '' to represent a literal '.
+function psEscape(s) {
+  return s.replace(/'/g, "''");
+}
+
+function spawnOrFail(cmd, args, label) {
+  const result = spawnSync(cmd, args, { stdio: "pipe" });
+  if (result.error) {
+    throw new Error(`${label}: ${result.error.message}`);
+  }
+  if (result.status !== 0) {
+    const stderr = result.stderr ? result.stderr.toString().trim() : "";
+    throw new Error(`${label} exited with code ${result.status}${stderr ? ": " + stderr : ""}`);
+  }
+}
+
+function extract(buffer, archiveName, binDir) {
   const tmpDir = path.join(__dirname, ".tmp-install");
   fs.mkdirSync(tmpDir, { recursive: true });
 
@@ -64,17 +119,21 @@ async function extract(buffer, archiveName, binDir) {
 
   try {
     if (archiveName.endsWith(".zip")) {
-      // Use PowerShell on Windows, unzip on others
       if (process.platform === "win32") {
-        execSync(
-          `powershell -NoProfile -Command "Expand-Archive -Force '${archivePath}' '${tmpDir}'"`,
-          { stdio: "pipe" }
+        spawnOrFail(
+          "powershell",
+          [
+            "-NoProfile",
+            "-Command",
+            `Expand-Archive -Force -Path '${psEscape(archivePath)}' -DestinationPath '${psEscape(tmpDir)}'`,
+          ],
+          "Expand-Archive"
         );
       } else {
-        execSync(`unzip -o "${archivePath}" -d "${tmpDir}"`, { stdio: "pipe" });
+        spawnOrFail("unzip", ["-o", archivePath, "-d", tmpDir], "unzip");
       }
     } else {
-      execSync(`tar -xzf "${archivePath}" -C "${tmpDir}"`, { stdio: "pipe" });
+      spawnOrFail("tar", ["-xzf", archivePath, "-C", tmpDir], "tar");
     }
 
     // Find the binary in the extracted files
@@ -111,8 +170,10 @@ async function main() {
   console.log(`ludus-cli: downloading ${archiveName}...`);
   const buffer = await download(url);
 
+  verifyChecksum(buffer, archiveName);
+
   console.log("ludus-cli: extracting binary...");
-  await extract(buffer, archiveName, binDir);
+  extract(buffer, archiveName, binDir);
 
   console.log("ludus-cli: installed successfully");
 }

--- a/npm/package.json
+++ b/npm/package.json
@@ -26,5 +26,6 @@
     "install.js",
     "run.js",
     "bin/"
-  ]
+  ],
+  "binaryChecksums": {}
 }

--- a/scripts/embed-checksums.js
+++ b/scripts/embed-checksums.js
@@ -1,0 +1,39 @@
+#!/usr/bin/env node
+"use strict";
+
+// embed-checksums.js — Embeds SHA-256 checksums from GoReleaser's checksums.txt
+// into npm/package.json's binaryChecksums field.
+//
+// Usage: node scripts/embed-checksums.js dist/checksums.txt npm/package.json
+//
+// GoReleaser checksums.txt format:
+//   <sha256hex>  <filename>
+
+const fs = require("fs");
+
+const [checksumFile, packageFile] = process.argv.slice(2);
+if (!checksumFile || !packageFile) {
+  console.error("Usage: node embed-checksums.js <checksums.txt> <package.json>");
+  process.exit(1);
+}
+
+const checksums = fs.readFileSync(checksumFile, "utf8");
+const pkg = JSON.parse(fs.readFileSync(packageFile, "utf8"));
+
+pkg.binaryChecksums = {};
+for (const line of checksums.split("\n")) {
+  const match = line.match(/^([0-9a-f]{64})\s+(.+)$/);
+  if (match) {
+    const [, hash, filename] = match;
+    pkg.binaryChecksums[filename] = hash;
+  }
+}
+
+const count = Object.keys(pkg.binaryChecksums).length;
+if (count === 0) {
+  console.error("Warning: no checksums found in " + checksumFile);
+  process.exit(1);
+}
+
+fs.writeFileSync(packageFile, JSON.stringify(pkg, null, 2) + "\n");
+console.log(`Embedded ${count} checksums into ${packageFile}`);


### PR DESCRIPTION
## Summary

Security hardening for the `ludus-cli` npm package based on socket.dev findings (Quality 64, Supply Chain Security 64).

**Fixes:**
- **Command injection** — Replace `execSync` (shell invocation) with `spawnSync` (direct process spawn, no shell). Eliminates socket.dev "Shell access" flag.
- **Integrity verification** — SHA-256 checksum verification of downloaded binaries. Checksums embedded in `package.json` at release time from GoReleaser's `checksums.txt`.
- **Redirect safety** — Bounded redirect following (max 5) prevents infinite redirect loops.
- **URL injection** — Semver format validation on `package.json` version before URL construction.
- **PowerShell escaping** — `psEscape()` for single-quote defense in depth (e.g., usernames like `O'Brien`).

**Release pipeline changes:**
- New `scripts/embed-checksums.js` reads GoReleaser's `dist/checksums.txt` and writes SHA-256 hashes into `npm/package.json` before publish.
- Removed `--tag beta` from npm publish (package was unpublished and will be republished fresh).

**Expected socket.dev score improvement:** Quality 64→85+, Supply Chain Security 64→85+

## Test plan
- [ ] `node scripts/embed-checksums.js` works with mock checksums.txt
- [ ] `install.js` validates version format (rejects `../../evil`)
- [ ] `install.js` download follows max 5 redirects
- [ ] `install.js` verifies SHA-256 when checksums present
- [ ] `install.js` gracefully skips verification when no checksums (dev)
- [ ] CI passes (build + lint + test on Ubuntu and Windows)