### PR TITLE
Auto-fix prerequisites in ludus run pipeline

### DIFF
--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -140,7 +140,7 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 		{
 			name: "Validate prerequisites",
 			fn: func(ctx context.Context) error {
-				checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
+				checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, true, &cfg.Game)
 				results := checker.RunAll()
 				failed := 0
 				for _, res := range results {


### PR DESCRIPTION
## Summary
- Change pipeline prerequisite check from validate-only (`Fix=false`) to auto-fix mode (`Fix=true`)
- Previously `ludus run` would fail with no guidance when fixable issues like missing plugin DLLs were detected
- Now applies the same fixes as `ludus init --fix` automatically

## Context
Running individual commands (`engine build`, `game build`, etc.) skips prerequisite checks entirely, so these issues never surfaced. Only `ludus run` gates on them, and it was set to validate-only mode — failing without offering to fix.

## Test plan
- [x] `go build` — compiles
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass
- [ ] Manual: `ludus run` auto-fixes PlatformCrypto DLLs on 5.7.4