### PR TITLE
Add prereq checks to individual stage commands

### DIFF
--- a/cmd/connect/connect.go
+++ b/cmd/connect/connect.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/devrecon/ludus/internal/deploy"
+	"github.com/devrecon/ludus/internal/prereq"
 	"github.com/devrecon/ludus/internal/state"
 	"github.com/spf13/cobra"
 )
@@ -31,6 +32,11 @@ func init() {
 }
 
 func runConnect(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {
+		return err
+	}
+
 	cfg := globals.Cfg
 
 	// Resolve connection address

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -11,6 +11,7 @@ import (
 	ctrBuilder "github.com/devrecon/ludus/internal/container"
 	"github.com/devrecon/ludus/internal/dflint"
 	"github.com/devrecon/ludus/internal/diagnose"
+	"github.com/devrecon/ludus/internal/prereq"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/spf13/cobra"
 )
@@ -91,6 +92,11 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		cfg.Game.Arch = archFlag
 	}
 
+	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
+	if err := prereq.Validate(checker.CheckDockerReady()); err != nil {
+		return err
+	}
+
 	serverBuildDir := resolveServerBuildDir()
 	containerHash := cache.ContainerKey(cfg, serverBuildDir)
 
@@ -144,6 +150,12 @@ func runBuild(cmd *cobra.Command, args []string) error {
 
 func runPush(cmd *cobra.Command, args []string) error {
 	cfg := globals.Cfg
+
+	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
+	if err := prereq.Validate(checker.CheckPushReady()); err != nil {
+		return err
+	}
+
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)
 
 	imageTag := pushTag

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -11,6 +11,7 @@ import (
 	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/diagnose"
 	"github.com/devrecon/ludus/internal/gamelift"
+	"github.com/devrecon/ludus/internal/prereq"
 	"github.com/devrecon/ludus/internal/pricing"
 	"github.com/devrecon/ludus/internal/stack"
 	"github.com/devrecon/ludus/internal/state"
@@ -235,6 +236,11 @@ func maybeCreateSession(ctx context.Context, sm deploy.SessionManager) error {
 }
 
 func runFleet(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {
+		return err
+	}
+
 	deployer, err := makeDeployer(cmd)
 	if err != nil {
 		return err
@@ -285,6 +291,11 @@ func runFleet(cmd *cobra.Command, args []string) error {
 }
 
 func runStack(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {
+		return err
+	}
+
 	cfg := globals.Cfg
 
 	// Apply flag overrides
@@ -383,6 +394,11 @@ func runStack(cmd *cobra.Command, args []string) error {
 }
 
 func runSession(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {
+		return err
+	}
+
 	target, err := resolveTarget(cmd)
 	if err != nil {
 		return err
@@ -405,6 +421,11 @@ func runSession(cmd *cobra.Command, args []string) error {
 }
 
 func runAnywhere(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {
+		return err
+	}
+
 	cfg := globals.Cfg
 
 	// Apply flag overrides
@@ -445,6 +466,11 @@ func runAnywhere(cmd *cobra.Command, args []string) error {
 }
 
 func runEC2(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {
+		return err
+	}
+
 	cfg := globals.Cfg
 
 	// Apply flag overrides

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"github.com/devrecon/ludus/internal/cache"
 	"github.com/devrecon/ludus/internal/dockerbuild"
 	engBuilder "github.com/devrecon/ludus/internal/engine"
+	"github.com/devrecon/ludus/internal/prereq"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/state"
 	"github.com/devrecon/ludus/internal/toolchain"
@@ -157,6 +158,11 @@ func runSetup(cmd *cobra.Command, args []string) error {
 }
 
 func runBuild(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckEngineReady()); err != nil {
+		return err
+	}
+
 	if resolveBackend() == "docker" {
 		return runDockerBuild(cmd)
 	}
@@ -247,6 +253,11 @@ func runDockerBuild(cmd *cobra.Command) error {
 }
 
 func runPush(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckPushReady()); err != nil {
+		return err
+	}
+
 	cfg := globals.Cfg
 
 	// Resolve the engine image tag from state or config

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -10,6 +10,7 @@ import (
 	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/dockerbuild"
 	gameBuilder "github.com/devrecon/ludus/internal/game"
+	"github.com/devrecon/ludus/internal/prereq"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/state"
 	"github.com/devrecon/ludus/internal/toolchain"
@@ -176,6 +177,11 @@ func resolveEngineImage() (string, error) {
 }
 
 func runBuild(cmd *cobra.Command, args []string) error {
+	checker := prereq.NewChecker(globals.Cfg.Engine.SourcePath, globals.Cfg.Engine.Version, false, &globals.Cfg.Game)
+	if err := prereq.Validate(checker.CheckGameReady()); err != nil {
+		return err
+	}
+
 	if resolveBackend() == "docker" {
 		return runDockerBuild(cmd)
 	}

--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -62,6 +62,49 @@ func (c *Checker) RunAll() []CheckResult {
 	return results
 }
 
+// Validate runs a set of checks and returns an error if any fail.
+// Warnings are printed but do not cause failure.
+func Validate(results []CheckResult) error {
+	failed := 0
+	for _, res := range results {
+		if !res.Passed {
+			fmt.Printf("  [FAIL] %s: %s\n", res.Name, res.Message)
+			failed++
+		} else if res.Warning {
+			fmt.Printf("  [WARN] %s: %s\n", res.Name, res.Message)
+		}
+	}
+	if failed > 0 {
+		return fmt.Errorf("%d prerequisite check(s) failed; run 'ludus init' for full diagnostics", failed)
+	}
+	return nil
+}
+
+// CheckEngineReady validates prerequisites for engine build commands.
+func (c *Checker) CheckEngineReady() []CheckResult {
+	return []CheckResult{c.checkEngineSource()}
+}
+
+// CheckGameReady validates prerequisites for game build commands.
+func (c *Checker) CheckGameReady() []CheckResult {
+	return []CheckResult{c.checkEngineSource(), c.checkGameContent()}
+}
+
+// CheckDockerReady validates prerequisites for container build commands.
+func (c *Checker) CheckDockerReady() []CheckResult {
+	return []CheckResult{c.checkDocker(), c.checkCrossArchEmulation()}
+}
+
+// CheckPushReady validates prerequisites for push commands (container/engine push).
+func (c *Checker) CheckPushReady() []CheckResult {
+	return []CheckResult{c.checkDocker(), c.checkAWSCredentials()}
+}
+
+// CheckAWSReady validates prerequisites for deploy and connect commands.
+func (c *Checker) CheckAWSReady() []CheckResult {
+	return []CheckResult{c.checkAWSCredentials()}
+}
+
 func (c *Checker) checkOS() CheckResult {
 	switch runtime.GOOS {
 	case "linux":

--- a/internal/prereq/checker_test.go
+++ b/internal/prereq/checker_test.go
@@ -2,6 +2,7 @@ package prereq
 
 import (
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/devrecon/ludus/internal/config"
@@ -22,6 +23,91 @@ func TestCheckCrossArchEmulation_NoGameConfig(t *testing.T) {
 	result := c.checkCrossArchEmulation()
 	if !result.Passed {
 		t.Errorf("expected pass with no game config, got: %s", result.Message)
+	}
+}
+
+func TestValidate_AllPass(t *testing.T) {
+	results := []CheckResult{
+		{Name: "A", Passed: true, Message: "ok"},
+		{Name: "B", Passed: true, Message: "ok"},
+	}
+	if err := Validate(results); err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+}
+
+func TestValidate_WithFailure(t *testing.T) {
+	results := []CheckResult{
+		{Name: "A", Passed: true, Message: "ok"},
+		{Name: "B", Passed: false, Message: "missing"},
+	}
+	err := Validate(results)
+	if err == nil {
+		t.Fatal("expected error for failed check")
+	}
+	if !strings.Contains(err.Error(), "1 prerequisite check(s) failed") {
+		t.Errorf("unexpected error message: %v", err)
+	}
+}
+
+func TestValidate_WarningsPass(t *testing.T) {
+	results := []CheckResult{
+		{Name: "A", Passed: true, Warning: true, Message: "heads up"},
+	}
+	if err := Validate(results); err != nil {
+		t.Errorf("warnings should not cause failure, got: %v", err)
+	}
+}
+
+func TestValidate_Empty(t *testing.T) {
+	if err := Validate(nil); err != nil {
+		t.Errorf("empty results should pass, got: %v", err)
+	}
+}
+
+func TestCheckEngineReady(t *testing.T) {
+	c := &Checker{EngineSourcePath: "/nonexistent"}
+	results := c.CheckEngineReady()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(results))
+	}
+	if results[0].Name == "" {
+		t.Error("expected non-empty check name")
+	}
+}
+
+func TestCheckGameReady(t *testing.T) {
+	c := &Checker{
+		EngineSourcePath: "/nonexistent",
+		GameConfig:       &config.GameConfig{},
+	}
+	results := c.CheckGameReady()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 checks, got %d", len(results))
+	}
+}
+
+func TestCheckDockerReady(t *testing.T) {
+	c := &Checker{GameConfig: &config.GameConfig{}}
+	results := c.CheckDockerReady()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 checks, got %d", len(results))
+	}
+}
+
+func TestCheckPushReady(t *testing.T) {
+	c := &Checker{GameConfig: &config.GameConfig{}}
+	results := c.CheckPushReady()
+	if len(results) != 2 {
+		t.Fatalf("expected 2 checks, got %d", len(results))
+	}
+}
+
+func TestCheckAWSReady(t *testing.T) {
+	c := &Checker{GameConfig: &config.GameConfig{}}
+	results := c.CheckAWSReady()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 check, got %d", len(results))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add lightweight prerequisite validation to individual commands so users get fast, targeted feedback without the full `RunAll()` check that `ludus init`/`ludus run` performs
- New `Validate()` helper and 5 `Check*Ready()` methods in `internal/prereq/checker.go`
- Wired into: `engine build`, `engine push`, `game build`, `container build`, `container push`, all deploy subcommands (`fleet`, `stack`, `session`, `anywhere`, `ec2`), and `connect`
- 12 new tests covering `Validate` edge cases and all `Check*Ready` method signatures

## Test plan

- [x] `go build` compiles
- [x] `go vet ./...` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass (12 new prereq tests)
- [ ] CI: Build (ubuntu/windows), Lint (ubuntu/windows), Test (ubuntu/windows)