### PR TITLE
Switch npm publish to OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write
 
 jobs:
   release:
@@ -40,9 +41,7 @@ jobs:
 
       - name: Publish npm package
         working-directory: npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           npm version "$VERSION" --no-git-tag-version
-          npm publish --access public
+          npm publish --access public --provenance


### PR DESCRIPTION
## Summary
- Replace `NPM_TOKEN` secret with OIDC trusted publishing
- Add `id-token: write` permission for GitHub Actions OIDC
- Add `--provenance` flag to `npm publish` for supply chain transparency
- `NPM_TOKEN` repo secret can be deleted after this is verified

## Test plan
- [ ] Merge, retag v0.1.6, verify npm publish succeeds