### PR TITLE
Check Docker daemon is running in prerequisites

### DIFF
--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -481,10 +481,18 @@ func (c *Checker) checkDocker() CheckResult {
 			Message: "docker not found in PATH",
 		}
 	}
+	// Docker is in PATH — verify the daemon is running.
+	if err := exec.Command("docker", "info").Run(); err != nil {
+		return CheckResult{
+			Name:    "Docker",
+			Passed:  false,
+			Message: "docker found but daemon is not running; start Docker Desktop or the docker service",
+		}
+	}
 	return CheckResult{
 		Name:    "Docker",
 		Passed:  true,
-		Message: "docker found",
+		Message: "docker daemon running",
 	}
 }
 


### PR DESCRIPTION
## Summary
- Extend the Docker prerequisite check to verify the daemon is actually running, not just that the binary is in PATH
- Runs `docker info` after finding the binary — fails with actionable message if daemon is down

## Test plan
- [x] `go build` — compiles
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass
- [ ] Manual: stop Docker Desktop, run `ludus init` — should show `[FAIL] Docker: daemon is not running`
- [ ] Manual: start Docker Desktop, run `ludus init` — should show `[OK] Docker: daemon running`