### PR TITLE
Suppress sensitive AWS output from push commands

### DIFF
--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -369,12 +369,13 @@ func (b *Builder) Push(ctx context.Context, opts PushOptions) error {
 	ecrURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s",
 		opts.AWSAccountID, opts.AWSRegion, opts.ECRRepository)
 
-	// Ensure ECR repository exists (create if missing)
-	if err := b.Runner.Run(ctx, "aws", "ecr", "describe-repositories",
+	// Ensure ECR repository exists (create if missing).
+	// Use RunQuiet to suppress JSON output containing account IDs.
+	if err := b.Runner.RunQuiet(ctx, "aws", "ecr", "describe-repositories",
 		"--repository-names", opts.ECRRepository,
 		"--region", opts.AWSRegion); err != nil {
 		fmt.Printf("    ECR repository %q not found, creating...\n", opts.ECRRepository)
-		if err := b.Runner.Run(ctx, "aws", "ecr", "create-repository",
+		if err := b.Runner.RunQuiet(ctx, "aws", "ecr", "create-repository",
 			"--repository-name", opts.ECRRepository,
 			"--region", opts.AWSRegion,
 			"--image-scanning-configuration", "scanOnPush=true"); err != nil {
@@ -395,16 +396,17 @@ func (b *Builder) Push(ctx context.Context, opts PushOptions) error {
 		return fmt.Errorf("getting ECR password: %w", err)
 	}
 	if err := retry.Do(ctx, retryCfg, func() error {
-		return b.Runner.RunWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
+		return b.Runner.RunQuietWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
 			"docker", "login", "--username", "AWS", "--password-stdin", loginURI)
 	}); err != nil {
 		return fmt.Errorf("ECR login failed: %w", err)
 	}
+	fmt.Println("    ECR login succeeded")
 
 	// Tag for ECR
 	localTag := fmt.Sprintf("%s:%s", b.opts.ImageName, b.opts.Tag)
 	remoteTag := fmt.Sprintf("%s:%s", ecrURI, opts.ImageTag)
-	if err := b.Runner.Run(ctx, "docker", "tag", localTag, remoteTag); err != nil {
+	if err := b.Runner.RunQuiet(ctx, "docker", "tag", localTag, remoteTag); err != nil {
 		return fmt.Errorf("docker tag failed: %w", err)
 	}
 

--- a/internal/dockerbuild/engine.go
+++ b/internal/dockerbuild/engine.go
@@ -147,12 +147,13 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts PushOptions) error {
 	ecrURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s",
 		opts.AWSAccountID, opts.AWSRegion, repoName)
 
-	// Ensure ECR repository exists
-	if err := b.Runner.Run(ctx, "aws", "ecr", "describe-repositories",
+	// Ensure ECR repository exists.
+	// Use RunQuiet to suppress JSON output containing account IDs.
+	if err := b.Runner.RunQuiet(ctx, "aws", "ecr", "describe-repositories",
 		"--repository-names", repoName,
 		"--region", opts.AWSRegion); err != nil {
 		fmt.Printf("  ECR repository %q not found, creating...\n", repoName)
-		if err := b.Runner.Run(ctx, "aws", "ecr", "create-repository",
+		if err := b.Runner.RunQuiet(ctx, "aws", "ecr", "create-repository",
 			"--repository-name", repoName,
 			"--region", opts.AWSRegion,
 			"--image-scanning-configuration", "scanOnPush=true"); err != nil {
@@ -173,11 +174,12 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts PushOptions) error {
 		return fmt.Errorf("getting ECR password: %w", err)
 	}
 	if err := retry.Do(ctx, retryCfg, func() error {
-		return b.Runner.RunWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
+		return b.Runner.RunQuietWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
 			"docker", "login", "--username", "AWS", "--password-stdin", loginURI)
 	}); err != nil {
 		return fmt.Errorf("ECR login failed: %w", err)
 	}
+	fmt.Println("  ECR login succeeded")
 
 	// Tag for ECR
 	localTag := b.FullImageTag()
@@ -186,7 +188,7 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts PushOptions) error {
 		tag = b.opts.ImageTag
 	}
 	remoteTag := fmt.Sprintf("%s:%s", ecrURI, tag)
-	if err := b.Runner.Run(ctx, "docker", "tag", localTag, remoteTag); err != nil {
+	if err := b.Runner.RunQuiet(ctx, "docker", "tag", localTag, remoteTag); err != nil {
 		return fmt.Errorf("docker tag failed: %w", err)
 	}
 

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -97,6 +97,57 @@ func (r *Runner) Run(ctx context.Context, name string, args ...string) error {
 	return cmd.Run()
 }
 
+// RunQuiet executes a command, suppressing stdout unless Verbose is set.
+// Stderr is always shown. Use this for commands whose stdout contains
+// sensitive data (e.g. AWS account IDs, tokens) that should not be
+// printed in normal mode.
+func (r *Runner) RunQuiet(ctx context.Context, name string, args ...string) error {
+	if r.Verbose || r.DryRun {
+		fmt.Fprintf(r.Stdout, "+ %s", name)
+		for _, arg := range args {
+			fmt.Fprintf(r.Stdout, " %s", arg)
+		}
+		fmt.Fprintln(r.Stdout)
+	}
+
+	if r.DryRun {
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.environ()
+	if r.Verbose {
+		cmd.Stdout = r.Stdout
+	}
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}
+
+// RunQuietWithStdin executes a command with the given reader piped to stdin,
+// suppressing stdout unless Verbose is set. Stderr is always shown.
+func (r *Runner) RunQuietWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) error {
+	if r.Verbose || r.DryRun {
+		fmt.Fprintf(r.Stdout, "+ %s", name)
+		for _, arg := range args {
+			fmt.Fprintf(r.Stdout, " %s", arg)
+		}
+		fmt.Fprintln(r.Stdout)
+	}
+
+	if r.DryRun {
+		return nil
+	}
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.environ()
+	cmd.Stdin = stdin
+	if r.Verbose {
+		cmd.Stdout = r.Stdout
+	}
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}
+
 // RunOutput executes a command and returns its stdout as bytes instead of streaming.
 func (r *Runner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
 	if r.Verbose || r.DryRun {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -206,6 +206,90 @@ func TestRunWithStdin_DryRun(t *testing.T) {
 	}
 }
 
+func TestRunQuiet_SuppressesStdout(t *testing.T) {
+	r := NewRunner(false, false) // not verbose
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	r.Stderr = &bytes.Buffer{}
+	ctx := context.Background()
+
+	err := r.RunQuiet(ctx, "go", "version")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected no stdout in quiet mode, got: %s", stdout.String())
+	}
+}
+
+func TestRunQuiet_ShowsStdoutWhenVerbose(t *testing.T) {
+	r := NewRunner(true, false) // verbose
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	r.Stderr = &bytes.Buffer{}
+	ctx := context.Background()
+
+	err := r.RunQuiet(ctx, "go", "version")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "+ go version") {
+		t.Errorf("expected verbose prefix, got: %s", output)
+	}
+	if !strings.Contains(output, "go version go") {
+		t.Errorf("expected command output in verbose mode, got: %s", output)
+	}
+}
+
+func TestRunQuiet_DryRun(t *testing.T) {
+	r := NewRunner(false, true) // dry-run
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	ctx := context.Background()
+
+	err := r.RunQuiet(ctx, "nonexistent-ludus-command-xyz")
+	if err != nil {
+		t.Errorf("expected nil error in dry-run mode, got: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "+ nonexistent-ludus-command-xyz") {
+		t.Errorf("expected dry-run output, got: %s", stdout.String())
+	}
+}
+
+func TestRunQuietWithStdin_SuppressesStdout(t *testing.T) {
+	r := NewRunner(false, false) // not verbose
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	r.Stderr = &bytes.Buffer{}
+	ctx := context.Background()
+
+	input := strings.NewReader("hello")
+	err := r.RunQuietWithStdin(ctx, input, "go", "version")
+	if err != nil {
+		t.Fatalf("expected nil error, got: %v", err)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("expected no stdout in quiet mode, got: %s", stdout.String())
+	}
+}
+
+func TestRunQuietWithStdin_DryRun(t *testing.T) {
+	r := NewRunner(false, true) // dry-run
+	var stdout bytes.Buffer
+	r.Stdout = &stdout
+	ctx := context.Background()
+
+	input := strings.NewReader("unused")
+	err := r.RunQuietWithStdin(ctx, input, "nonexistent-ludus-command-xyz")
+	if err != nil {
+		t.Errorf("expected nil error in dry-run mode, got: %v", err)
+	}
+	if !strings.Contains(stdout.String(), "+ nonexistent-ludus-command-xyz") {
+		t.Errorf("expected dry-run output, got: %s", stdout.String())
+	}
+}
+
 func TestRunOutput_DryRun(t *testing.T) {
 	r := NewRunner(false, true) // DryRun=true
 	var stdout bytes.Buffer


### PR DESCRIPTION
## Summary
- Add `RunQuiet` and `RunQuietWithStdin` methods to `runner.Runner` — suppress stdout unless `--verbose` is set
- Update container and engine push paths to use quiet variants for `aws ecr` and `docker login`/`tag` commands that leak account IDs and tokens
- `docker push` remains verbose so users see upload progress

## Test plan
- [x] 5 new unit tests for `RunQuiet` and `RunQuietWithStdin` (suppress, verbose passthrough, dry-run)
- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual: `ludus container push` no longer shows AWS account IDs in normal mode
- [ ] Manual: `ludus container push --verbose` still shows full output