### PR TITLE
Consolidate GameSessionInfo and resolveServerBuildDir

### DIFF
--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -2,7 +2,6 @@ package container
 
 import (
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/devrecon/ludus/cmd/globals"
@@ -71,23 +70,10 @@ func resolveArch() string {
 	return globals.Cfg.Game.ResolvedArch()
 }
 
-// resolveServerBuildDir determines the server build directory from config.
-func resolveServerBuildDir() string {
-	cfg := globals.Cfg
-	platformDir := config.ServerPlatformDir(cfg.Game.ResolvedArch())
-	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
-	}
-	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
-	}
-	return ""
-}
-
 func runBuild(cmd *cobra.Command, args []string) error {
 	cfg := globals.Cfg
 
-	// Apply arch flag to config so resolveServerBuildDir sees it
+	// Apply arch flag to config so ResolveServerBuildDir sees it
 	if archFlag != "" {
 		cfg.Game.Arch = archFlag
 	}
@@ -97,7 +83,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	serverBuildDir := resolveServerBuildDir()
+	serverBuildDir := config.ResolveServerBuildDir(cfg)
 	containerHash := cache.ContainerKey(cfg, serverBuildDir)
 
 	if !noCache {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -3,7 +3,6 @@ package deploy
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -503,7 +502,7 @@ func runEC2(cmd *cobra.Command, args []string) error {
 		fmt.Println(sug)
 	}
 
-	serverBuildDir := resolveServerBuildDirFromCfg(cfg)
+	serverBuildDir := config.ResolveServerBuildDir(cfg)
 	if serverBuildDir == "" {
 		return fmt.Errorf("could not determine server build directory; set game.projectPath in ludus.yaml")
 	}
@@ -531,18 +530,6 @@ func runEC2(cmd *cobra.Command, args []string) error {
 		fmt.Println("\nNext: ludus connect")
 	}
 	return nil
-}
-
-// resolveServerBuildDirFromCfg determines the server build directory from config.
-func resolveServerBuildDirFromCfg(cfg *config.Config) string {
-	platformDir := config.ServerPlatformDir(cfg.Game.ResolvedArch())
-	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
-	}
-	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
-	}
-	return ""
 }
 
 func runDestroy(cmd *cobra.Command, args []string) error {

--- a/cmd/globals/resolve.go
+++ b/cmd/globals/resolve.go
@@ -3,7 +3,6 @@ package globals
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 
 	"github.com/devrecon/ludus/internal/anywhere"
 	"github.com/devrecon/ludus/internal/awsutil"
@@ -121,7 +120,7 @@ func resolveAnywhere(ctx context.Context, cfg *config.Config) (deploy.Target, er
 	}
 
 	// Resolve server build directory
-	serverBuildDir := resolveServerBuildDir(cfg)
+	serverBuildDir := config.ResolveServerBuildDir(cfg)
 	if serverBuildDir == "" {
 		return nil, fmt.Errorf("could not determine server build directory; set game.projectPath in ludus.yaml")
 	}
@@ -176,16 +175,4 @@ func resolveEC2Fleet(ctx context.Context, cfg *config.Config) (deploy.Target, er
 	}, awsCfg, r)
 
 	return ec2fleet.NewTargetAdapter(deployer), nil
-}
-
-// resolveServerBuildDir determines the server build directory from config.
-func resolveServerBuildDir(cfg *config.Config) string {
-	platformDir := config.ServerPlatformDir(cfg.Game.ResolvedArch())
-	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
-	}
-	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
-	}
-	return ""
 }

--- a/cmd/mcp/helpers.go
+++ b/cmd/mcp/helpers.go
@@ -2,10 +2,8 @@ package mcp
 
 import (
 	"context"
-	"path/filepath"
 
 	"github.com/devrecon/ludus/internal/cache"
-	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/deploy"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
@@ -72,17 +70,4 @@ func checkCacheHit(noCache bool, stage cache.StageKey, hash string, cachedResult
 	return &mcpsdk.CallToolResult{
 		Content: []mcpsdk.Content{&mcpsdk.TextContent{Text: jsonString(cachedResult)}},
 	}
-}
-
-// resolveServerBuildDir determines the server build directory from config,
-// matching the logic in cmd/container and cmd/pipeline.
-func resolveServerBuildDir(cfg *config.Config) string {
-	platformDir := config.ServerPlatformDir(cfg.Game.ResolvedArch())
-	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
-	}
-	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
-	}
-	return ""
 }

--- a/cmd/mcp/tools_container.go
+++ b/cmd/mcp/tools_container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/devrecon/ludus/cmd/globals"
+	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/container"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
@@ -56,7 +57,7 @@ func handleContainerBuild(ctx context.Context, _ *mcp.CallToolRequest, input con
 		tag = cfg.Container.Tag
 	}
 
