### PR TITLE
Add README for npm package

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -1,0 +1,65 @@
+# ludus-cli
+
+CLI tool that automates the end-to-end pipeline for deploying Unreal Engine 5 dedicated servers to AWS GameLift.
+
+Ludus handles the entire workflow that would otherwise require dozens of manual steps across multiple tools: UE5 source builds, game server compilation, Docker containerization, ECR push, and GameLift fleet deployment.
+
+## Install
+
+```bash
+npm install -g ludus-cli
+```
+
+Or run directly:
+
+```bash
+npx ludus-cli --help
+```
+
+## What it does
+
+```
+ludus run --verbose
+```
+
+This single command orchestrates six stages:
+
+1. **Prerequisite validation** — OS, engine source, game content, Docker, AWS CLI, disk space, RAM
+2. **Engine build** — UE5 source compilation
+3. **Game server build** — Dedicated server packaging via RunUAT
+4. **Container build** — Dockerfile generation and Docker image build
+5. **ECR push** — Docker image push to Amazon ECR
+6. **GameLift deploy** — Container fleet creation with IAM roles and polling
+
+## Deployment targets
+
+| Target | Command | Docker required? | ARM64 (Graviton) |
+|--------|---------|:---:|:---:|
+| GameLift Containers | `ludus deploy fleet` | Yes | Yes |
+| CloudFormation Stack | `ludus deploy stack` | Yes | Yes |
+| GameLift Managed EC2 | `ludus deploy ec2` | No | Yes |
+| GameLift Anywhere | `ludus deploy anywhere` | No | No |
+| Binary export | `ludus deploy binary` | No | Yes |
+
+## AI Agent Integration (MCP)
+
+Ludus includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server exposing 21 tools. Any MCP-compatible AI agent can orchestrate the full pipeline programmatically.
+
+```json
+{
+  "mcpServers": {
+    "ludus": {
+      "command": "npx",
+      "args": ["-y", "ludus-cli", "mcp"]
+    }
+  }
+}
+```
+
+## Documentation
+
+Full documentation, configuration reference, and prerequisites: [github.com/jpvelasco/ludus](https://github.com/jpvelasco/ludus)
+
+## License
+
+[MIT](https://github.com/jpvelasco/ludus/blob/main/LICENSE)


### PR DESCRIPTION
## Summary
- Add `npm/README.md` so the npm package page shows documentation instead of "This package does not have a README"
- Concise version of the main README: install instructions, feature highlights, deployment targets, MCP config example

## Test plan
- [ ] Verify npm/README.md renders correctly on GitHub
- [ ] After merge + tag, verify npmjs.com/package/ludus-cli shows the README