### PR TITLE
Add cross-architecture emulation check to prerequisites

### DIFF
--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -50,6 +50,7 @@ func (c *Checker) RunAll() []CheckResult {
 	results = append(results, c.checkGameContent())
 	results = append(results, c.checkServerMap())
 	results = append(results, c.checkDocker())
+	results = append(results, c.checkCrossArchEmulation())
 	results = append(results, c.checkCommand("aws", "AWS CLI"))
 	results = append(results, c.checkAWSCredentials())
 	results = append(results, c.checkCommand("git", "Git"))
@@ -484,6 +485,66 @@ func (c *Checker) checkDocker() CheckResult {
 		Name:    "Docker",
 		Passed:  true,
 		Message: "docker found",
+	}
+}
+
+// checkCrossArchEmulation verifies that Docker can build for the target
+// architecture when it differs from the host. Cross-architecture builds
+// (e.g. arm64 on an amd64 host) require QEMU user-mode emulation via binfmt_misc.
+func (c *Checker) checkCrossArchEmulation() CheckResult {
+	name := "Cross-Arch Emulation"
+
+	if c.GameConfig == nil {
+		return CheckResult{Name: name, Passed: true, Message: "no game config; skipping"}
+	}
+
+	targetArch := c.GameConfig.ResolvedArch()
+	if targetArch == runtime.GOARCH {
+		return CheckResult{
+			Name:    name,
+			Passed:  true,
+			Message: fmt.Sprintf("native build (%s); no emulation needed", targetArch),
+		}
+	}
+
+	// Docker must be available for this check to be meaningful.
+	if _, err := exec.LookPath("docker"); err != nil {
+		return CheckResult{
+			Name:    name,
+			Passed:  true,
+			Warning: true,
+			Message: "docker not found; skipping cross-arch check",
+		}
+	}
+
+	// Map Go arch names to Docker platform strings.
+	dockerPlatform := "linux/" + targetArch
+
+	out, err := exec.Command("docker", "buildx", "inspect", "--bootstrap").CombinedOutput()
+	if err != nil {
+		return CheckResult{
+			Name:    name,
+			Passed:  true,
+			Warning: true,
+			Message: "docker buildx not available; cannot verify cross-arch support",
+		}
+	}
+
+	if strings.Contains(string(out), dockerPlatform) {
+		return CheckResult{
+			Name:    name,
+			Passed:  true,
+			Message: fmt.Sprintf("Docker can build for %s (QEMU emulation registered)", dockerPlatform),
+		}
+	}
+
+	return CheckResult{
+		Name:   name,
+		Passed: false,
+		Message: fmt.Sprintf("Docker cannot build for %s on this %s host; "+
+			"install QEMU emulation with:\n"+
+			"    docker run --rm --privileged tonistiigi/binfmt --install %s",
+			dockerPlatform, runtime.GOARCH, targetArch),
 	}
 }
 

--- a/internal/prereq/checker_test.go
+++ b/internal/prereq/checker_test.go
@@ -1,0 +1,48 @@
+package prereq
+
+import (
+	"runtime"
+	"testing"
+
+	"github.com/devrecon/ludus/internal/config"
+)
+
+func TestCheckCrossArchEmulation_NativeArch(t *testing.T) {
+	c := &Checker{
+		GameConfig: &config.GameConfig{Arch: runtime.GOARCH},
+	}
+	result := c.checkCrossArchEmulation()
+	if !result.Passed {
+		t.Errorf("expected pass for native arch, got: %s", result.Message)
+	}
+}
+
+func TestCheckCrossArchEmulation_NoGameConfig(t *testing.T) {
+	c := &Checker{}
+	result := c.checkCrossArchEmulation()
+	if !result.Passed {
+		t.Errorf("expected pass with no game config, got: %s", result.Message)
+	}
+}
+
+func TestCheckCrossArchEmulation_CrossArch(t *testing.T) {
+	// Pick an arch that differs from the host.
+	targetArch := "arm64"
+	if runtime.GOARCH == "arm64" {
+		targetArch = "amd64"
+	}
+
+	c := &Checker{
+		GameConfig: &config.GameConfig{Arch: targetArch},
+	}
+	result := c.checkCrossArchEmulation()
+
+	// On CI or machines without Docker/QEMU this may pass or fail —
+	// we just verify it doesn't panic and returns a coherent result.
+	if result.Name != "Cross-Arch Emulation" {
+		t.Errorf("expected name 'Cross-Arch Emulation', got: %s", result.Name)
+	}
+	if result.Message == "" {
+		t.Error("expected non-empty message")
+	}
+}


### PR DESCRIPTION
## Summary
- Add `checkCrossArchEmulation()` to prerequisite checker
- Detects missing QEMU/binfmt emulation early in `ludus init` and `ludus run` instead of failing during `container build`
- Checks `docker buildx inspect --bootstrap` for target platform support when `game.arch` differs from host arch
- Gracefully skips if Docker is not installed or buildx is unavailable

## Test plan
- [x] 3 new unit tests (native arch, no config, cross-arch)
- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [ ] Manual: `ludus init` shows `[OK] Cross-Arch Emulation` with QEMU installed
- [ ] Manual: `ludus init` shows `[FAIL]` without QEMU and cross-arch config