### PR TITLE
Add retry with exponential backoff for network-dependent CLI commands

### DIFF
--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/retry"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/wrapper"
 )
@@ -381,14 +382,22 @@ func (b *Builder) Push(ctx context.Context, opts PushOptions) error {
 		}
 	}
 
-	// Authenticate with ECR — get password then pipe to docker login (no shell)
+	// Authenticate with ECR — get password then pipe to docker login (no shell).
+	// Both steps are retried since ECR auth tokens can fail on transient errors.
 	loginURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", opts.AWSAccountID, opts.AWSRegion)
-	password, err := b.Runner.RunOutput(ctx, "aws", "ecr", "get-login-password", "--region", opts.AWSRegion)
-	if err != nil {
+	retryCfg := retry.Default()
+	var password []byte
+	if err := retry.Do(ctx, retryCfg, func() error {
+		var err error
+		password, err = b.Runner.RunOutput(ctx, "aws", "ecr", "get-login-password", "--region", opts.AWSRegion)
+		return err
+	}); err != nil {
 		return fmt.Errorf("getting ECR password: %w", err)
 	}
-	if err := b.Runner.RunWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
-		"docker", "login", "--username", "AWS", "--password-stdin", loginURI); err != nil {
+	if err := retry.Do(ctx, retryCfg, func() error {
+		return b.Runner.RunWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
+			"docker", "login", "--username", "AWS", "--password-stdin", loginURI)
+	}); err != nil {
 		return fmt.Errorf("ECR login failed: %w", err)
 	}
 
@@ -399,8 +408,10 @@ func (b *Builder) Push(ctx context.Context, opts PushOptions) error {
 		return fmt.Errorf("docker tag failed: %w", err)
 	}
 
-	// Push to ECR
-	if err := b.Runner.Run(ctx, "docker", "push", remoteTag); err != nil {
+	// Push to ECR — retried since large uploads are vulnerable to network errors.
+	if err := retry.Do(ctx, retryCfg, func() error {
+		return b.Runner.Run(ctx, "docker", "push", remoteTag)
+	}); err != nil {
 		return fmt.Errorf("docker push failed: %w", err)
 	}
 

--- a/internal/dockerbuild/engine.go
+++ b/internal/dockerbuild/engine.go
@@ -9,6 +9,7 @@ import (
 
 	"strings"
 
+	"github.com/devrecon/ludus/internal/retry"
 	"github.com/devrecon/ludus/internal/runner"
 )
 
@@ -159,14 +160,22 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts PushOptions) error {
 		}
 	}
 
-	// Authenticate with ECR — get password then pipe to docker login (no shell)
+	// Authenticate with ECR — get password then pipe to docker login (no shell).
+	// Both steps are retried since ECR auth tokens can fail on transient errors.
 	loginURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", opts.AWSAccountID, opts.AWSRegion)
-	password, err := b.Runner.RunOutput(ctx, "aws", "ecr", "get-login-password", "--region", opts.AWSRegion)
-	if err != nil {
+	retryCfg := retry.Default()
+	var password []byte
+	if err := retry.Do(ctx, retryCfg, func() error {
+		var err error
+		password, err = b.Runner.RunOutput(ctx, "aws", "ecr", "get-login-password", "--region", opts.AWSRegion)
+		return err
+	}); err != nil {
 		return fmt.Errorf("getting ECR password: %w", err)
 	}
-	if err := b.Runner.RunWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
-		"docker", "login", "--username", "AWS", "--password-stdin", loginURI); err != nil {
+	if err := retry.Do(ctx, retryCfg, func() error {
+		return b.Runner.RunWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
+			"docker", "login", "--username", "AWS", "--password-stdin", loginURI)
+	}); err != nil {
 		return fmt.Errorf("ECR login failed: %w", err)
 	}
 
@@ -181,8 +190,10 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts PushOptions) error {
 		return fmt.Errorf("docker tag failed: %w", err)
 	}
 
