### PR TITLE
Fix Go security and code quality issues

### DIFF
--- a/internal/anywhere/deployer.go
+++ b/internal/anywhere/deployer.go
@@ -2,6 +2,7 @@ package anywhere
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -11,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
 	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+	"github.com/aws/smithy-go"
 
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/tags"
@@ -345,22 +347,26 @@ func wrapperConfigDir() (string, error) {
 	return filepath.Join(home, ".cache", "ludus", "anywhere"), nil
 }
 
-// isConflict returns true if the error indicates a resource already exists.
+// isConflict returns true if the AWS API error code indicates a resource already exists.
 func isConflict(err error) bool {
-	if err == nil {
-		return false
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "ConflictException", "EntityAlreadyExistsException":
+			return true
+		}
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "ConflictException") || strings.Contains(msg, "already exists")
+	return false
 }
 
-// isNotFound returns true if the error indicates a resource was not found.
+// isNotFound returns true if the AWS API error code indicates a resource was not found.
 func isNotFound(err error) bool {
-	if err == nil {
-		return false
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NotFoundException", "ResourceNotFoundException", "NoSuchEntity":
+			return true
+		}
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "NotFoundException") ||
-		strings.Contains(msg, "NoSuchEntity") ||
-		strings.Contains(msg, "NotFound")
+	return false
 }

--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -157,7 +157,7 @@ game-server-details:
 }
 
 // copyFile copies a file from src to dst, preserving permissions.
-func copyFile(src, dst string) error {
+func copyFile(src, dst string) (retErr error) {
 	in, err := os.Open(src)
 	if err != nil {
 		return err
@@ -168,7 +168,11 @@ func copyFile(src, dst string) error {
 	if err != nil {
 		return err
 	}
-	defer out.Close()
+	defer func() {
+		if cerr := out.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
 
 	if _, err := io.Copy(out, in); err != nil {
 		return err
@@ -377,11 +381,14 @@ func (b *Builder) Push(ctx context.Context, opts PushOptions) error {
 		}
 	}
 
-	// Authenticate with ECR
+	// Authenticate with ECR — get password then pipe to docker login (no shell)
 	loginURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", opts.AWSAccountID, opts.AWSRegion)
-	if err := b.Runner.Run(ctx, "bash", "-c",
-		fmt.Sprintf("aws ecr get-login-password --region %s | docker login --username AWS --password-stdin %s",
-			opts.AWSRegion, loginURI)); err != nil {
+	password, err := b.Runner.RunOutput(ctx, "aws", "ecr", "get-login-password", "--region", opts.AWSRegion)
+	if err != nil {
+		return fmt.Errorf("getting ECR password: %w", err)
+	}
+	if err := b.Runner.RunWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
+		"docker", "login", "--username", "AWS", "--password-stdin", loginURI); err != nil {
 		return fmt.Errorf("ECR login failed: %w", err)
 	}
 

--- a/internal/dockerbuild/engine.go
+++ b/internal/dockerbuild/engine.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"time"
 
+	"strings"
+
 	"github.com/devrecon/ludus/internal/runner"
 )
 
@@ -157,11 +159,14 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts PushOptions) error {
 		}
 	}
 
-	// Authenticate with ECR
+	// Authenticate with ECR — get password then pipe to docker login (no shell)
 	loginURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", opts.AWSAccountID, opts.AWSRegion)
-	if err := b.Runner.Run(ctx, "bash", "-c",
-		fmt.Sprintf("aws ecr get-login-password --region %s | docker login --username AWS --password-stdin %s",
-			opts.AWSRegion, loginURI)); err != nil {
+	password, err := b.Runner.RunOutput(ctx, "aws", "ecr", "get-login-password", "--region", opts.AWSRegion)
+	if err != nil {
+		return fmt.Errorf("getting ECR password: %w", err)
+	}
+	if err := b.Runner.RunWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
+		"docker", "login", "--username", "AWS", "--password-stdin", loginURI); err != nil {
 		return fmt.Errorf("ECR login failed: %w", err)
 	}
 

--- a/internal/ec2fleet/deployer.go
+++ b/internal/ec2fleet/deployer.go
@@ -3,6 +3,7 @@ package ec2fleet
 import (
 	"archive/zip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -18,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/aws/smithy-go"
 
 	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/runner"
@@ -269,7 +271,11 @@ func (d *Deployer) CreateBuild(ctx context.Context, bucket, key string) (string,
 			return buildID, fmt.Errorf("build failed")
 		}
 
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return buildID, ctx.Err()
+		case <-time.After(pollInterval):
+		}
 	}
 
 	return buildID, fmt.Errorf("timed out waiting for build to become READY")
@@ -411,7 +417,11 @@ func (d *Deployer) CreateFleet(ctx context.Context, buildID string) (*FleetStatu
 			return result, fmt.Errorf("fleet entered ERROR state")
 		}
 
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case <-time.After(pollInterval):
+		}
 	}
 
 	return result, fmt.Errorf("timed out waiting for fleet to become ACTIVE")
@@ -511,7 +521,11 @@ func (d *Deployer) Destroy(ctx context.Context, fleetID, buildID, s3Bucket, s3Ke
 				break
 			}
 			fmt.Println("  Waiting for fleet deletion...")
-			time.Sleep(pollInterval)
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(pollInterval):
+			}
 		}
 		fmt.Println("Fleet deleted.")
 	}
@@ -703,13 +717,14 @@ func addFileToZip(w *zip.Writer, srcPath, zipPath string) error {
 	return err
 }
 
