### PR TITLE
Fix Ctrl+C batch file prompt leak on Windows

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecr v1.56.1
 	github.com/aws/aws-sdk-go-v2/service/gamelift v1.51.1
 	github.com/aws/aws-sdk-go-v2/service/iam v1.53.6
+	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.9
 	github.com/aws/aws-sdk-go-v2/service/s3 v1.97.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.41.9
 	github.com/aws/smithy-go v1.24.2
@@ -29,7 +30,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/checksum v1.9.12 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.13.20 // indirect
 	github.com/aws/aws-sdk-go-v2/service/internal/s3shared v1.19.20 // indirect
-	github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi v1.31.9 // indirect
 	github.com/aws/aws-sdk-go-v2/service/signin v1.0.8 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.30.13 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.35.17 // indirect

--- a/internal/engine/builder_windows.go
+++ b/internal/engine/builder_windows.go
@@ -40,7 +40,10 @@ func (b *Builder) runBat(ctx context.Context, batPath string, args ...string) er
 	}
 
 	cmd := exec.CommandContext(ctx, "cmd")
-	cmd.SysProcAttr = &syscall.SysProcAttr{CmdLine: cmdLine}
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		CmdLine:       cmdLine,
+		CreationFlags: syscall.CREATE_NEW_PROCESS_GROUP,
+	}
 	cmd.Dir = b.opts.SourcePath
 	cmd.Stdout = b.Runner.Stdout
 	cmd.Stderr = b.Runner.Stderr


### PR DESCRIPTION
## Summary

- Adds `CREATE_NEW_PROCESS_GROUP` to child `cmd.exe` processes so Windows does not deliver `CTRL_C_EVENT` to the batch interpreter
- Previously, pressing Ctrl+C during Setup.bat/Build.bat would trigger `Terminate batch job (Y/N)?` which leaked to PowerShell after ludus exited
- Now `exec.CommandContext` handles clean termination via context cancellation instead

One-line fix in `internal/engine/builder_windows.go` — affects all batch file invocations (Setup.bat, GenerateProjectFiles.bat, Build.bat).

## Test plan
- [ ] `go build && golangci-lint run && go test` — all pass
- [ ] Run `ludus engine setup`, press Ctrl+C — no "Terminate batch job?" prompt
- [ ] Verify clean PowerShell return after Ctrl+C
- [ ] Verify no zombie cmd.exe processes after exit