### PR TITLE
Bump Node.js from 20 to 22 LTS in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "22"
           registry-url: "https://registry.npmjs.org"
 
       - name: Embed binary checksums into npm package


### PR DESCRIPTION
## Summary

- Update `actions/setup-node` from Node.js 20 to 22 (current LTS) in the release workflow
- Node.js 20 reaches EOL April 2026

## Test plan

- [ ] CI passes
- [ ] Release workflow syntax is valid (verified: only `node-version` value changed)