### PR TITLE
Scrub personal email and path from public files

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,7 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-**jpvelasco@pm.me**.
+**143497+jpvelasco@users.noreply.github.com**.
 
 All complaints will be reviewed and investigated promptly and fairly.
 

--- a/ludus.example.yaml
+++ b/ludus.example.yaml
@@ -3,7 +3,7 @@
 
 engine:
   # Path to your Unreal Engine source directory
-  sourcePath: "/home/devrecon/Documents/Source/UnrealEngine-5.6.1-release"
+  sourcePath: "/path/to/UnrealEngine-5.6.1-release"
   # Engine version tag
   version: "5.6.1"
   # Max parallel compile jobs (0 = auto-detect based on available RAM)


### PR DESCRIPTION
## Summary

Pre-public-release PII scrub:
- Replace personal email in CODE_OF_CONDUCT.md with GitHub noreply address
- Replace `/home/devrecon/...` path in ludus.example.yaml with generic `/path/to/...`

## Test plan

- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes