### PR TITLE
Add README badges, quickstart section, and fix disk space requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@
   <a href="https://github.com/jpvelasco/ludus/releases/latest"><img src="https://img.shields.io/github/v/release/jpvelasco/ludus?include_prereleases" alt="Release"></a>
   <a href="https://github.com/jpvelasco/ludus/blob/main/LICENSE"><img src="https://img.shields.io/github/license/jpvelasco/ludus" alt="License"></a>
   <a href="https://github.com/jpvelasco/ludus/blob/main/go.mod"><img src="https://img.shields.io/github/go-mod/go-version/jpvelasco/ludus" alt="Go"></a>
+  <a href="https://goreportcard.com/report/github.com/jpvelasco/ludus"><img src="https://goreportcard.com/badge/github.com/jpvelasco/ludus" alt="Go Report Card"></a>
+  <a href="https://www.npmjs.com/package/ludus-cli"><img src="https://img.shields.io/npm/v/ludus-cli" alt="npm"></a>
 </p>
 
 # Ludus
@@ -22,6 +24,24 @@ That's what this project does. Ludus is the training ground — it takes your ga
 A CLI tool that automates the end-to-end pipeline for deploying Unreal Engine 5 dedicated servers to AWS GameLift.
 
 Ludus handles the entire workflow that would otherwise require dozens of manual steps across multiple tools: UE5 source builds, game server compilation, Docker containerization, ECR push, and GameLift fleet deployment. For local development, GameLift Anywhere mode skips containers entirely — fleet creation takes seconds instead of minutes. While Lyra (Epic's sample game) is the default project, Ludus supports any UE5 game with dedicated server targets.
+
+## Quickstart
+
+```bash
+# Install
+npm install -g ludus-cli
+
+# Configure (edit ludus.yaml with your engine path and AWS settings)
+ludus setup
+
+# Validate your environment
+ludus init --verbose
+
+# Run the full pipeline
+ludus run --verbose
+```
+
+**Prerequisites at a glance**: UE5 source build, Docker, AWS CLI v2, Go 1.24+, 16 GB RAM, 300 GB disk. See [detailed prerequisites](#prerequisites) below.
 
 ## What it does
 
@@ -44,7 +64,7 @@ This single command orchestrates six stages:
 
 - **OS**: Windows 10/11 or Linux x86_64 (Ubuntu recommended)
 - **RAM**: 16 GB minimum (UE5 linking uses ~8 GB per job)
-- **Disk**: 100 GB free (after engine source is on disk)
+- **Disk**: 300 GB free (a fully built UE5 engine occupies 280–320 GB)
 - **Go**: 1.24+
 
 ### External tools

--- a/internal/prereq/checker_unix.go
+++ b/internal/prereq/checker_unix.go
@@ -29,7 +29,7 @@ func (c *Checker) checkDiskSpace() CheckResult {
 	}
 
 	freeGB := (stat.Bavail * uint64(stat.Bsize)) / (1024 * 1024 * 1024)
-	const requiredGB = 100
+	const requiredGB = 300
 
 	if freeGB < requiredGB {
 		return CheckResult{

--- a/internal/prereq/checker_windows.go
+++ b/internal/prereq/checker_windows.go
@@ -1071,7 +1071,7 @@ func (c *Checker) checkDiskSpace() CheckResult {
 	}
 
 	freeGB := freeBytesAvailable / (1024 * 1024 * 1024)
-	const requiredGB = 100
+	const requiredGB = 300
 
 	if freeGB < requiredGB {
 		return CheckResult{


### PR DESCRIPTION
## Summary

- Add Go Report Card and npm version badges to README header
- Add quickstart section with 4-command getting started flow and prerequisites one-liner
- Update disk space requirement from 100 GB to 300 GB across README and both platform prereq checkers (measured: a fully built UE5 engine occupies 280–320 GB across versions 5.4–5.7)

## Test plan

- [ ] CI passes (build, lint, tests on ubuntu + windows)
- [ ] Verify badges render on GitHub README
- [ ] Verify quickstart anchor link to prerequisites works