### PR TITLE
Add keywords to npm package

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -22,6 +22,23 @@
     "x64",
     "arm64"
   ],
+  "keywords": [
+    "unreal-engine",
+    "ue5",
+    "gamelift",
+    "aws",
+    "dedicated-server",
+    "game-server",
+    "gamedev",
+    "deployment",
+    "docker",
+    "mcp",
+    "cli",
+    "devops",
+    "arm64",
+    "graviton",
+    "buildgraph"
+  ],
   "files": [
     "install.js",
     "run.js",


### PR DESCRIPTION
## Summary
- Add 15 search keywords to `npm/package.json` for npm search discoverability
- Keywords: unreal-engine, ue5, gamelift, aws, dedicated-server, game-server, gamedev, deployment, docker, mcp, cli, devops, arm64, graviton, buildgraph

## Test plan
- [ ] After merge + tag, verify `npm view ludus-cli keywords` shows all 15 keywords