-	// Push to ECR
-	if err := b.Runner.Run(ctx, "docker", "push", remoteTag); err != nil {
+	// Push to ECR — retried since engine images are very large (60-100 GB).
+	if err := retry.Do(ctx, retryCfg, func() error {
+		return b.Runner.Run(ctx, "docker", "push", remoteTag)
+	}); err != nil {
 		return fmt.Errorf("docker push failed: %w", err)
 	}
 

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,80 @@
+package retry
+
+import (
+	"context"
+	"fmt"
+	"math"
+	"math/rand/v2"
+	"time"
+)
+
+// Config controls retry behavior.
+type Config struct {
+	// MaxAttempts is the total number of attempts (1 = no retry). Default 3.
+	MaxAttempts int
+	// BaseDelay is the initial delay before the first retry. Default 1s.
+	BaseDelay time.Duration
+	// MaxDelay caps the backoff delay. Default 30s.
+	MaxDelay time.Duration
+}
+
+// Default returns a Config suitable for CLI commands (docker push, git clone, etc.).
+func Default() Config {
+	return Config{
+		MaxAttempts: 3,
+		BaseDelay:   time.Second,
+		MaxDelay:    30 * time.Second,
+	}
+}
+
+// Do calls fn up to cfg.MaxAttempts times with exponential backoff and jitter.
+// It returns nil on the first successful call or the last error if all attempts fail.
+// The context is checked between attempts; cancellation stops retries immediately.
+func Do(ctx context.Context, cfg Config, fn func() error) error {
+	if cfg.MaxAttempts <= 0 {
+		cfg.MaxAttempts = 3
+	}
+	if cfg.BaseDelay <= 0 {
+		cfg.BaseDelay = time.Second
+	}
+	if cfg.MaxDelay <= 0 {
+		cfg.MaxDelay = 30 * time.Second
+	}
+
+	var lastErr error
+	for attempt := range cfg.MaxAttempts {
+		lastErr = fn()
+		if lastErr == nil {
+			return nil
+		}
+
+		// Don't sleep after the last attempt.
+		if attempt == cfg.MaxAttempts-1 {
+			break
+		}
+
+		delay := backoffDelay(attempt, cfg.BaseDelay, cfg.MaxDelay)
+		fmt.Printf("    Attempt %d/%d failed, retrying in %s...\n", attempt+1, cfg.MaxAttempts, delay.Round(time.Millisecond))
+
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(delay):
+		}
+	}
+	return lastErr
+}
+
+// backoffDelay calculates delay with exponential backoff and full jitter.
+// delay = random(0, min(maxDelay, baseDelay * 2^attempt))
+func backoffDelay(attempt int, base, max time.Duration) time.Duration {
+	exp := math.Pow(2, float64(attempt))
+	delay := time.Duration(float64(base) * exp)
+	if delay > max {
+		delay = max
+	}
+	// Full jitter: uniform random in [delay/2, delay]
+	half := delay / 2
+	jitter := time.Duration(rand.Int64N(int64(half) + 1)) //nolint:gosec // jitter for backoff timing, not security
+	return half + jitter
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,141 @@
+package retry
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestDo_SuccessOnFirstAttempt(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), Default(), func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestDo_SuccessOnRetry(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), Config{MaxAttempts: 3, BaseDelay: time.Millisecond, MaxDelay: 10 * time.Millisecond}, func() error {
+		calls++
+		if calls < 3 {
+			return errors.New("transient")
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDo_AllAttemptsFail(t *testing.T) {
+	calls := 0
+	sentinel := errors.New("permanent")
+	err := Do(context.Background(), Config{MaxAttempts: 3, BaseDelay: time.Millisecond, MaxDelay: 10 * time.Millisecond}, func() error {
+		calls++
+		return sentinel
+	})
+	if !errors.Is(err, sentinel) {
+		t.Fatalf("expected sentinel error, got %v", err)
+	}
+	if calls != 3 {
+		t.Fatalf("expected 3 calls, got %d", calls)
+	}
+}
+
+func TestDo_RespectsContextCancellation(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	calls := 0
+	err := Do(ctx, Config{MaxAttempts: 5, BaseDelay: time.Second, MaxDelay: time.Second}, func() error {
+		calls++
+		cancel()
+		return errors.New("fail")
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("expected context.Canceled, got %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call before cancel, got %d", calls)
+	}
+}
+
+func TestDo_SingleAttempt(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), Config{MaxAttempts: 1, BaseDelay: time.Millisecond}, func() error {
+		calls++
+		return errors.New("fail")
+	})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestDo_DefaultsForZeroConfig(t *testing.T) {
+	calls := 0
+	err := Do(context.Background(), Config{}, func() error {
+		calls++
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("expected 1 call, got %d", calls)
+	}
+}
+
+func TestBackoffDelay_Exponential(t *testing.T) {
+	base := 100 * time.Millisecond
+	max := 10 * time.Second
+
+	prev := time.Duration(0)
+	for attempt := range 5 {
+		d := backoffDelay(attempt, base, max)
+		if d > max {
+			t.Errorf("attempt %d: delay %v exceeds max %v", attempt, d, max)
+		}
+		if d < 0 {
+			t.Errorf("attempt %d: negative delay %v", attempt, d)
+		}
+		// Delays should generally increase (with jitter, not strictly monotonic,
+		// but the upper bound doubles each time).
+		_ = prev
+		prev = d
+	}
+}
+
+func TestBackoffDelay_CappedAtMax(t *testing.T) {
+	max := time.Second
+	for range 100 {
+		d := backoffDelay(20, time.Millisecond, max)
+		if d > max {
+			t.Fatalf("delay %v exceeds max %v", d, max)
+		}
+	}
+}
+
+func TestDefault(t *testing.T) {
+	cfg := Default()
+	if cfg.MaxAttempts != 3 {
+		t.Errorf("MaxAttempts: got %d, want 3", cfg.MaxAttempts)
+	}
+	if cfg.BaseDelay != time.Second {
+		t.Errorf("BaseDelay: got %v, want 1s", cfg.BaseDelay)
+	}
+	if cfg.MaxDelay != 30*time.Second {
+		t.Errorf("MaxDelay: got %v, want 30s", cfg.MaxDelay)
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/devrecon/ludus/internal/retry"
 	"github.com/devrecon/ludus/internal/runner"
 )
 
@@ -68,11 +69,13 @@ func EnsureBinary(ctx context.Context, r *runner.Runner, arch string) (string, e
 		if err := os.MkdirAll(filepath.Dir(cacheDir), 0755); err != nil {
 			return "", fmt.Errorf("creating cache directory: %w", err)
 		}
-		// Remove stale cache if it exists but source is missing
-		os.RemoveAll(cacheDir)
 
-		if err := r.Run(ctx, "git", "clone", "--branch", WrapperVersion, "--depth", "1",
-			WrapperRepo, cacheDir); err != nil {
+		if err := retry.Do(ctx, retry.Default(), func() error {
+			// Clean up any partial clone from a previous failed attempt.
+			os.RemoveAll(cacheDir)
+			return r.Run(ctx, "git", "clone", "--branch", WrapperVersion, "--depth", "1",
+				WrapperRepo, cacheDir)
+		}); err != nil {
 			return "", fmt.Errorf("cloning game server wrapper: %w", err)
 		}
 	}
@@ -110,7 +113,9 @@ func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir, arch s
 	// Download the GameLift Server SDK if not already present
 	if _, err := os.Stat(sdkZip); err != nil {
 		fmt.Println("  Downloading GameLift Server SDK...")
-		if err := r.RunInDir(ctx, cacheDir, "curl", "-L", serverSDKURL, "-o", sdkZip); err != nil {
+		if err := retry.Do(ctx, retry.Default(), func() error {
+			return r.RunInDir(ctx, cacheDir, "curl", "-L", serverSDKURL, "-o", sdkZip)
+		}); err != nil {
 			return fmt.Errorf("downloading server SDK: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary

- New `internal/retry` package: exponential backoff with full jitter, context-aware, configurable attempts/delays (default: 3 attempts, 1s base, 30s max)
- Wrap retryable CLI commands: `docker push`, `docker login`, `aws ecr get-login-password`, `git clone`, `curl` download
- Fix partial-clone cleanup: failed git clone retries now remove incomplete directory before reattempting
- AWS SDK v2 calls (GameLift, IAM, STS, S3, CloudFormation) already have built-in retry — no changes needed

## Test plan

- [ ] CI passes (build, lint, tests on ubuntu + windows)
- [ ] 9 new tests in `internal/retry/` cover: success, retry-then-success, all-fail, context cancellation, single attempt, zero config, exponential growth, max cap, defaults
- [ ] E2E validation planned: full pipeline run with UE 5.7