-// isNotFound returns true if the error message indicates a resource was not found.
+// isNotFound returns true if the AWS API error code indicates a resource was not found.
 func isNotFound(err error) bool {
-	if err == nil {
-		return false
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NotFoundException", "ResourceNotFoundException", "NoSuchEntity":
+			return true
+		}
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "NotFoundException") ||
-		strings.Contains(msg, "NoSuchEntity") ||
-		strings.Contains(msg, "NotFound")
+	return false
 }

--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -2,8 +2,8 @@ package gamelift
 
 import (
 	"context"
+	"errors"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -11,6 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
 	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+
+	"github.com/aws/smithy-go"
 
 	"github.com/devrecon/ludus/internal/tags"
 )
@@ -135,7 +137,11 @@ func (d *Deployer) CreateContainerGroupDefinition(ctx context.Context) (string, 
 			return cgdARN, fmt.Errorf("container group definition failed: %s", reason)
 		}
 
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return cgdARN, ctx.Err()
+		case <-time.After(pollInterval):
+		}
 	}
 
 	return cgdARN, fmt.Errorf("timed out waiting for container group definition to become READY")
@@ -240,7 +246,11 @@ func (d *Deployer) CreateFleet(ctx context.Context, cgdARN string) (*FleetStatus
 			return result, nil
 		}
 
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return result, ctx.Err()
+		case <-time.After(pollInterval):
+		}
 	}
 
 	return result, fmt.Errorf("timed out waiting for fleet to become ACTIVE")
@@ -330,15 +340,16 @@ func (d *Deployer) Destroy(ctx context.Context) error {
 	return nil
 }
 
-// isNotFound returns true if the error message indicates a resource was not found.
+// isNotFound returns true if the AWS API error code indicates a resource was not found.
 func isNotFound(err error) bool {
-	if err == nil {
-		return false
+	var apiErr smithy.APIError
+	if errors.As(err, &apiErr) {
+		switch apiErr.ErrorCode() {
+		case "NotFoundException", "ResourceNotFoundException", "NoSuchEntity":
+			return true
+		}
 	}
-	msg := err.Error()
-	return strings.Contains(msg, "NotFoundException") ||
-		strings.Contains(msg, "NoSuchEntity") ||
-		strings.Contains(msg, "NotFound")
+	return false
 }
 
 func (d *Deployer) deleteFleet(ctx context.Context) error {
@@ -387,7 +398,11 @@ func (d *Deployer) deleteFleet(ctx context.Context) error {
 			return fmt.Errorf("polling fleet deletion: %w", err)
 		}
 		fmt.Println("  Waiting for fleet deletion...")
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
 	}
 
 	return fmt.Errorf("timed out waiting for fleet deletion")

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -117,6 +117,28 @@ func (r *Runner) RunOutput(ctx context.Context, name string, args ...string) ([]
 	return cmd.Output()
 }
 
+// RunWithStdin executes a command with the given reader piped to stdin.
+func (r *Runner) RunWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) error {
+	if r.Verbose || r.DryRun {
+		fmt.Fprintf(r.Stdout, "+ %s", name)
+		for _, arg := range args {
+			fmt.Fprintf(r.Stdout, " %s", arg)
+		}
+		fmt.Fprintln(r.Stdout)
+	}
+
+	if r.DryRun {
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.environ()
+	cmd.Stdin = stdin
+	cmd.Stdout = r.Stdout
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}
+
 // RunInDir executes a command in a specific directory.
 func (r *Runner) RunInDir(ctx context.Context, dir, name string, args ...string) error {
 	if r.Verbose || r.DryRun {

--- a/internal/stack/deployer.go
+++ b/internal/stack/deployer.go
@@ -235,7 +235,11 @@ func (d *StackDeployer) Destroy(ctx context.Context) error {
 			return fmt.Errorf("stack deletion failed: %s", reason)
 		}
 
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
 	}
 
 	return fmt.Errorf("timed out waiting for stack deletion")
@@ -325,7 +329,11 @@ func (d *StackDeployer) pollStack(ctx context.Context, successStatus, failStatus
 			return status, fmt.Errorf("stack operation failed (%s): %s", status, reason)
 		}
 
-		time.Sleep(pollInterval)
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(pollInterval):
+		}
 	}
 
 	return "", fmt.Errorf("timed out waiting for stack to reach %s", successStatus)


### PR DESCRIPTION
## Summary

Addresses 5 verified findings from the security and code quality review.

### Security fixes

| Finding | Fix | Files |
|---------|-----|-------|
| ECR auth piped through `bash -c` | Split into `RunOutput` (get password) + `RunWithStdin` (pipe to docker login) — no shell invocation | `container/builder.go`, `dockerbuild/engine.go` |
| `isNotFound()`/`isConflict()` use string matching on error messages | Use `smithy.APIError` with `errors.As` and `ErrorCode()` switch | `gamelift/deployer.go`, `ec2fleet/deployer.go`, `anywhere/deployer.go` |

### Quality fixes

| Finding | Fix | Files |
|---------|-----|-------|
| Polling loops use `time.Sleep` (ignores ctx cancellation) | Replace with `select { case <-ctx.Done(): ... case <-time.After(): }` — 8 loops across 3 deployers | `gamelift/`, `ec2fleet/`, `stack/` |
| `copyFile()` ignores `out.Close()` error | Named return + defer closure checks close error (catches buffered write flush failures) | `container/builder.go` |
| No `RunWithStdin` on Runner | Added `RunWithStdin(ctx, stdin, name, args...)` method | `runner/runner.go` |

## Test plan
- [ ] `go build` — compiles
- [ ] `go vet ./...` — clean
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `go test ./...` — all pass
- [ ] CI passes on Ubuntu and Windows