### PR TITLE
Fix toolchain detection when LINUX_MULTIARCH_ROOT points to toolchain dir

### DIFF
--- a/internal/buildgraph/generator_test.go
+++ b/internal/buildgraph/generator_test.go
@@ -91,6 +91,7 @@ func TestGenerate_AMD64(t *testing.T) {
 	engineAgent := findAgent(bg, "Engine")
 	if engineAgent == nil {
 		t.Fatal("Engine agent not found")
+		return
 	}
 	if len(engineAgent.Nodes) != 3 {
 		t.Fatalf("Engine agent: want 3 nodes, got %d", len(engineAgent.Nodes))
@@ -99,6 +100,7 @@ func TestGenerate_AMD64(t *testing.T) {
 	setupNode := findNode(engineAgent, "Setup")
 	if setupNode == nil {
 		t.Fatal("Setup node not found")
+		return
 	}
 	if setupNode.Requires != "" {
 		t.Errorf("Setup node should have no Requires, got %q", setupNode.Requires)
@@ -113,6 +115,7 @@ func TestGenerate_AMD64(t *testing.T) {
 	gpfNode := findNode(engineAgent, "GenerateProjectFiles")
 	if gpfNode == nil {
 		t.Fatal("GenerateProjectFiles node not found")
+		return
 	}
 	if gpfNode.Requires != "Setup" {
 		t.Errorf("GenerateProjectFiles Requires: got %q, want Setup", gpfNode.Requires)
@@ -121,6 +124,7 @@ func TestGenerate_AMD64(t *testing.T) {
 	compileNode := findNode(engineAgent, "CompileEngine")
 	if compileNode == nil {
 		t.Fatal("CompileEngine node not found")
+		return
 	}
 	if compileNode.Requires != "GenerateProjectFiles" {
 		t.Errorf("CompileEngine Requires: got %q, want GenerateProjectFiles", compileNode.Requires)
@@ -139,6 +143,7 @@ func TestGenerate_AMD64(t *testing.T) {
 	gameAgent := findAgent(bg, "Game")
 	if gameAgent == nil {
 		t.Fatal("Game agent not found")
+		return
 	}
 	if len(gameAgent.Nodes) != 1 {
 		t.Fatalf("Game agent: want 1 node, got %d", len(gameAgent.Nodes))
@@ -168,10 +173,12 @@ func TestGenerate_ARM64(t *testing.T) {
 	gameAgent := findAgent(bg, "Game")
 	if gameAgent == nil {
 		t.Fatal("Game agent not found")
+		return
 	}
 	serverNode := findNode(gameAgent, "BuildServer")
 	if serverNode == nil {
 		t.Fatal("BuildServer node not found")
+		return
 	}
 	if !strings.Contains(serverNode.Steps[0].Arguments, "-platform=LinuxArm64") {
 		t.Errorf("BuildServer args should contain -platform=LinuxArm64, got %q", serverNode.Steps[0].Arguments)
@@ -190,6 +197,7 @@ func TestGenerate_WithClient(t *testing.T) {
 	gameAgent := findAgent(bg, "Game")
 	if gameAgent == nil {
 		t.Fatal("Game agent not found")
+		return
 	}
 	if len(gameAgent.Nodes) != 2 {
 		t.Fatalf("Game agent with client: want 2 nodes, got %d", len(gameAgent.Nodes))
@@ -229,6 +237,7 @@ func TestGenerate_WithoutClient(t *testing.T) {
 	gameAgent := findAgent(bg, "Game")
 	if gameAgent == nil {
 		t.Fatal("Game agent not found")
+		return
 	}
 	if len(gameAgent.Nodes) != 1 {
 		t.Fatalf("Game agent without client: want 1 node, got %d", len(gameAgent.Nodes))
@@ -253,6 +262,7 @@ func TestGenerate_Shipping(t *testing.T) {
 	opt := findOption(bg, "ServerConfig")
 	if opt == nil {
 		t.Fatal("ServerConfig option not found")
+		return
 	}
 	if opt.DefaultValue != "Shipping" {
 		t.Errorf("ServerConfig default: got %q, want Shipping", opt.DefaultValue)

--- a/internal/toolchain/toolchain.go
+++ b/internal/toolchain/toolchain.go
@@ -140,7 +140,7 @@ func checkToolchainLinux(engineSourcePath string, result CheckResult) CheckResul
 
 	// Fallback: LINUX_MULTIARCH_ROOT
 	if multiarchRoot := os.Getenv("LINUX_MULTIARCH_ROOT"); multiarchRoot != "" {
-		if found, path := findToolchainDir(multiarchRoot, spec.DirPrefix); found {
+		if found, path := findToolchainInRoot(multiarchRoot, spec.DirPrefix); found {
 			result.Found = true
 			result.FoundPath = path
 			result.Message = fmt.Sprintf("toolchain %s found via LINUX_MULTIARCH_ROOT at %s (engine %s from %s)",
@@ -164,7 +164,7 @@ func checkToolchainWindows(_ string, result CheckResult) CheckResult {
 		return result
 	}
 
-	if found, path := findToolchainDir(multiarchRoot, spec.DirPrefix); found {
+	if found, path := findToolchainInRoot(multiarchRoot, spec.DirPrefix); found {
 		result.Found = true
 		result.FoundPath = path
 		result.Message = fmt.Sprintf("toolchain %s found via LINUX_MULTIARCH_ROOT (engine %s from %s)",
@@ -175,6 +175,33 @@ func checkToolchainWindows(_ string, result CheckResult) CheckResult {
 	result.Message = fmt.Sprintf("toolchain %s not found in LINUX_MULTIARCH_ROOT (%s) for engine %s",
 		spec.DirPrefix, multiarchRoot, result.EngineVersion)
 	return result
+}
+
+// findToolchainInRoot locates a toolchain directory matching prefix. It checks
+// three locations to handle different LINUX_MULTIARCH_ROOT conventions:
+//  1. rootDir contains a subdirectory matching prefix (user points to parent)
+//  2. rootDir itself matches prefix (Epic's installer points to the toolchain)
+//  3. rootDir's parent contains a sibling matching prefix (Epic's installer
+//     points to a different version's toolchain)
+func findToolchainInRoot(rootDir, prefix string) (bool, string) {
+	// 1. Check subdirectories of rootDir
+	if found, path := findToolchainDir(rootDir, prefix); found {
+		return true, path
+	}
+
+	// 2. Check if rootDir itself matches the prefix
+	cleanRoot := filepath.Clean(rootDir)
+	if strings.HasPrefix(filepath.Base(cleanRoot), prefix) {
+		return true, cleanRoot
+	}
+
+	// 3. Check sibling directories (parent of rootDir)
+	parentDir := filepath.Dir(cleanRoot)
+	if found, path := findToolchainDir(parentDir, prefix); found {
+		return true, path
+	}
+
+	return false, ""
 }
 
 // findToolchainDir scans parentDir for a directory entry whose name starts

--- a/internal/toolchain/toolchain_test.go
+++ b/internal/toolchain/toolchain_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -144,6 +145,7 @@ func TestLookupToolchain(t *testing.T) {
 			}
 			if spec == nil {
 				t.Fatalf("expected spec for version %q, got nil", tt.version)
+				return
 			}
 			if spec.ClangMajor != tt.clang {
 				t.Errorf("got ClangMajor %d, want %d", spec.ClangMajor, tt.clang)
@@ -198,6 +200,82 @@ func TestFindToolchainDir(t *testing.T) {
 		found, _ := findToolchainDir(dir, "v25_clang-18")
 		if found {
 			t.Fatal("expected no match for file (not directory)")
+		}
+	})
+}
+
+func TestFindToolchainInRoot(t *testing.T) {
+	t.Run("subdirectory matches", func(t *testing.T) {
+		parent := t.TempDir()
+		if err := os.Mkdir(filepath.Join(parent, "v26_clang-20.1.8-rockylinux8"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		found, path := findToolchainInRoot(parent, "v26_clang-20")
+		if !found {
+			t.Fatal("expected match via subdirectory")
+		}
+		if !strings.Contains(path, "v26_clang-20") {
+			t.Errorf("unexpected path: %s", path)
+		}
+	})
+
+	t.Run("root dir itself matches", func(t *testing.T) {
+		// Simulate Epic's installer: LINUX_MULTIARCH_ROOT points to the toolchain dir
+		parent := t.TempDir()
+		toolchainDir := filepath.Join(parent, "v26_clang-20.1.8-rockylinux8")
+		if err := os.Mkdir(toolchainDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		found, path := findToolchainInRoot(toolchainDir, "v26_clang-20")
+		if !found {
+			t.Fatal("expected match via root dir name")
+		}
+		if path != toolchainDir {
+			t.Errorf("got %s, want %s", path, toolchainDir)
+		}
+	})
+
+	t.Run("sibling directory matches", func(t *testing.T) {
+		// LINUX_MULTIARCH_ROOT points to an older toolchain, but sibling has the right one
+		parent := t.TempDir()
+		oldDir := filepath.Join(parent, "v25_clang-18.1.0-rockylinux8")
+		newDir := filepath.Join(parent, "v26_clang-20.1.8-rockylinux8")
+		if err := os.Mkdir(oldDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Mkdir(newDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		found, path := findToolchainInRoot(oldDir, "v26_clang-20")
+		if !found {
+			t.Fatal("expected match via sibling directory")
+		}
+		if !strings.Contains(path, "v26_clang-20") {
+			t.Errorf("unexpected path: %s", path)
+		}
+	})
+
+	t.Run("no match anywhere", func(t *testing.T) {
+		parent := t.TempDir()
+		if err := os.Mkdir(filepath.Join(parent, "v22_clang-16.0.6-centos7"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		found, _ := findToolchainInRoot(parent, "v26_clang-20")
+		if found {
+			t.Fatal("expected no match")
+		}
+	})
+
+	t.Run("root dir with trailing slash", func(t *testing.T) {
+		parent := t.TempDir()
+		toolchainDir := filepath.Join(parent, "v26_clang-20.1.8-rockylinux8")
+		if err := os.Mkdir(toolchainDir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		// Add trailing slash like Epic's installer does on Windows
+		found, _ := findToolchainInRoot(toolchainDir+string(filepath.Separator), "v26_clang-20")
+		if !found {
+			t.Fatal("expected match with trailing slash")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Epic's cross-compile toolchain installer sets `LINUX_MULTIARCH_ROOT` to the toolchain directory itself (e.g. `.../v26_clang-20.1.8-rockylinux8`) rather than the parent directory. `ludus init` was scanning subdirectories only, so it couldn't find the toolchain.
- Add `findToolchainInRoot()` that checks 3 locations: subdirectories, the root dir itself, and sibling directories.
- Fix pre-existing SA5011 staticcheck false positives in buildgraph/toolchain tests (unreachable `return` after `t.Fatal`).

## Test plan
- [x] `go test ./internal/toolchain/...` — 17 tests pass (5 new for `findToolchainInRoot`)
- [x] `go test ./internal/buildgraph/...` — 8 tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `ludus init --verbose` — correctly detects toolchain as `[OK]` with Epic's `LINUX_MULTIARCH_ROOT` convention