### PR TITLE
Add community files for public release

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,39 @@
+---
+name: Bug Report
+about: Report a bug or unexpected behavior
+title: ""
+labels: bug
+assignees: ""
+---
+
+**Ludus version**
+<!-- Output of `ludus --version` or `git rev-parse --short HEAD` -->
+
+**Environment**
+- OS:
+- UE version:
+- Go version:
+- Docker version (if applicable):
+
+**Description**
+<!-- A clear description of the bug -->
+
+**Steps to reproduce**
+1.
+2.
+3.
+
+**Expected behavior**
+<!-- What you expected to happen -->
+
+**Actual behavior**
+<!-- What actually happened -->
+
+**Error output**
+<!-- Paste the full output with `--verbose`. Redact any AWS account IDs or credentials. -->
+
+```
+```
+
+**Additional context**
+<!-- Screenshots, config snippets (redact secrets), `ludus doctor` output, etc. -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest a new feature or improvement
+title: ""
+labels: enhancement
+assignees: ""
+---
+
+**Problem**
+<!-- What problem does this solve? What's the pain point? -->
+
+**Proposed solution**
+<!-- How should this work? CLI usage examples are helpful. -->
+
+**Alternatives considered**
+<!-- Any other approaches you thought about -->
+
+**Additional context**
+<!-- UE version constraints, AWS service details, etc. -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,17 @@
+## Summary
+
+<!-- 1-3 sentences: what this PR does and why -->
+
+## Changes
+
+-
+
+## Testing
+
+- [ ] `golangci-lint run ./...` passes
+- [ ] `go test ./...` passes
+- [ ] Tested manually with `--verbose` (describe what you ran)
+
+## Notes
+
+<!-- Anything reviewers should know: breaking changes, config changes, new dependencies, etc. -->

--- a/.gitignore
+++ b/.gitignore
@@ -1,12 +1,18 @@
 # Binary
 ludus
 ludus.exe
+ludus-*.exe
 
 # Config with real values (contains AWS account IDs, paths, etc.)
 ludus.yaml
+ludus-*.yaml
+*.yaml.bak
 
 # Pipeline state (session IPs, fleet IDs, etc.)
 .ludus/
+
+# Claude Code
+.claude/
 
 # Go
 vendor/
@@ -35,3 +41,7 @@ npm/node_modules/
 *.test
 coverage.out
 coverage.html
+
+# Local scratch scripts
+arm64-build-all.sh
+scripts/build-arm64-servers.sh

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,76 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity
+and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the
+  overall community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or
+  advances of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email
+  address, without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+**jpvelasco@pm.me**.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.0, available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+
+[homepage]: https://www.contributor-covenant.org

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,69 @@
+# Contributing to Ludus
+
+Thanks for your interest in contributing! Ludus is open source under the MIT license and we welcome contributions of all kinds.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork and create a branch:
+   ```bash
+   git clone git@github.com:<your-username>/ludus.git
+   cd ludus
+   git checkout -b feat/your-feature
+   ```
+3. Install dependencies:
+   - Go 1.24+
+   - golangci-lint v2 (`go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`)
+4. Activate pre-commit hooks:
+   ```bash
+   git config core.hooksPath .hooks
+   ```
+
+## Development Workflow
+
+```bash
+go build -o ludus.exe -v .        # Build (Windows)
+go build -o ludus -v .            # Build (Linux/macOS)
+go vet ./...                      # Static analysis
+golangci-lint run ./...           # Lint (must pass)
+go test ./...                     # Run all tests
+go test -v ./internal/toolchain   # Run a single package
+```
+
+The pre-commit hook runs build, lint, and tests automatically. All three must pass before committing.
+
+## Pull Request Process
+
+1. Create a branch from `main` with a descriptive name (`feat/`, `fix/`, `docs/`)
+2. Make your changes — keep PRs focused on a single concern
+3. Ensure `golangci-lint run ./...` and `go test ./...` pass
+4. Write a clear PR description explaining **what** changed and **why**
+5. CI runs lint, build, and test on both Ubuntu and Windows — all must pass
+
+## Code Style
+
+- Follow existing patterns — see [AGENTS.md](AGENTS.md) for detailed conventions
+- Use `runner.Runner` for shell execution (never raw `exec.Command`)
+- Two import groups: stdlib, then everything else
+- Table-driven tests with stdlib only (no testify)
+- Error wrapping: `fmt.Errorf("brief context: %w", err)`
+
+## What to Contribute
+
+- Bug fixes with reproduction steps
+- Documentation improvements
+- Test coverage for uncovered packages
+- New deployment target implementations (via `deploy.Target` interface)
+- Platform support improvements (WSL2, macOS)
+
+## Reporting Issues
+
+Use [GitHub Issues](https://github.com/jpvelasco/ludus/issues). For bugs, include:
+- Ludus version (`ludus --version` or `git rev-parse --short HEAD`)
+- OS and UE version
+- Steps to reproduce
+- Full error output (with `--verbose`)
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you agree to uphold it.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,35 @@
+# Security Policy
+
+## Supported Versions
+
+| Version | Supported |
+|---------|-----------|
+| Latest release | Yes |
+| Older releases | No |
+
+## Reporting a Vulnerability
+
+**Do not open a public GitHub issue for security vulnerabilities.**
+
+Instead, please report vulnerabilities via [GitHub Security Advisories](https://github.com/jpvelasco/ludus/security/advisories/new).
+
+Include:
+- Description of the vulnerability
+- Steps to reproduce
+- Impact assessment
+- Suggested fix (if any)
+
+You should receive an acknowledgment within 48 hours. We will work with you to understand the issue and coordinate a fix before any public disclosure.
+
+## Scope
+
+Ludus generates Dockerfiles, executes shell commands, and interacts with AWS APIs. Security-relevant areas include:
+
+- **Generated Dockerfiles** — Ludus includes built-in Dockerfile linting (`ludus doctor`) with rules for root user, unpinned base images, package cleanup, and sensitive environment variables
+- **Shell command execution** — All commands go through `runner.Runner`; no user input is interpolated into shell strings
+- **AWS credentials** — Ludus never stores or logs AWS credentials; it relies on the AWS SDK credential chain
+- **Container images** — Optional Trivy scanning via `ludus doctor` for vulnerability detection
+
+## Dependencies
+
+Ludus uses Dependabot to monitor Go module and GitHub Actions dependencies weekly. Security updates are prioritized.


### PR DESCRIPTION
## Summary

Prepares the repo for open source public preview by adding standard community files and hardening .gitignore.

- **CONTRIBUTING.md** — Dev setup, workflow, code style, PR process
- **CODE_OF_CONDUCT.md** — Contributor Covenant v2.0
- **SECURITY.md** — Vulnerability reporting via GitHub Security Advisories
- **Issue templates** — Bug report + feature request
- **PR template** — Lint/test/manual verification checklist
- **.gitignore** — Profile configs, `.claude/`, extra binaries, scratch scripts

Also set repo description and topics via GitHub API.

## Test plan

- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes
- [x] Pre-commit hooks pass
- [ ] After merge: enable branch protection on `main` (requires public repo)
- [ ] After merge: enable GitHub Security Advisories