### PR TITLE
Add Claude Code MCP configuration to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -444,6 +444,14 @@ Set `game.arch: arm64` in `ludus.yaml` to default all commands to ARM64 without 
 
 Add ludus as an MCP server in your agent's config. The JSON format varies by client.
 
+#### Claude Code
+
+```bash
+claude mcp add ludus -- npx -y ludus-cli mcp
+```
+
+This registers ludus as a project-scoped MCP server. Restart Claude Code after adding.
+
 #### OpenCode
 
 Add to `opencode.json` in your project root (or `~/.config/opencode/config.json` globally):

--- a/npm/README.md
+++ b/npm/README.md
@@ -45,6 +45,14 @@ This single command orchestrates six stages:
 
 Ludus includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server exposing 21 tools. Any MCP-compatible AI agent can orchestrate the full pipeline programmatically.
 
+**Claude Code:**
+
+```bash
+claude mcp add ludus -- npx -y ludus-cli mcp
+```
+
+**Claude Desktop / Kiro / Cursor:**
+
 ```json
 {
   "mcpServers": {


### PR DESCRIPTION
## Summary

- Add Claude Code `claude mcp add` one-liner to README MCP client configuration section
- Add Claude Code config to npm/README.md (shown on npmjs.com)

Claude Code was the only MCP-compatible agent missing from the configuration docs.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Verify npm README renders correctly