### PR TITLE
Fix npm trusted publishing: upgrade to Node 24

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Set up Node.js
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Embed binary checksums into npm package
@@ -44,4 +44,4 @@ jobs:
         run: |
           VERSION="${GITHUB_REF_NAME#v}"
           npm version "$VERSION" --no-git-tag-version
-          npm publish --access public --provenance
+          npm publish --access public


### PR DESCRIPTION
## Summary
- Upgrade Node.js 22 → 24 in release workflow (npm 10.9.4 → 11.x)
- npm trusted publishing requires npm >= 11.5.1 for OIDC auth
- Remove `--provenance` flag — trusted publishing generates provenance automatically

## Context
npm 10.x doesn't support OIDC-based authentication (trusted publishing). It can sign provenance but still needs an NPM_TOKEN for auth, which is why publishes were failing with 404.

## Test plan
- [ ] Merge, delete v0.1.7 release, re-run workflow
- [ ] Verify npm publish succeeds without NPM_TOKEN