### PR TITLE
Improve runner test coverage from 55% to 97%

### DIFF
--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -137,3 +137,86 @@ func TestVerbose_PrintsCommand(t *testing.T) {
 		t.Errorf("expected stdout to contain '+ go version', got: %s", output)
 	}
 }
+
+func TestRunInDir_Success(t *testing.T) {
+	r := NewRunner(false, false)
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	r.Stderr = &bytes.Buffer{}
+	ctx := context.Background()
+
+	// Run "go version" in a temp directory
+	tmpDir := t.TempDir()
+	err := r.RunInDir(ctx, tmpDir, "go", "version")
+	if err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+}
+
+func TestRunInDir_DryRun(t *testing.T) {
+	r := NewRunner(false, true) // DryRun=true
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	ctx := context.Background()
+
+	tmpDir := t.TempDir()
+	err := r.RunInDir(ctx, tmpDir, "nonexistent-ludus-command-xyz", "arg1")
+	if err != nil {
+		t.Errorf("expected nil error in dry-run mode, got: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "+ cd") {
+		t.Errorf("expected dry-run output to contain '+ cd', got: %s", output)
+	}
+	if !strings.Contains(output, "nonexistent-ludus-command-xyz") {
+		t.Errorf("expected dry-run output to contain command name, got: %s", output)
+	}
+}
+
+func TestRunWithStdin_Success(t *testing.T) {
+	r := NewRunner(false, false)
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	r.Stderr = &bytes.Buffer{}
+	ctx := context.Background()
+
+	input := strings.NewReader("hello from stdin")
+	err := r.RunWithStdin(ctx, input, "go", "version")
+	if err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+}
+
+func TestRunWithStdin_DryRun(t *testing.T) {
+	r := NewRunner(false, true) // DryRun=true
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	ctx := context.Background()
+
+	input := strings.NewReader("unused input")
+	err := r.RunWithStdin(ctx, input, "nonexistent-ludus-command-xyz")
+	if err != nil {
+		t.Errorf("expected nil error in dry-run mode, got: %v", err)
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "+ nonexistent-ludus-command-xyz") {
+		t.Errorf("expected dry-run output to contain command, got: %s", output)
+	}
+}
+
+func TestRunOutput_DryRun(t *testing.T) {
+	r := NewRunner(false, true) // DryRun=true
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	ctx := context.Background()
+
+	out, err := r.RunOutput(ctx, "nonexistent-ludus-command-xyz")
+	if err != nil {
+		t.Errorf("expected nil error in dry-run mode, got: %v", err)
+	}
+	if string(out) != "(dry-run)" {
+		t.Errorf("expected '(dry-run)', got %q", string(out))
+	}
+}


### PR DESCRIPTION
## Summary
- Add tests for `RunInDir` (success + dry-run)
- Add tests for `RunWithStdin` (success + dry-run)
- Add test for `RunOutput` dry-run mode

Closes the runner coverage gap from PR #87. Runner package goes from 55% → 97% coverage (14 tests total).

## Test Plan
- [x] `go test -v -cover ./internal/runner/` — 14/14 pass, 97.1% coverage
- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [ ] CI passes on both ubuntu and windows