### PR TITLE
Streamline AGENTS.md for contributors

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,57 +1,47 @@
-# AGENTS.md
+# Coding Guidelines
 
-Guidelines for AI coding agents working in this repository.
+For contributors and AI coding agents working in this repository.
+See also [ARCHITECTURE.md](ARCHITECTURE.md) for the high-level design and module map.
 
-## Build / Lint / Test Commands
+## Build / Lint / Test
 
 ```bash
 # Build
 go build -o ludus -v              # Linux/macOS
 go build -o ludus.exe -v .        # Windows
-GOOS=windows go build -o /dev/null .  # Cross-compile check from Linux
 
-# Lint (golangci-lint v2 required — v1 does not support Go 1.24)
+# Lint (golangci-lint v2 required)
 golangci-lint run ./...
 
 # Test
 go test ./...                          # All tests
 go test -v ./internal/toolchain        # Single package
 go test -v -run TestParseBuildVersion ./internal/toolchain  # Single test
-go test -v -run TestParseBuildVersion/valid_JSON ./internal/toolchain  # Single subtest
 
 # Other
 go vet ./...                      # Static analysis
 go mod tidy                       # Clean up module dependencies
 ```
 
-Pre-commit hooks (`.hooks/pre-commit`) run `go build ./...`, lint, and `go test ./...`.
+Pre-commit hooks (`.hooks/pre-commit`) run build, lint, and test.
 Activate with `git config core.hooksPath .hooks`.
 
 ## Project Structure
 
 - `main.go` — Entry point; calls `root.Execute()`.
-- `cmd/` — Cobra command packages. Each command package exports `var Cmd = &cobra.Command{...}`,
-  registered in `cmd/root/root.go` via `rootCmd.AddCommand(...)` in `init()`.
-  Handler functions are named `run<Command>`.
-  - **Exceptions**: `cmd/globals/` exports mutable global state (`Cfg`, `Verbose`,
-    `JSONOutput`, `DryRun`), not a `Cmd`. The `init` command is defined as an
-    unexported `initCmd` in `cmd/root/init.go`.
-  - **Subcommand groups**: Some commands are groups with subcommands (e.g., `deploy`
-    has `fleet`, `stack`, `session`, `anywhere`, `destroy`; `engine` has `build`,
-    `setup`, `push`). These `Cmd` vars have no `RunE` of their own.
-  - `cmd/mcp/` — MCP (Model Context Protocol) server for AI agent orchestration
-    via stdio JSON-RPC.
+- `cmd/` — Cobra command packages. Each exports `var Cmd = &cobra.Command{...}`,
+  registered in `cmd/root/root.go`. Handler functions are named `run<Command>`.
+  - `cmd/globals/` exports mutable global state (`Cfg`, `Verbose`, `JSONOutput`, `DryRun`),
+    not a `Cmd`. The `init` command lives in `cmd/root/init.go`.
+  - `cmd/mcp/` — MCP server for AI agent orchestration (21 tools, stdio JSON-RPC).
 - `internal/` — All business logic (unexported). One primary type per file.
-  Key packages: `config`, `runner`, `engine`, `game`, `container`, `deploy`,
-  `gamelift`, `stack`, `ec2fleet`, `binary`, `anywhere`, `tags`, `state`, `cache`,
-  `status`, `prereq`, `toolchain`, `wrapper`, `ci`, `dockerbuild`, `buildgraph`,
-  `pricing`, `diagnose`, `dflint`, `progress`.
+  See [ARCHITECTURE.md](ARCHITECTURE.md) for the full package layout.
 - Config loaded via Viper from `ludus.yaml`.
 - Platform-specific files use `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
 
 ## Code Style
 
-### Formatting & Imports
+### Formatting and Imports
 
 Enforced by `gofmt`. Two import groups separated by a blank line: (1) stdlib,
 (2) everything else (third-party and project imports together, sorted alphabetically).
@@ -66,15 +56,14 @@ import (
 )
 ```
 
-Aliases only to resolve naming conflicts, using concise names. Common patterns
-include AWS type packages (`gltypes`, `cftypes`, `iamtypes`) and cmd-vs-internal
-disambiguation (`engBuilder`, `gameBuilder`, `ctrBuilder`, `internalstatus`).
+Aliases only to resolve naming conflicts. Common patterns: AWS type packages
+(`gltypes`, `cftypes`), cmd-vs-internal disambiguation (`engBuilder`, `gameBuilder`).
 
 ### Naming
 
 - **Packages**: lowercase, single word. Multi-word concatenated (`dockerbuild`).
 - **Files**: `snake_case.go`. Build-tagged: `checker_unix.go`, `process_windows.go`.
-- **Acronyms**: Fully uppercase: `ID`, `URI`, `ARN`, `ECR`, `IAM`, `AWS`, `SDK`, `IP`.
+- **Acronyms**: Fully uppercase: `ID`, `URI`, `ARN`, `ECR`, `IAM`, `AWS`.
 - **Structs**: PascalCase nouns — `Builder`, `Deployer`, `TargetAdapter`.
 - **Options/Results**: `BuildOptions`, `BuildResult`, `DeployOptions`, `FleetStatus`.
 - **Constants**: Unexported camelCase (`iamRoleName`), exported PascalCase (`WrapperRepo`).