-	serverBuildDir := resolveServerBuildDir(cfg)
+	serverBuildDir := config.ResolveServerBuildDir(cfg)
 
 	b := container.NewBuilder(container.BuildOptions{
 		ServerBuildDir: serverBuildDir,
@@ -108,7 +109,7 @@ func handleContainerPush(ctx context.Context, _ *mcp.CallToolRequest, input cont
 		tag = cfg.Container.Tag
 	}
 
-	serverBuildDir := resolveServerBuildDir(cfg)
+	serverBuildDir := config.ResolveServerBuildDir(cfg)
 
 	b := container.NewBuilder(container.BuildOptions{
 		ServerBuildDir: serverBuildDir,

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -187,7 +187,7 @@ func handleDeployFleet(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 		return toolError(fmt.Sprintf("could not resolve deploy target: %v", err))
 	}
 
-	serverBuildDir := resolveServerBuildDir(cfg)
+	serverBuildDir := config.ResolveServerBuildDir(cfg)
 	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
 		cfg.AWS.AccountID, cfg.AWS.Region, cfg.AWS.ECRRepository, cfg.Container.Tag)
 
@@ -412,7 +412,7 @@ func handleDeployEC2(ctx context.Context, _ *mcp.CallToolRequest, input deployEC
 		return toolError(fmt.Sprintf("could not resolve ec2 target: %v", err))
 	}
 
-	serverBuildDir := resolveServerBuildDir(cfg)
+	serverBuildDir := config.ResolveServerBuildDir(cfg)
 	var result deployEC2Result
 
 	captured, err := withCapture(func() error {

--- a/internal/anywhere/adapter.go
+++ b/internal/anywhere/adapter.go
@@ -225,11 +225,7 @@ func (a *TargetAdapter) CreateSession(ctx context.Context, maxPlayers int) (*dep
 		fmt.Printf("Warning: failed to write session state: %v\n", err)
 	}
 
-	return &deploy.SessionInfo{
-		SessionID: info.SessionID,
-		IPAddress: info.IPAddress,
-		Port:      info.Port,
-	}, nil
+	return info, nil
 }
 
 // DescribeSession implements deploy.SessionManager.

--- a/internal/anywhere/deployer.go
+++ b/internal/anywhere/deployer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
 	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
 	"github.com/devrecon/ludus/internal/awsutil"
+	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/tags"
 )
@@ -216,7 +217,7 @@ func (d *Deployer) LaunchServer(ctx context.Context, wrapperBinary, fleetARN, lo
 
 // CreateGameSession creates a game session on the Anywhere fleet.
 // The Location parameter is required for Anywhere fleets.
-func (d *Deployer) CreateGameSession(ctx context.Context, fleetID, location string, maxPlayers int) (*GameSessionInfo, error) {
+func (d *Deployer) CreateGameSession(ctx context.Context, fleetID, location string, maxPlayers int) (*deploy.SessionInfo, error) {
 	out, err := d.glClient.CreateGameSession(ctx, &gamelift.CreateGameSessionInput{
 		FleetId:                   aws.String(fleetID),
 		Location:                  aws.String(location),
@@ -226,7 +227,7 @@ func (d *Deployer) CreateGameSession(ctx context.Context, fleetID, location stri
 		return nil, fmt.Errorf("creating game session: %w", err)
 	}
 
-	info := &GameSessionInfo{
+	info := &deploy.SessionInfo{
 		SessionID: aws.ToString(out.GameSession.GameSessionId),
 		IPAddress: aws.ToString(out.GameSession.IpAddress),
 		Port:      int(aws.ToInt32(out.GameSession.Port)),
@@ -305,13 +306,6 @@ func (d *Deployer) Destroy(ctx context.Context, fleetID, computeName, locationNa
 	}
 
 	return nil
-}
-
-// GameSessionInfo holds connection details for a game session.
-type GameSessionInfo struct {
-	SessionID string
-	IPAddress string
-	Port      int
 }
 
 // DetectLocalIP returns the first non-loopback IPv4 address found on the machine.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -344,3 +344,15 @@ func Defaults() *Config {
 		},
 	}
 }
+
+// ResolveServerBuildDir determines the packaged server build directory from config.
+func ResolveServerBuildDir(cfg *Config) string {
+	platformDir := ServerPlatformDir(cfg.Game.ResolvedArch())
+	if cfg.Game.ProjectPath != "" {
+		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
+	}
+	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
+		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
+	}
+	return ""
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -488,3 +488,57 @@ func TestGameConfig_ResolveProjectPath(t *testing.T) {
 		}
 	})
 }
+
+func TestResolveServerBuildDir(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectPath string
+		sourcePath  string
+		projectName string
+		arch        string
+		want        string
+	}{
+		{
+			name:        "custom project with projectPath",
+			projectPath: "/games/MyGame/MyGame.uproject",
+			arch:        "amd64",
+			want:        filepath.Join("/games/MyGame", "PackagedServer", "LinuxServer"),
+		},
+		{
+			name:        "Lyra with engine source",
+			sourcePath:  "/engine",
+			projectName: "Lyra",
+			arch:        "arm64",
+			want:        filepath.Join("/engine", "Samples", "Games", "Lyra", "PackagedServer", "LinuxArm64Server"),
+		},
+		{
+			name:        "projectPath takes priority over Lyra",
+			projectPath: "/games/MyGame/MyGame.uproject",
+			sourcePath:  "/engine",
+			projectName: "Lyra",
+			arch:        "amd64",
+			want:        filepath.Join("/games/MyGame", "PackagedServer", "LinuxServer"),
+		},
+		{
+			name: "neither set returns empty",
+			arch: "amd64",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Engine: EngineConfig{SourcePath: tt.sourcePath},
+				Game: GameConfig{
+					ProjectPath: tt.projectPath,
+					ProjectName: tt.projectName,
+					Arch:        tt.arch,
+				},
+			}
+			got := ResolveServerBuildDir(cfg)
+			if got != tt.want {
+				t.Errorf("ResolveServerBuildDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ec2fleet/adapter.go
+++ b/internal/ec2fleet/adapter.go
@@ -198,11 +198,7 @@ func (a *TargetAdapter) CreateSession(ctx context.Context, maxPlayers int) (*dep
 		fmt.Printf("Warning: failed to write session state: %v\n", err)
 	}
 
-	return &deploy.SessionInfo{
-		SessionID: info.SessionID,
-		IPAddress: info.IPAddress,
-		Port:      info.Port,
-	}, nil
+	return info, nil
 }
 
 // DescribeSession implements deploy.SessionManager.

--- a/internal/ec2fleet/deployer.go
+++ b/internal/ec2fleet/deployer.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/devrecon/ludus/internal/awsutil"
 	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/tags"
 	"github.com/devrecon/ludus/internal/wrapper"
@@ -420,7 +421,7 @@ func (d *Deployer) CreateFleet(ctx context.Context, buildID string) (*FleetStatu
 }
 
 // CreateGameSession creates a game session on the EC2 fleet.
-func (d *Deployer) CreateGameSession(ctx context.Context, fleetID string, maxPlayers int) (*GameSessionInfo, error) {
+func (d *Deployer) CreateGameSession(ctx context.Context, fleetID string, maxPlayers int) (*deploy.SessionInfo, error) {
 	out, err := d.glClient.CreateGameSession(ctx, &gamelift.CreateGameSessionInput{
 		FleetId:                   aws.String(fleetID),
 		MaximumPlayerSessionCount: aws.Int32(int32(maxPlayers)),
@@ -429,7 +430,7 @@ func (d *Deployer) CreateGameSession(ctx context.Context, fleetID string, maxPla
 		return nil, fmt.Errorf("creating game session: %w", err)
 	}
 
-	info := &GameSessionInfo{
+	info := &deploy.SessionInfo{
 		SessionID: aws.ToString(out.GameSession.GameSessionId),
 		IPAddress: aws.ToString(out.GameSession.IpAddress),
 		Port:      int(aws.ToInt32(out.GameSession.Port)),
@@ -587,13 +588,6 @@ func (d *Deployer) deleteIAMRole(ctx context.Context) error {
 
 	fmt.Println("IAM role deleted.")
 	return nil
-}
-
-// GameSessionInfo holds connection details for a game session.
-type GameSessionInfo struct {
-	SessionID string
-	IPAddress string
-	Port      int
 }
 
 // generateEC2WrapperConfig creates the game server wrapper config.yaml content

--- a/internal/gamelift/adapter.go
+++ b/internal/gamelift/adapter.go
@@ -117,11 +117,7 @@ func (a *TargetAdapter) CreateSession(ctx context.Context, maxPlayers int) (*dep
 		fmt.Printf("Warning: failed to write state: %v\n", err)
 	}
 
-	return &deploy.SessionInfo{
-		SessionID: info.SessionID,
-		IPAddress: info.IPAddress,
-		Port:      info.Port,
-	}, nil
+	return info, nil
 }
 
 // DescribeSession implements deploy.SessionManager.

--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -10,6 +10,7 @@ import (
 	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/devrecon/ludus/internal/awsutil"
+	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/tags"
 )
 
@@ -247,15 +248,8 @@ func (d *Deployer) CreateFleet(ctx context.Context, cgdARN string) (*FleetStatus
 	return result, fmt.Errorf("timed out waiting for fleet to become ACTIVE")
 }
 
-// GameSessionInfo holds connection details for a game session.
-type GameSessionInfo struct {
-	SessionID string
-	IPAddress string
-	Port      int
-}
-
 // CreateGameSession creates a test game session on the fleet.
-func (d *Deployer) CreateGameSession(ctx context.Context, fleetID string, maxPlayers int) (*GameSessionInfo, error) {
+func (d *Deployer) CreateGameSession(ctx context.Context, fleetID string, maxPlayers int) (*deploy.SessionInfo, error) {
 	out, err := d.glClient.CreateGameSession(ctx, &gamelift.CreateGameSessionInput{
 		FleetId:                   aws.String(fleetID),
 		MaximumPlayerSessionCount: aws.Int32(int32(maxPlayers)),
@@ -264,7 +258,7 @@ func (d *Deployer) CreateGameSession(ctx context.Context, fleetID string, maxPla
 		return nil, fmt.Errorf("creating game session: %w", err)
 	}
 
-	info := &GameSessionInfo{
+	info := &deploy.SessionInfo{
 		SessionID: aws.ToString(out.GameSession.GameSessionId),
 		IPAddress: aws.ToString(out.GameSession.IpAddress),
 		Port:      int(aws.ToInt32(out.GameSession.Port)),

--- a/internal/stack/adapter.go
+++ b/internal/stack/adapter.go
@@ -118,11 +118,7 @@ func (a *TargetAdapter) CreateSession(ctx context.Context, maxPlayers int) (*dep
 		fmt.Printf("Warning: failed to write state: %v\n", err)
 	}
 
-	return &deploy.SessionInfo{
-		SessionID: info.SessionID,
-		IPAddress: info.IPAddress,
-		Port:      info.Port,
-	}, nil
+	return info, nil
 }
 
 // DescribeSession implements deploy.SessionManager.

--- a/internal/stack/deployer.go
+++ b/internal/stack/deployer.go
@@ -11,6 +11,7 @@ import (
 	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
 
+	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/tags"
 )
 
@@ -55,13 +56,6 @@ type StackStatus struct {
 	Status    string
 	FleetID   string
 	Outputs   map[string]string
-}
-
-// GameSessionInfo holds connection details for a game session.
-type GameSessionInfo struct {
-	SessionID string
-	IPAddress string
-	Port      int
 }
 
 // StackDeployer manages CloudFormation stack lifecycle for GameLift resources.
@@ -258,7 +252,7 @@ func (d *StackDeployer) GetFleetID(ctx context.Context) (string, error) {
 }
 
 // CreateGameSession creates a game session on the fleet managed by this stack.
-func (d *StackDeployer) CreateGameSession(ctx context.Context, fleetID string, maxPlayers int) (*GameSessionInfo, error) {
+func (d *StackDeployer) CreateGameSession(ctx context.Context, fleetID string, maxPlayers int) (*deploy.SessionInfo, error) {
 	out, err := d.glClient.CreateGameSession(ctx, &gamelift.CreateGameSessionInput{
 		FleetId:                   aws.String(fleetID),
 		MaximumPlayerSessionCount: aws.Int32(int32(maxPlayers)),
@@ -267,7 +261,7 @@ func (d *StackDeployer) CreateGameSession(ctx context.Context, fleetID string, m
 		return nil, fmt.Errorf("creating game session: %w", err)
 	}
 
-	info := &GameSessionInfo{
+	info := &deploy.SessionInfo{
 		SessionID: aws.ToString(out.GameSession.GameSessionId),
 		IPAddress: aws.ToString(out.GameSession.IpAddress),
 		Port:      int(aws.ToInt32(out.GameSession.Port)),


### PR DESCRIPTION
## Summary
- Replace four duplicate `GameSessionInfo` structs (gamelift, ec2fleet, stack, anywhere) with the canonical `deploy.SessionInfo`, simplifying adapter code from field-by-field copies to direct returns
- Extract `resolveServerBuildDir` from four `cmd/` packages into `config.ResolveServerBuildDir` with table-driven tests
- Net reduction: 28 lines removed across 16 files

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` all tests pass
- [x] `golangci-lint run ./...` zero issues
- [x] Grep confirms zero remaining `GameSessionInfo` definitions
- [x] Grep confirms single `ResolveServerBuildDir` definition in `config.go`
- [x] New `TestResolveServerBuildDir` covers 4 cases (custom project, Lyra, priority, empty)