### PR TITLE
Add v0.1.11 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.1.11] - 2026-03-23
+
+### Fixed
+- `ludus run` now auto-fixes prerequisite issues (e.g. missing plugin DLLs) instead of failing with no guidance — previously only `ludus init --fix` could resolve them (#106)
+
 ## [0.1.10] - 2026-03-23
 
 ### Fixed


### PR DESCRIPTION
## Summary
- Add CHANGELOG entry for v0.1.11: auto-fix prerequisites in ludus run pipeline (#106)