### PR TITLE
Add unit tests for core packages

### DIFF
--- a/internal/cache/cache_test.go
+++ b/internal/cache/cache_test.go
@@ -111,6 +111,81 @@ func TestDirManifest(t *testing.T) {
 	}
 }
 
+func TestLoadCorruptedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Write corrupted JSON to the cache file
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachePath(), []byte("{not valid json!!!"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Load()
+	if err == nil {
+		t.Fatal("expected error loading corrupted cache file")
+	}
+}
+
+func TestLoadNullEntries(t *testing.T) {
+	tmpDir := t.TempDir()
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Write valid JSON but with null entries field
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachePath(), []byte(`{"entries": null}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	c, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	// Should initialize nil entries map to empty
+	if c.Entries == nil {
+		t.Fatal("expected non-nil entries map after loading null entries")
+	}
+}
+
+func TestMissReason(t *testing.T) {
+	c := &Cache{Entries: make(map[StageKey]*Entry)}
+
+	reason := c.MissReason(StageEngine, "abc")
+	if reason != "no previous build recorded" {
+		t.Errorf("expected 'no previous build recorded', got %q", reason)
+	}
+
+	c.Set(StageEngine, "abc", "2025-01-01T00:00:00Z")
+
+	reason = c.MissReason(StageEngine, "abc")
+	if reason != "" {
+		t.Errorf("expected empty reason for hit, got %q", reason)
+	}
+
+	reason = c.MissReason(StageEngine, "different")
+	if reason == "" {
+		t.Error("expected non-empty reason for changed inputs")
+	}
+}
+
 func TestHashDeterministic(t *testing.T) {
 	h1 := hash("a", "b", "c")
 	h2 := hash("a", "b", "c")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,490 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaults(t *testing.T) {
+	cfg := Defaults()
+
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"engine backend", cfg.Engine.Backend, "native"},
+		{"engine docker image name", cfg.Engine.DockerImageName, "ludus-engine"},
+		{"engine docker base image", cfg.Engine.DockerBaseImage, "ubuntu:22.04"},
+		{"game project name", cfg.Game.ProjectName, "Lyra"},
+		{"game platform", cfg.Game.Platform, "linux"},
+		{"game arch", cfg.Game.Arch, "amd64"},
+		{"game server map", cfg.Game.ServerMap, "L_Expanse"},
+		{"container image name", cfg.Container.ImageName, "ludus-server"},
+		{"container tag", cfg.Container.Tag, "latest"},
+		{"deploy target", cfg.Deploy.Target, "gamelift"},
+		{"gamelift fleet name", cfg.GameLift.FleetName, "ludus-fleet"},
+		{"gamelift instance type", cfg.GameLift.InstanceType, "c6i.large"},
+		{"gamelift container group", cfg.GameLift.ContainerGroupName, "ludus-container-group"},
+		{"aws region", cfg.AWS.Region, "us-east-1"},
+		{"aws ecr repository", cfg.AWS.ECRRepository, "ludus-server"},
+		{"anywhere location", cfg.Anywhere.LocationName, "custom-ludus-dev"},
+		{"anywhere aws profile", cfg.Anywhere.AWSProfile, "default"},
+		{"ec2fleet sdk version", cfg.EC2Fleet.ServerSDKVersion, "5.4.0"},
+		{"ci workflow path", cfg.CI.WorkflowPath, ".github/workflows/ludus-pipeline.yml"},
+		{"ci runner dir", cfg.CI.RunnerDir, "~/actions-runner"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("got %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+
+	// Numeric defaults
+	if cfg.Engine.MaxJobs != 0 {
+		t.Errorf("engine max jobs: got %d, want 0", cfg.Engine.MaxJobs)
+	}
+	if cfg.Container.ServerPort != 7777 {
+		t.Errorf("container server port: got %d, want 7777", cfg.Container.ServerPort)
+	}
+	if cfg.GameLift.MaxConcurrentSessions != 1 {
+		t.Errorf("gamelift max concurrent sessions: got %d, want 1", cfg.GameLift.MaxConcurrentSessions)
+	}
+
+	// Map defaults
+	if cfg.AWS.Tags["ManagedBy"] != "ludus" {
+		t.Errorf("aws tags ManagedBy: got %q, want %q", cfg.AWS.Tags["ManagedBy"], "ludus")
+	}
+	if len(cfg.CI.RunnerLabels) != 3 {
+		t.Errorf("ci runner labels: got %d labels, want 3", len(cfg.CI.RunnerLabels))
+	}
+}
+
+func TestNormalizeArch(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", "amd64"},
+		{"amd64", "amd64", "amd64"},
+		{"x86_64", "x86_64", "amd64"},
+		{"arm64", "arm64", "arm64"},
+		{"aarch64", "aarch64", "arm64"},
+		{"uppercase AMD64", "AMD64", "amd64"},
+		{"uppercase ARM64", "ARM64", "arm64"},
+		{"mixed case AArch64", "AArch64", "arm64"},
+		{"whitespace", "  arm64  ", "arm64"},
+		{"unknown defaults to amd64", "mips64", "amd64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := NormalizeArch(tt.input)
+			if got != tt.want {
+				t.Errorf("NormalizeArch(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServerPlatformDir(t *testing.T) {
+	tests := []struct {
+		arch string
+		want string
+	}{
+		{"amd64", "LinuxServer"},
+		{"arm64", "LinuxArm64Server"},
+		{"x86_64", "LinuxServer"},
+		{"aarch64", "LinuxArm64Server"},
+		{"", "LinuxServer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			got := ServerPlatformDir(tt.arch)
+			if got != tt.want {
+				t.Errorf("ServerPlatformDir(%q) = %q, want %q", tt.arch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBinariesPlatformDir(t *testing.T) {
+	tests := []struct {
+		arch string
+		want string
+	}{
+		{"amd64", "Linux"},
+		{"arm64", "LinuxArm64"},
+		{"", "Linux"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			got := BinariesPlatformDir(tt.arch)
+			if got != tt.want {
+				t.Errorf("BinariesPlatformDir(%q) = %q, want %q", tt.arch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestUEPlatformName(t *testing.T) {
+	tests := []struct {
+		arch string
+		want string
+	}{
+		{"amd64", "Linux"},
+		{"arm64", "LinuxArm64"},
+		{"", "Linux"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			got := UEPlatformName(tt.arch)
+			if got != tt.want {
+				t.Errorf("UEPlatformName(%q) = %q, want %q", tt.arch, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGameConfig_ResolvedServerTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		serverTarget string
+		projectName  string
+		want         string
+	}{
+		{"explicit target", "MyServer", "MyGame", "MyServer"},
+		{"default from project", "", "MyGame", "MyGameServer"},
+		{"default Lyra", "", "Lyra", "LyraServer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GameConfig{ServerTarget: tt.serverTarget, ProjectName: tt.projectName}
+			got := g.ResolvedServerTarget()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGameConfig_ResolvedClientTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		clientTarget string
+		projectName  string
+		want         string
+	}{
+		{"explicit target", "MyClient", "MyGame", "MyClient"},
+		{"default from project", "", "MyGame", "MyGameGame"},
+		{"default Lyra", "", "Lyra", "LyraGame"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GameConfig{ClientTarget: tt.clientTarget, ProjectName: tt.projectName}
+			got := g.ResolvedClientTarget()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGameConfig_ResolvedGameTarget(t *testing.T) {
+	tests := []struct {
+		name        string
+		gameTarget  string
+		projectName string
+		want        string
+	}{
+		{"explicit target", "MyTarget", "MyGame", "MyTarget"},
+		{"default from project", "", "MyGame", "MyGameGame"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GameConfig{GameTarget: tt.gameTarget, ProjectName: tt.projectName}
+			got := g.ResolvedGameTarget()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGameConfig_ResolvedArch(t *testing.T) {
+	tests := []struct {
+		arch string
+		want string
+	}{
+		{"", "amd64"},
+		{"arm64", "arm64"},
+		{"aarch64", "arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			g := &GameConfig{Arch: tt.arch}
+			got := g.ResolvedArch()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLoad_MissingFile(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load should not fail on missing file: %v", err)
+	}
+
+	// Should return defaults
+	if cfg.Game.ProjectName != "Lyra" {
+		t.Errorf("expected default project name %q, got %q", "Lyra", cfg.Game.ProjectName)
+	}
+}
+
+func TestLoad_ValidYAML(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	yamlContent := `engine:
+  sourcePath: /tmp/ue5
+  version: "5.7.0"
+game:
+  projectName: MyGame
+  arch: arm64
+aws:
+  region: eu-west-1
+`
+	if err := os.WriteFile("ludus.yaml", []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if cfg.Game.ProjectName != "MyGame" {
+		t.Errorf("project name: got %q, want %q", cfg.Game.ProjectName, "MyGame")
+	}
+	if cfg.Game.Arch != "arm64" {
+		t.Errorf("arch: got %q, want %q", cfg.Game.Arch, "arm64")
+	}
+	if cfg.AWS.Region != "eu-west-1" {
+		t.Errorf("region: got %q, want %q", cfg.AWS.Region, "eu-west-1")
+	}
+	// Defaults should still apply for unset fields
+	if cfg.Container.ServerPort != 7777 {
+		t.Errorf("server port should default to 7777, got %d", cfg.Container.ServerPort)
+	}
+}
+
+func TestLoad_ExplicitPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "custom.yaml")
+
+	yamlContent := `game:
+  projectName: CustomGame
+`
+	if err := os.WriteFile(configPath, []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(configPath)
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if cfg.Game.ProjectName != "CustomGame" {
+		t.Errorf("project name: got %q, want %q", cfg.Game.ProjectName, "CustomGame")
+	}
+}
+
+func TestLoad_MalformedYAML(t *testing.T) {
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "bad.yaml")
+
+	// YAML with a mapping value where a sequence is expected triggers a parse error
+	if err := os.WriteFile(configPath, []byte("engine:\n  - sourcePath: x\n    sourcePath: y"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load(configPath)
+	// Viper/YAML may or may not error on subtly invalid YAML, but the result
+	// should either return an error or silently return defaults without panic.
+	if err != nil {
+		return // expected — malformed YAML raised an error
+	}
+	// If no error, verify we at least get a usable config (defensive parse)
+	if cfg == nil {
+		t.Fatal("expected non-nil config even for lenient parse")
+	}
+}
+
+func TestLoad_NegativeCases(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		wantErr bool
+	}{
+		{
+			name:    "empty file",
+			content: "",
+			wantErr: false, // Viper treats empty as no config
+		},
+		{
+			name:    "valid but empty YAML",
+			content: "---\n",
+			wantErr: false,
+		},
+		{
+			name:    "unknown keys ignored",
+			content: "nonexistent:\n  foo: bar\n",
+			wantErr: false,
+		},
+		{
+			name:    "wrong type for port",
+			content: "container:\n  serverPort: not-a-number\n",
+			wantErr: true,
+		},
+		{
+			name:    "wrong type for maxJobs",
+			content: "engine:\n  maxJobs: [1, 2, 3]\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmpDir := t.TempDir()
+			configPath := filepath.Join(tmpDir, "ludus.yaml")
+			if err := os.WriteFile(configPath, []byte(tt.content), 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			_, err := Load(configPath)
+			if tt.wantErr && err == nil {
+				t.Error("expected error, got nil")
+			}
+			if !tt.wantErr && err != nil {
+				t.Errorf("unexpected error: %v", err)
+			}
+		})
+	}
+}
+
+func TestLoad_DeprecatedLyraKey(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	yamlContent := `lyra:
+  projectName: LegacyGame
+  serverMap: TestMap
+`
+	if err := os.WriteFile("ludus.yaml", []byte(yamlContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := Load("")
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if cfg.Game.ProjectName != "LegacyGame" {
+		t.Errorf("project name: got %q, want %q (lyra key migration)", cfg.Game.ProjectName, "LegacyGame")
+	}
+	if cfg.Game.ServerMap != "TestMap" {
+		t.Errorf("server map: got %q, want %q (lyra key migration)", cfg.Game.ServerMap, "TestMap")
+	}
+}
+
+func TestGameConfig_ResolveProjectPath(t *testing.T) {
+	t.Run("already set", func(t *testing.T) {
+		g := &GameConfig{ProjectPath: "/existing/path.uproject"}
+		g.ResolveProjectPath("/engine")
+		if g.ProjectPath != "/existing/path.uproject" {
+			t.Errorf("should not change existing path, got %q", g.ProjectPath)
+		}
+	})
+
+	t.Run("empty engine path", func(t *testing.T) {
+		g := &GameConfig{ProjectName: "Lyra"}
+		g.ResolveProjectPath("")
+		if g.ProjectPath != "" {
+			t.Errorf("should not set path with empty engine path, got %q", g.ProjectPath)
+		}
+	})
+
+	t.Run("Lyra with valid engine path", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		lyraDir := filepath.Join(tmpDir, "Samples", "Games", "Lyra")
+		if err := os.MkdirAll(lyraDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		uproject := filepath.Join(lyraDir, "Lyra.uproject")
+		if err := os.WriteFile(uproject, []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		g := &GameConfig{ProjectName: "Lyra"}
+		g.ResolveProjectPath(tmpDir)
+		if g.ProjectPath != uproject {
+			t.Errorf("got %q, want %q", g.ProjectPath, uproject)
+		}
+	})
+
+	t.Run("Lyra with missing uproject", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		g := &GameConfig{ProjectName: "Lyra"}
+		g.ResolveProjectPath(tmpDir)
+		if g.ProjectPath != "" {
+			t.Errorf("should not set path when uproject missing, got %q", g.ProjectPath)
+		}
+	})
+
+	t.Run("non-Lyra project", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		g := &GameConfig{ProjectName: "MyGame"}
+		g.ResolveProjectPath(tmpDir)
+		if g.ProjectPath != "" {
+			t.Errorf("should not auto-resolve for non-Lyra projects, got %q", g.ProjectPath)
+		}
+	})
+}

--- a/internal/container/builder_test.go
+++ b/internal/container/builder_test.go
@@ -1,0 +1,276 @@
+package container
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveProjectName(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectName string
+		want        string
+	}{
+		{"explicit", "MyGame", "MyGame"},
+		{"empty defaults to Lyra", "", "Lyra"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBuilder(BuildOptions{ProjectName: tt.projectName}, nil)
+			got := b.resolveProjectName()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveServerTarget(t *testing.T) {
+	tests := []struct {
+		name         string
+		serverTarget string
+		projectName  string
+		want         string
+	}{
+		{"explicit", "CustomServer", "", "CustomServer"},
+		{"default from project", "", "MyGame", "MyGameServer"},
+		{"default Lyra", "", "", "LyraServer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBuilder(BuildOptions{
+				ServerTarget: tt.serverTarget,
+				ProjectName:  tt.projectName,
+			}, nil)
+			got := b.resolveServerTarget()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveArch(t *testing.T) {
+	tests := []struct {
+		name string
+		arch string
+		want string
+	}{
+		{"empty defaults to amd64", "", "amd64"},
+		{"amd64", "amd64", "amd64"},
+		{"arm64", "arm64", "arm64"},
+		{"aarch64 normalized", "aarch64", "arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBuilder(BuildOptions{Arch: tt.arch}, nil)
+			got := b.resolveArch()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateDockerfile(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        BuildOptions
+		wantContain []string
+	}{
+		{
+			name: "amd64 defaults",
+			opts: BuildOptions{
+				ServerPort:  7777,
+				ProjectName: "Lyra",
+			},
+			wantContain: []string{
+				"FROM public.ecr.aws/amazonlinux/amazonlinux:2023",
+				"Lyra/Binaries/Linux/LyraServer",
+				"EXPOSE 7777/udp",
+				"USER ueserver",
+				"ENTRYPOINT [\"./amazon-gamelift-servers-game-server-wrapper\"]",
+			},
+		},
+		{
+			name: "arm64",
+			opts: BuildOptions{
+				ServerPort:   7777,
+				ProjectName:  "MyGame",
+				ServerTarget: "MyGameServer",
+				Arch:         "arm64",
+			},
+			wantContain: []string{
+				"MyGame/Binaries/LinuxArm64/MyGameServer",
+				"EXPOSE 7777/udp",
+			},
+		},
+		{
+			name: "custom port",
+			opts: BuildOptions{
+				ServerPort:  9999,
+				ProjectName: "Test",
+			},
+			wantContain: []string{
+				"EXPOSE 9999/udp",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBuilder(tt.opts, nil)
+			dockerfile := b.GenerateDockerfile()
+
+			for _, want := range tt.wantContain {
+				if !strings.Contains(dockerfile, want) {
+					t.Errorf("Dockerfile missing %q\ngot:\n%s", want, dockerfile)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateWrapperConfig(t *testing.T) {
+	tests := []struct {
+		name        string
+		opts        BuildOptions
+		wantContain []string
+	}{
+		{
+			name: "amd64 Lyra",
+			opts: BuildOptions{
+				ServerPort:  7777,
+				ProjectName: "Lyra",
+			},
+			wantContain: []string{
+				"gamePort: 7777",
+				"./Lyra/Binaries/Linux/LyraServer",
+				"\"Lyra\"",
+			},
+		},
+		{
+			name: "arm64 custom",
+			opts: BuildOptions{
+				ServerPort:   8888,
+				ProjectName:  "FPS",
+				ServerTarget: "FPSServer",
+				Arch:         "arm64",
+			},
+			wantContain: []string{
+				"gamePort: 8888",
+				"./FPS/Binaries/LinuxArm64/FPSServer",
+				"\"FPS\"",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBuilder(tt.opts, nil)
+			config := b.GenerateWrapperConfig()
+
+			for _, want := range tt.wantContain {
+				if !strings.Contains(config, want) {
+					t.Errorf("wrapper config missing %q\ngot:\n%s", want, config)
+				}
+			}
+		})
+	}
+}
+
+func TestGenerateDockerignore(t *testing.T) {
+	b := NewBuilder(BuildOptions{}, nil)
+	ignore := b.GenerateDockerignore()
+
+	wantPatterns := []string{"**/*.debug", "**/*.sym", "Manifest_*.txt"}
+	for _, p := range wantPatterns {
+		if !strings.Contains(ignore, p) {
+			t.Errorf("dockerignore missing pattern %q", p)
+		}
+	}
+}
+
+func TestResolveServerBinaryName(t *testing.T) {
+	t.Run("no build dir", func(t *testing.T) {
+		b := NewBuilder(BuildOptions{
+			ProjectName:  "Lyra",
+			ServerTarget: "LyraServer",
+		}, nil)
+		got := b.resolveServerBinaryName()
+		if got != "LyraServer" {
+			t.Errorf("got %q, want %q", got, "LyraServer")
+		}
+	})
+
+	t.Run("development build", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		binDir := filepath.Join(tmpDir, "Lyra", "Binaries", "Linux")
+		if err := os.MkdirAll(binDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Development build: bare target name
+		if err := os.WriteFile(filepath.Join(binDir, "LyraServer"), []byte("binary"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		b := NewBuilder(BuildOptions{
+			ServerBuildDir: tmpDir,
+			ProjectName:    "Lyra",
+			ServerTarget:   "LyraServer",
+		}, nil)
+		got := b.resolveServerBinaryName()
+		if got != "LyraServer" {
+			t.Errorf("got %q, want %q", got, "LyraServer")
+		}
+	})
+
+	t.Run("shipping build", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		binDir := filepath.Join(tmpDir, "Lyra", "Binaries", "Linux")
+		if err := os.MkdirAll(binDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// Shipping build: Target-Platform-Config pattern
+		if err := os.WriteFile(filepath.Join(binDir, "LyraServer-Linux-Shipping"), []byte("binary"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		b := NewBuilder(BuildOptions{
+			ServerBuildDir: tmpDir,
+			ProjectName:    "Lyra",
+			ServerTarget:   "LyraServer",
+		}, nil)
+		got := b.resolveServerBinaryName()
+		if got != "LyraServer-Linux-Shipping" {
+			t.Errorf("got %q, want %q", got, "LyraServer-Linux-Shipping")
+		}
+	})
+
+	t.Run("arm64 shipping build", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		binDir := filepath.Join(tmpDir, "Lyra", "Binaries", "LinuxArm64")
+		if err := os.MkdirAll(binDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(binDir, "LyraServer-LinuxArm64-Shipping"), []byte("binary"), 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		b := NewBuilder(BuildOptions{
+			ServerBuildDir: tmpDir,
+			ProjectName:    "Lyra",
+			ServerTarget:   "LyraServer",
+			Arch:           "arm64",
+		}, nil)
+		got := b.resolveServerBinaryName()
+		if got != "LyraServer-LinuxArm64-Shipping" {
+			t.Errorf("got %q, want %q", got, "LyraServer-LinuxArm64-Shipping")
+		}
+	})
+}

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -1,0 +1,180 @@
+package pricing
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEstimateCost(t *testing.T) {
+	tests := []struct {
+		name         string
+		instanceType string
+		wantOK       bool
+		wantPrice    float64
+	}{
+		{"known c6i.large", "c6i.large", true, 0.085},
+		{"known c6g.large", "c6g.large", true, 0.068},
+		{"known c7g.large", "c7g.large", true, 0.072},
+		{"unknown type", "z99.mega", false, 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			price, ok := EstimateCost(tt.instanceType)
+			if ok != tt.wantOK {
+				t.Errorf("ok: got %v, want %v", ok, tt.wantOK)
+			}
+			if tt.wantOK && price != tt.wantPrice {
+				t.Errorf("price: got %f, want %f", price, tt.wantPrice)
+			}
+		})
+	}
+}
+
+func TestFormatEstimate(t *testing.T) {
+	tests := []struct {
+		name         string
+		instanceType string
+		wantEmpty    bool
+		wantContain  string
+	}{
+		{"known type", "c6i.large", false, "$0.085/hr"},
+		{"unknown type", "z99.mega", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatEstimate(tt.instanceType)
+			if tt.wantEmpty && result != "" {
+				t.Errorf("expected empty string, got %q", result)
+			}
+			if !tt.wantEmpty && !strings.Contains(result, tt.wantContain) {
+				t.Errorf("expected result to contain %q, got %q", tt.wantContain, result)
+			}
+		})
+	}
+}
+
+func TestDefaultInstanceType(t *testing.T) {
+	tests := []struct {
+		arch string
+		want string
+	}{
+		{"amd64", "c6i.large"},
+		{"arm64", "c7g.large"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.arch, func(t *testing.T) {
+			got := DefaultInstanceType(tt.arch)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstanceArch(t *testing.T) {
+	tests := []struct {
+		instanceType string
+		want         string
+	}{
+		{"c6i.large", "amd64"},
+		{"c6g.large", "arm64"},
+		{"c7g.xlarge", "arm64"},
+		{"m5.large", "amd64"},
+		{"m6g.large", "arm64"},
+		{"r5.large", "amd64"},
+		{"z99.mega", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.instanceType, func(t *testing.T) {
+			got := InstanceArch(tt.instanceType)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFormatSuggestion(t *testing.T) {
+	tests := []struct {
+		name      string
+		current   string
+		arch      string
+		wantEmpty bool
+		wantPart  string
+	}{
+		{"arm64 no suggestion", "c6g.large", "arm64", true, ""},
+		{"amd64 with alternative", "c6i.large", "amd64", false, "c6g.large"},
+		{"amd64 c5 with alternative", "c5.large", "amd64", false, "c6g.large"},
+		{"amd64 no alternative", "r5.large", "amd64", true, ""},
+		{"unknown type", "z99.mega", "amd64", true, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := FormatSuggestion(tt.current, tt.arch)
+			if tt.wantEmpty && result != "" {
+				t.Errorf("expected empty, got %q", result)
+			}
+			if !tt.wantEmpty && !strings.Contains(result, tt.wantPart) {
+				t.Errorf("expected to contain %q, got %q", tt.wantPart, result)
+			}
+		})
+	}
+}
+
+func TestFormatGuidance(t *testing.T) {
+	t.Run("amd64 default", func(t *testing.T) {
+		result := FormatGuidance("c6i.large", "amd64")
+		if !strings.Contains(result, "c6i.large") {
+			t.Error("should include c6i.large")
+		}
+		if !strings.Contains(result, "current") {
+			t.Error("should mark current instance")
+		}
+		if !strings.Contains(result, "Graviton") {
+			t.Error("should mention Graviton alternatives for amd64")
+		}
+	})
+
+	t.Run("arm64", func(t *testing.T) {
+		result := FormatGuidance("c7g.large", "arm64")
+		if !strings.Contains(result, "c7g.large") {
+			t.Error("should include c7g.large")
+		}
+		if !strings.Contains(result, "c6g.large") {
+			t.Error("should include c6g instances for arm64")
+		}
+	})
+
+	t.Run("no current type", func(t *testing.T) {
+		result := FormatGuidance("", "")
+		if strings.Contains(result, "current:") {
+			t.Error("should not show current type when empty")
+		}
+	})
+}
+
+func TestInstanceCatalogConsistency(t *testing.T) {
+	// Every instance in the catalog should have a price in the map
+	for _, inst := range instances {
+		price, ok := EstimateCost(inst.Type)
+		if !ok {
+			t.Errorf("instance %s missing from price map", inst.Type)
+		}
+		if price != inst.PriceUSD {
+			t.Errorf("instance %s: price map %f != catalog %f", inst.Type, price, inst.PriceUSD)
+		}
+	}
+}
+
+func TestInstanceArchValues(t *testing.T) {
+	for _, inst := range instances {
+		if inst.Arch != "amd64" && inst.Arch != "arm64" {
+			t.Errorf("instance %s has invalid arch %q", inst.Type, inst.Arch)
+		}
+	}
+}

--- a/internal/state/state_test.go
+++ b/internal/state/state_test.go
@@ -1,0 +1,592 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStatePathForProfile(t *testing.T) {
+	tests := []struct {
+		name    string
+		profile string
+		want    string
+	}{
+		{"default", "", filepath.Join(".ludus", "state.json")},
+		{"named", "staging", filepath.Join(".ludus", "profiles", "staging.json")},
+		{"another", "prod", filepath.Join(".ludus", "profiles", "prod.json")},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := statePathForProfile(tt.profile)
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetAndActiveProfile(t *testing.T) {
+	// Save and restore the original profile
+	orig := activeProfile
+	defer func() { activeProfile = orig }()
+
+	SetProfile("test-profile")
+	if ActiveProfile() != "test-profile" {
+		t.Errorf("got %q, want %q", ActiveProfile(), "test-profile")
+	}
+
+	SetProfile("")
+	if ActiveProfile() != "" {
+		t.Errorf("got %q, want empty", ActiveProfile())
+	}
+}
+
+func TestLoadSaveRoundtrip(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	// Save and restore the profile
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	s := &State{
+		Fleet: &FleetState{
+			FleetID:   "fleet-123",
+			Status:    "active",
+			CreatedAt: "2025-01-01T00:00:00Z",
+		},
+		Session: &SessionState{
+			SessionID: "session-456",
+			IPAddress: "10.0.0.1",
+			Port:      7777,
+			Status:    "active",
+		},
+	}
+
+	if err := Save(s); err != nil {
+		t.Fatalf("Save failed: %v", err)
+	}
+
+	loaded, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+
+	if loaded.Fleet == nil {
+		t.Fatal("expected fleet state after roundtrip")
+	}
+	if loaded.Fleet.FleetID != "fleet-123" {
+		t.Errorf("fleet ID: got %q, want %q", loaded.Fleet.FleetID, "fleet-123")
+	}
+	if loaded.Session == nil {
+		t.Fatal("expected session state after roundtrip")
+	}
+	if loaded.Session.IPAddress != "10.0.0.1" {
+		t.Errorf("session IP: got %q, want %q", loaded.Session.IPAddress, "10.0.0.1")
+	}
+	if loaded.Session.Port != 7777 {
+		t.Errorf("session port: got %d, want 7777", loaded.Session.Port)
+	}
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	s, err := Load()
+	if err != nil {
+		t.Fatalf("Load should not fail on missing file: %v", err)
+	}
+	if s.Fleet != nil || s.Session != nil {
+		t.Fatal("expected nil fleet and session for missing file")
+	}
+}
+
+func TestUpdateAndClearFleet(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	if err := UpdateFleet(&FleetState{FleetID: "f-1", Status: "active"}); err != nil {
+		t.Fatalf("UpdateFleet: %v", err)
+	}
+
+	s, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Fleet == nil || s.Fleet.FleetID != "f-1" {
+		t.Fatal("fleet not updated")
+	}
+
+	if err := ClearFleet(); err != nil {
+		t.Fatalf("ClearFleet: %v", err)
+	}
+
+	s, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Fleet != nil {
+		t.Error("fleet should be nil after clear")
+	}
+	if s.Session != nil {
+		t.Error("session should also be cleared with fleet")
+	}
+}
+
+func TestUpdateAndClearSession(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	if err := UpdateSession(&SessionState{SessionID: "s-1", IPAddress: "1.2.3.4", Port: 7777}); err != nil {
+		t.Fatalf("UpdateSession: %v", err)
+	}
+
+	s, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Session == nil || s.Session.SessionID != "s-1" {
+		t.Fatal("session not updated")
+	}
+
+	if err := ClearSession(); err != nil {
+		t.Fatalf("ClearSession: %v", err)
+	}
+
+	s, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Session != nil {
+		t.Error("session should be nil after clear")
+	}
+}
+
+func TestProfileIsolation(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+
+	// Write to default profile
+	SetProfile("")
+	if err := UpdateFleet(&FleetState{FleetID: "default-fleet"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write to named profile
+	SetProfile("staging")
+	if err := UpdateFleet(&FleetState{FleetID: "staging-fleet"}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back default — should have default-fleet
+	SetProfile("")
+	s, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Fleet == nil || s.Fleet.FleetID != "default-fleet" {
+		t.Errorf("default profile: got fleet %v, want default-fleet", s.Fleet)
+	}
+
+	// Read back staging — should have staging-fleet
+	SetProfile("staging")
+	s, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Fleet == nil || s.Fleet.FleetID != "staging-fleet" {
+		t.Errorf("staging profile: got fleet %v, want staging-fleet", s.Fleet)
+	}
+}
+
+func TestListProfiles(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+
+	// No profiles dir yet
+	profiles, err := ListProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(profiles) != 0 {
+		t.Errorf("expected 0 profiles, got %d", len(profiles))
+	}
+
+	// Create profiles by writing to them
+	SetProfile("beta")
+	if err := Save(&State{}); err != nil {
+		t.Fatal(err)
+	}
+	SetProfile("alpha")
+	if err := Save(&State{}); err != nil {
+		t.Fatal(err)
+	}
+
+	profiles, err = ListProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(profiles) != 2 {
+		t.Fatalf("expected 2 profiles, got %d", len(profiles))
+	}
+	// Should be sorted
+	if profiles[0] != "alpha" || profiles[1] != "beta" {
+		t.Errorf("expected [alpha beta], got %v", profiles)
+	}
+}
+
+func TestDeleteProfile(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+
+	// Cannot delete default
+	if err := DeleteProfile(""); err == nil {
+		t.Error("expected error deleting default profile")
+	}
+
+	// Cannot delete non-existent
+	if err := DeleteProfile("ghost"); err == nil {
+		t.Error("expected error deleting non-existent profile")
+	}
+
+	// Create and delete
+	SetProfile("temp")
+	if err := Save(&State{}); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := DeleteProfile("temp"); err != nil {
+		t.Fatalf("DeleteProfile: %v", err)
+	}
+
+	profiles, err := ListProfiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, p := range profiles {
+		if p == "temp" {
+			t.Error("profile 'temp' should have been deleted")
+		}
+	}
+}
+
+func TestLoadCorruptedStateFile(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	// Write corrupted JSON
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, stateFile), []byte("{corrupt!!!"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = Load()
+	if err == nil {
+		t.Fatal("expected error loading corrupted state file")
+	}
+}
+
+func TestLoadEmptyJSONState(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	// Write valid but empty JSON object
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, stateFile), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load()
+	if err != nil {
+		t.Fatalf("Load failed: %v", err)
+	}
+	if s.Fleet != nil || s.Session != nil || s.Deploy != nil {
+		t.Error("expected all nil fields for empty JSON state")
+	}
+}
+
+func TestUpdateDeploy(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	if err := UpdateDeploy(&DeployState{
+		TargetName: "gamelift",
+		Status:     "active",
+		Detail:     "fleet-abc",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Deploy == nil {
+		t.Fatal("expected deploy state")
+	}
+	if s.Deploy.TargetName != "gamelift" {
+		t.Errorf("target name: got %q, want %q", s.Deploy.TargetName, "gamelift")
+	}
+}
+
+func TestUpdateEC2Fleet(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	if err := UpdateEC2Fleet(&EC2FleetState{
+		FleetID:  "ec2-fleet-1",
+		BuildID:  "build-1",
+		S3Bucket: "my-bucket",
+		Status:   "active",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.EC2Fleet == nil || s.EC2Fleet.FleetID != "ec2-fleet-1" {
+		t.Fatal("EC2 fleet not updated")
+	}
+
+	if err := ClearEC2Fleet(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.EC2Fleet != nil {
+		t.Error("EC2 fleet should be nil after clear")
+	}
+}
+
+func TestUpdateAnywhere(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	if err := UpdateAnywhere(&AnywhereState{
+		FleetID:    "anywhere-1",
+		IPAddress:  "192.168.1.1",
+		ServerPort: 7777,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Anywhere == nil || s.Anywhere.FleetID != "anywhere-1" {
+		t.Fatal("anywhere not updated")
+	}
+
+	if err := ClearAnywhere(); err != nil {
+		t.Fatal(err)
+	}
+	s, err = Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Anywhere != nil {
+		t.Error("anywhere should be nil after clear")
+	}
+}
+
+func TestUpdateEngineImage(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	if err := UpdateEngineImage(&EngineImageState{
+		ImageTag: "ludus-engine:5.7",
+		Version:  "5.7",
+		BuiltAt:  "2025-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.EngineImage == nil || s.EngineImage.ImageTag != "ludus-engine:5.7" {
+		t.Fatal("engine image not updated")
+	}
+}
+
+func TestUpdateClient(t *testing.T) {
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	tmpDir := t.TempDir()
+	if err := os.Chdir(tmpDir); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(origDir) }()
+
+	origProfile := activeProfile
+	defer func() { activeProfile = origProfile }()
+	SetProfile("")
+
+	if err := UpdateClient(&ClientState{
+		BinaryPath: "/path/to/client",
+		Platform:   "Win64",
+		BuiltAt:    "2025-01-01T00:00:00Z",
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	s, err := Load()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Client == nil || s.Client.Platform != "Win64" {
+		t.Fatal("client not updated")
+	}
+}

--- a/internal/tags/tags_test.go
+++ b/internal/tags/tags_test.go
@@ -1,0 +1,232 @@
+package tags
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/devrecon/ludus/internal/config"
+)
+
+func TestBuild_DefaultTags(t *testing.T) {
+	cfg := config.Defaults()
+	tags := Build(cfg)
+
+	if tags["ManagedBy"] != "ludus" {
+		t.Errorf("ManagedBy: got %q, want %q", tags["ManagedBy"], "ludus")
+	}
+	if tags["Project"] != "Lyra" {
+		t.Errorf("Project: got %q, want %q", tags["Project"], "Lyra")
+	}
+}
+
+func TestBuild_CustomTags(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.AWS.Tags = map[string]string{
+		"Environment": "prod",
+		"Team":        "platform",
+	}
+	cfg.Game.ProjectName = "MyGame"
+
+	tags := Build(cfg)
+
+	if tags["Environment"] != "prod" {
+		t.Errorf("Environment: got %q, want %q", tags["Environment"], "prod")
+	}
+	if tags["Team"] != "platform" {
+		t.Errorf("Team: got %q, want %q", tags["Team"], "platform")
+	}
+	if tags["Project"] != "MyGame" {
+		t.Errorf("Project: got %q, want %q", tags["Project"], "MyGame")
+	}
+	if tags["ManagedBy"] != "ludus" {
+		t.Errorf("ManagedBy: got %q, want %q", tags["ManagedBy"], "ludus")
+	}
+}
+
+func TestBuild_UserOverridesManagedBy(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.AWS.Tags = map[string]string{
+		"ManagedBy": "custom-tool",
+	}
+
+	tags := Build(cfg)
+	if tags["ManagedBy"] != "custom-tool" {
+		t.Errorf("ManagedBy should be overridable, got %q", tags["ManagedBy"])
+	}
+}
+
+func TestBuild_UserOverridesProject(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.AWS.Tags = map[string]string{
+		"Project": "ExplicitProject",
+	}
+	cfg.Game.ProjectName = "IgnoredProject"
+
+	tags := Build(cfg)
+	if tags["Project"] != "ExplicitProject" {
+		t.Errorf("user-set Project should not be overridden, got %q", tags["Project"])
+	}
+}
+
+func TestBuild_EmptyProjectName(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Game.ProjectName = ""
+	cfg.AWS.Tags = map[string]string{}
+
+	tags := Build(cfg)
+	if _, ok := tags["Project"]; ok {
+		t.Error("Project tag should not be set when project name is empty")
+	}
+}
+
+func TestMerge(t *testing.T) {
+	base := map[string]string{"A": "1", "B": "2"}
+	extra := map[string]string{"B": "override", "C": "3"}
+
+	result := Merge(base, extra)
+
+	if result["A"] != "1" {
+		t.Errorf("A: got %q, want %q", result["A"], "1")
+	}
+	if result["B"] != "override" {
+		t.Errorf("B: got %q, want %q", result["B"], "override")
+	}
+	if result["C"] != "3" {
+		t.Errorf("C: got %q, want %q", result["C"], "3")
+	}
+
+	// Original should not be modified
+	if base["B"] != "2" {
+		t.Error("Merge should not modify base map")
+	}
+}
+
+func TestMerge_MultipleExtras(t *testing.T) {
+	base := map[string]string{"A": "1"}
+	extra1 := map[string]string{"B": "2"}
+	extra2 := map[string]string{"B": "3", "C": "4"}
+
+	result := Merge(base, extra1, extra2)
+	if result["B"] != "3" {
+		t.Errorf("later extras should override earlier: got %q, want %q", result["B"], "3")
+	}
+	if result["C"] != "4" {
+		t.Errorf("C: got %q, want %q", result["C"], "4")
+	}
+}
+
+func TestWithResourceName(t *testing.T) {
+	base := map[string]string{"ManagedBy": "ludus"}
+	result := WithResourceName(base, "my-fleet")
+
+	if result["Name"] != "my-fleet" {
+		t.Errorf("Name: got %q, want %q", result["Name"], "my-fleet")
+	}
+	if result["ManagedBy"] != "ludus" {
+		t.Errorf("ManagedBy should be preserved, got %q", result["ManagedBy"])
+	}
+	// Original should not be modified
+	if _, ok := base["Name"]; ok {
+		t.Error("WithResourceName should not modify original map")
+	}
+}
+
+func TestToTemplateTags_Deterministic(t *testing.T) {
+	tags := map[string]string{
+		"Zebra":  "z",
+		"Apple":  "a",
+		"Mango":  "m",
+		"Banana": "b",
+	}
+
+	result1 := ToTemplateTags(tags)
+	result2 := ToTemplateTags(tags)
+
+	if result1 != result2 {
+		t.Error("ToTemplateTags should be deterministic")
+	}
+
+	// Verify sorted order
+	appleIdx := strings.Index(result1, "Apple")
+	bananaIdx := strings.Index(result1, "Banana")
+	mangoIdx := strings.Index(result1, "Mango")
+	zebraIdx := strings.Index(result1, "Zebra")
+
+	if appleIdx > bananaIdx || bananaIdx > mangoIdx || mangoIdx > zebraIdx {
+		t.Errorf("tags should be sorted alphabetically by key")
+	}
+}
+
+func TestToTemplateTags_ValidJSON(t *testing.T) {
+	tags := map[string]string{
+		"Key1": "Value1",
+		"Key2": "Value2",
+	}
+
+	result := ToTemplateTags(tags)
+
+	var parsed []struct {
+		Key   string `json:"Key"`
+		Value string `json:"Value"`
+	}
+	if err := json.Unmarshal([]byte(result), &parsed); err != nil {
+		t.Fatalf("result should be valid JSON: %v\ngot: %s", err, result)
+	}
+	if len(parsed) != 2 {
+		t.Errorf("expected 2 tags, got %d", len(parsed))
+	}
+}
+
+func TestToGameLiftTags(t *testing.T) {
+	tags := map[string]string{"Key1": "Val1", "Key2": "Val2"}
+	result := ToGameLiftTags(tags)
+
+	if len(result) != 2 {
+		t.Fatalf("expected 2 tags, got %d", len(result))
+	}
+
+	found := make(map[string]string)
+	for _, tag := range result {
+		found[*tag.Key] = *tag.Value
+	}
+	if found["Key1"] != "Val1" || found["Key2"] != "Val2" {
+		t.Errorf("unexpected tag values: %v", found)
+	}
+}
+
+func TestToIAMTags(t *testing.T) {
+	tags := map[string]string{"Role": "server"}
+	result := ToIAMTags(tags)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(result))
+	}
+	if *result[0].Key != "Role" || *result[0].Value != "server" {
+		t.Errorf("unexpected tag: %v", result[0])
+	}
+}
+
+func TestToCFNTags(t *testing.T) {
+	tags := map[string]string{"Stack": "game"}
+	result := ToCFNTags(tags)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(result))
+	}
+	if *result[0].Key != "Stack" || *result[0].Value != "game" {
+		t.Errorf("unexpected tag: %v", result[0])
+	}
+}
+
+func TestToS3Tags(t *testing.T) {
+	tags := map[string]string{"Bucket": "builds"}
+	result := ToS3Tags(tags)
+
+	if len(result) != 1 {
+		t.Fatalf("expected 1 tag, got %d", len(result))
+	}
+	if *result[0].Key != "Bucket" || *result[0].Value != "builds" {
+		t.Errorf("unexpected tag: %v", result[0])
+	}
+}


### PR DESCRIPTION
## Summary

- Add unit tests for 5 previously untested packages: `config`, `container`, `pricing`, `state`, `tags`
- Enhance existing `cache` tests with negative-path coverage (corrupted files, null entries, miss reasons)
- 1,845 lines of new test code across 6 files

## Package Coverage

| Package | Before | After |
|---------|--------|-------|
| `config` | 0% | **96.3%** |
| `pricing` | 0% | **96.9%** |
| `tags` | 0% | **100%** |
| `state` | 0% | **82.8%** |
| `container` | 0% | **25.4%** |
| `cache` | 49.2% | **54%+** |

## What's Tested

- **config**: Defaults, arch normalization (10 cases), platform dir helpers, resolved targets, YAML loading (missing/valid/explicit path/deprecated `lyra:` migration), negative cases (wrong types, empty files)
- **container**: Project/target/arch resolution, Dockerfile generation (amd64/arm64), wrapper config generation, dockerignore, server binary detection (dev vs shipping builds)
- **state**: Load/save roundtrips, profile isolation, all update/clear helpers (fleet, session, deploy, EC2, Anywhere, engine image, client), corrupted and empty state files, profile listing and deletion
- **tags**: Build with defaults/custom/overrides, merge behavior, resource naming, SDK conversions (GameLift, IAM, CFN, S3), deterministic JSON template output
- **pricing**: Cost lookups, instance arch detection, Graviton suggestions, format helpers, catalog consistency checks
- **cache**: Corrupted JSON handling, null entries recovery, miss reason messages

## Test Plan

- [x] `go test ./...` — all pass
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] Pre-commit hooks pass (build + lint + tests)