### PR TITLE
Tag ECR repositories with ManagedBy=ludus on creation

### DIFF
--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -378,7 +378,8 @@ func (b *Builder) Push(ctx context.Context, opts PushOptions) error {
 		if err := b.Runner.RunQuiet(ctx, "aws", "ecr", "create-repository",
 			"--repository-name", opts.ECRRepository,
 			"--region", opts.AWSRegion,
-			"--image-scanning-configuration", "scanOnPush=true"); err != nil {
+			"--image-scanning-configuration", "scanOnPush=true",
+			"--tags", "Key=ManagedBy,Value=ludus"); err != nil {
 			return fmt.Errorf("creating ECR repository: %w", err)
 		}
 	}

--- a/internal/dockerbuild/engine.go
+++ b/internal/dockerbuild/engine.go
@@ -156,7 +156,8 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts PushOptions) error {
 		if err := b.Runner.RunQuiet(ctx, "aws", "ecr", "create-repository",
 			"--repository-name", repoName,
 			"--region", opts.AWSRegion,
-			"--image-scanning-configuration", "scanOnPush=true"); err != nil {
+			"--image-scanning-configuration", "scanOnPush=true",
+			"--tags", "Key=ManagedBy,Value=ludus"); err != nil {
 			return fmt.Errorf("creating ECR repository: %w", err)
 		}
 	}


### PR DESCRIPTION
## Summary

- Game server ECR repo (`container push`) and engine ECR repo (`engine push`) were created without tags
- S3 bucket was already tagged correctly (verified in `ec2fleet/deployer.go:129-138`)
- Now all ludus-managed AWS resources are consistently tagged, making them discoverable via the Resource Groups Tagging API

## Test plan
- [ ] `ludus container push` — verify ECR repo has `ManagedBy=ludus` tag
- [ ] `ludus resources` — ECR repos now appear via tagging API (not just name pattern)