### PR TITLE
Add v0.1.10 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.10] - 2026-03-23
+
+### Fixed
+- Suppress sensitive AWS output (account IDs, tokens) from `container push` and `engine push` commands — new `RunQuiet`/`RunQuietWithStdin` runner methods suppress stdout unless `--verbose` is set (#104)
+
 ## [0.1.9] - 2026-03-23
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Add CHANGELOG entry for v0.1.10: suppress sensitive AWS output from push commands (#104)