### PR TITLE
Add v0.1.5 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.5] - 2026-03-11
+
+### Added
+- Claude Code MCP configuration to README and npm docs (#85)
+
 ## [0.1.4] - 2026-03-11
 
 ### Added
@@ -46,6 +51,7 @@ Initial public release.
 - BuildGraph XML generation — for Horde/UET CI pipelines
 - npm package (`ludus-cli`) with pre-built binaries for Linux, macOS, and Windows
 
+[0.1.5]: https://github.com/jpvelasco/ludus/compare/v0.1.4...v0.1.5
 [0.1.4]: https://github.com/jpvelasco/ludus/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/jpvelasco/ludus/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/jpvelasco/ludus/releases/tag/v0.1.2


### PR DESCRIPTION
## Summary

- Add v0.1.5 changelog entry for Claude Code MCP configuration docs (#85)

## Test plan

- [ ] Verify CHANGELOG renders correctly