@@ -89,25 +78,18 @@ func NewBuilder(opts BuildOptions, r *runner.Runner) *Builder
 ```
 
 Method receivers are single-letter pointer receivers matching the type initial:
-`b` for `*Builder`, `d` for `*Deployer`, `r` for `*Runner`, `c` for `*Checker`.
+`b` for `*Builder`, `d` for `*Deployer`, `r` for `*Runner`.
 
 `context.Context` is the first parameter for all I/O or long-running methods.
-Pure computation functions omit it.
 
 ### Error Handling
 
-- Wrap with `fmt.Errorf("brief context: %w", err)`. Context is lowercase, no
-  trailing punctuation: `"reading config: %w"`, `"creating location: %w"`.
-- Terminal errors (no underlying cause) use `fmt.Errorf` without `%w`.
-- No sentinel errors (`var Err*`) and no custom error types — all errors are
-  `fmt.Errorf` or from library calls.
-- Non-fatal issues: `fmt.Printf("Warning: failed to write state: %v\n", err)`.
-- AWS not-found checks use `smithy.APIError` type assertion (`errors.As()`) for structured error matching.
+- Wrap with `fmt.Errorf("brief context: %w", err)`. Lowercase, no trailing punctuation.
+- No sentinel errors (`var Err*`) and no custom error types.
+- Non-fatal issues: `fmt.Printf("Warning: ...")`.
+- AWS errors: use `smithy.APIError` via `errors.As()` for structured error matching.
 
-### Comments & Output
-
-Doc comments on all exported identifiers, starting with the identifier name.
-Struct fields get inline `//` comments in config types. Inline comments explain "why".
+### Output
 
 No logging library. All output via `fmt`:
 - `fmt.Println` / `fmt.Printf` for status; `fmt.Fprintln(os.Stderr, ...)` for warnings.
@@ -117,8 +99,7 @@ No logging library. All output via `fmt`:
 ## Test Conventions
 
 - **stdlib only** — no testify or assertion libraries.
-- **Same-package tests** (access to unexported symbols): `package toolchain`, not
-  `package toolchain_test`.
+- **Same-package tests** (access to unexported symbols).
 - **Table-driven tests** using anonymous struct slices. Loop variable is `tt`:
   ```go
   tests := []struct{ name string; input string; want int }{ ... }
@@ -127,36 +108,20 @@ No logging library. All output via `fmt`:
   }
   ```
 - **Assertions** via `if got != want` with `t.Errorf` / `t.Fatalf`.
-- **Temp dirs** via `t.TempDir()`, **env overrides** via `t.Setenv()` (both auto-cleaned).
-- **Skip** unavailable tests with `t.Skipf(...)`.
-- Test files are co-located: `builder_test.go` alongside `builder.go`.
+- **Temp dirs** via `t.TempDir()`, **env overrides** via `t.Setenv()`.
+- Test files co-located: `builder_test.go` alongside `builder.go`.
 
 ## Lint Configuration
 
-Enabled linters (`.golangci.yml`, v2 format): errcheck, govet, ineffassign,
-staticcheck, unused, gocritic, misspell, unconvert, gosec.
+`.golangci.yml` (v2 format). Enabled: errcheck, govet, ineffassign, staticcheck,
+unused, gocritic, misspell, unconvert, gosec.
 
 Key gosec exclusions: G104 (unhandled errors in cleanup), G204/G702 (subprocess
 with variable), G304/G703 (file inclusion via variable), G115 (integer overflow),
 G301/G306 (dir/file perms). ST1005 suppressed — error messages may start with
 proper nouns like `Setup.sh`.
 
-## Key Patterns
-
-- **Builder pattern**: `New*(opts)` constructor, operation methods, structured results.
-- **Runner abstraction**: Never call `exec.Command` directly — use `runner.Runner`
-  which handles verbose/dry-run uniformly.
-- **Dual build backends**: Engine and game builds support both `native` and `docker`
-  backends. See `internal/dockerbuild/`.
-- **Pluggable targets**: `deploy.Target` interface with `gamelift`, `stack`, `ec2`,
-  `binary`, `anywhere` implementations. Factory in `cmd/globals/resolve.go`.
-- **State persistence**: `.ludus/state.json` for fleet/session/client info.
-- **Build caching**: `.ludus/cache.json` with input hashing per stage.
-- **Platform dispatch**: `//go:build windows` / `//go:build !windows` pairs with
-  matching function signatures. Minor differences use `runtime.GOOS` inline.
-
 ## UE Source Patches
 
-Ludus patches UE source files at init/build time. See `UE_SOURCE_PATCHES.md` for
-full details on each patch and testing procedures. Use `scripts/validate_ue_versions.sh`
-for multi-version structural validation against UE source tarballs.
+Ludus patches UE source files at init/build time. See [UE_SOURCE_PATCHES.md](UE_SOURCE_PATCHES.md)
+for full details on each patch and testing procedures.


### PR DESCRIPTION
## Summary

Refactor AGENTS.md from internal AI-agent guidance to general contributor coding guidelines.

- Rename title to "Coding Guidelines" — for contributors and their AI agents
- Remove Key Patterns and package list sections (now in ARCHITECTURE.md)
- Add cross-references to ARCHITECTURE.md for module layout
- Remove internal script references
- 163 -> 120 lines, no content duplication with ARCHITECTURE.md

## Test plan

- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes