### PR TITLE
Extract instance type auto-switch into pricing.AutoSwitch

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -172,10 +172,9 @@ func makeDeployer(cmd *cobra.Command) (*gamelift.Deployer, error) {
 	}
 
 	// Auto-default instance type based on server architecture
-	arch := cfg.Game.ResolvedArch()
-	if instArch := pricing.InstanceArch(it); instArch != "" && instArch != arch {
-		it = pricing.DefaultInstanceType(arch)
-		fmt.Printf("Note: Switching instance type to %s to match %s server architecture\n", it, arch)
+	if resolved, switched := pricing.AutoSwitch(it, cfg.Game.ResolvedArch()); switched {
+		fmt.Printf("Note: Switching instance type to %s to match %s server architecture\n", resolved, cfg.Game.ResolvedArch())
+		it = resolved
 	}
 
 	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
@@ -314,12 +313,10 @@ func runStack(cmd *cobra.Command, args []string) error {
 	}
 
 	// Auto-default instance type based on server architecture
-	arch := cfg.Game.ResolvedArch()
-	if instArch := pricing.InstanceArch(cfg.GameLift.InstanceType); instArch != "" && instArch != arch {
-		defaultIT := pricing.DefaultInstanceType(arch)
-		fmt.Printf("Note: Switching instance type from %s (%s) to %s (%s) to match server architecture\n",
-			cfg.GameLift.InstanceType, instArch, defaultIT, arch)
-		cfg.GameLift.InstanceType = defaultIT
+	if resolved, switched := pricing.AutoSwitch(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch()); switched {
+		fmt.Printf("Note: Switching instance type from %s to %s to match %s server architecture\n",
+			cfg.GameLift.InstanceType, resolved, cfg.Game.ResolvedArch())
+		cfg.GameLift.InstanceType = resolved
 	}
 
 	sn := stackName

--- a/cmd/globals/resolve.go
+++ b/cmd/globals/resolve.go
@@ -43,12 +43,10 @@ func ResolveTarget(ctx context.Context, cfg *config.Config, targetOverride strin
 
 func resolveGameLift(ctx context.Context, cfg *config.Config) (deploy.Target, error) {
 	// Auto-default instance type based on server architecture
-	arch := cfg.Game.ResolvedArch()
-	if instArch := pricing.InstanceArch(cfg.GameLift.InstanceType); instArch != "" && instArch != arch {
-		defaultIT := pricing.DefaultInstanceType(arch)
-		fmt.Printf("Note: Switching instance type from %s (%s) to %s (%s) to match server architecture\n",
-			cfg.GameLift.InstanceType, instArch, defaultIT, arch)
-		cfg.GameLift.InstanceType = defaultIT
+	if resolved, switched := pricing.AutoSwitch(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch()); switched {
+		fmt.Printf("Note: Switching instance type from %s to %s to match %s server architecture\n",
+			cfg.GameLift.InstanceType, resolved, cfg.Game.ResolvedArch())
+		cfg.GameLift.InstanceType = resolved
 	}
 
 	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)
@@ -74,12 +72,10 @@ func resolveGameLift(ctx context.Context, cfg *config.Config) (deploy.Target, er
 
 func resolveStack(ctx context.Context, cfg *config.Config) (deploy.Target, error) {
 	// Auto-default instance type based on server architecture
-	arch := cfg.Game.ResolvedArch()
-	if instArch := pricing.InstanceArch(cfg.GameLift.InstanceType); instArch != "" && instArch != arch {
-		defaultIT := pricing.DefaultInstanceType(arch)
-		fmt.Printf("Note: Switching instance type from %s (%s) to %s (%s) to match server architecture\n",
-			cfg.GameLift.InstanceType, instArch, defaultIT, arch)
-		cfg.GameLift.InstanceType = defaultIT
+	if resolved, switched := pricing.AutoSwitch(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch()); switched {
+		fmt.Printf("Note: Switching instance type from %s to %s to match %s server architecture\n",
+			cfg.GameLift.InstanceType, resolved, cfg.Game.ResolvedArch())
+		cfg.GameLift.InstanceType = resolved
 	}
 
 	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)
@@ -146,12 +142,10 @@ func resolveAnywhere(ctx context.Context, cfg *config.Config) (deploy.Target, er
 
 func resolveEC2Fleet(ctx context.Context, cfg *config.Config) (deploy.Target, error) {
 	// Auto-default instance type based on server architecture
-	arch := cfg.Game.ResolvedArch()
-	if instArch := pricing.InstanceArch(cfg.GameLift.InstanceType); instArch != "" && instArch != arch {
-		defaultIT := pricing.DefaultInstanceType(arch)
-		fmt.Printf("Note: Switching instance type from %s (%s) to %s (%s) to match server architecture\n",
-			cfg.GameLift.InstanceType, instArch, defaultIT, arch)
-		cfg.GameLift.InstanceType = defaultIT
+	if resolved, switched := pricing.AutoSwitch(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch()); switched {
+		fmt.Printf("Note: Switching instance type from %s to %s to match %s server architecture\n",
+			cfg.GameLift.InstanceType, resolved, cfg.Game.ResolvedArch())
+		cfg.GameLift.InstanceType = resolved
 	}
 
 	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -255,9 +255,8 @@ func handleDeployStack(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 	}
 
 	// Auto-default instance type based on server architecture
-	arch := cfg.Game.ResolvedArch()
-	if instArch := pricing.InstanceArch(cfg.GameLift.InstanceType); instArch != "" && instArch != arch {
-		cfg.GameLift.InstanceType = pricing.DefaultInstanceType(arch)
+	if resolved, switched := pricing.AutoSwitch(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch()); switched {
+		cfg.GameLift.InstanceType = resolved
 	}
 
 	sn := input.StackName

--- a/internal/pricing/pricing.go
+++ b/internal/pricing/pricing.go
@@ -158,6 +158,17 @@ func curatedInstances(arch string) []InstanceSpec {
 	return result
 }
 
+// AutoSwitch returns the appropriate instance type for the given server architecture.
+// If the instance type's architecture doesn't match, it returns the default for that
+// arch with switched=true. Unknown or empty instance types are returned unchanged.
+func AutoSwitch(instanceType, arch string) (resolved string, switched bool) {
+	instArch := InstanceArch(instanceType)
+	if instArch == "" || instArch == arch {
+		return instanceType, false
+	}
+	return DefaultInstanceType(arch), true
+}
+
 // DefaultInstanceType returns the recommended default instance type for the given architecture.
 func DefaultInstanceType(arch string) string {
 	if arch == "arm64" {

--- a/internal/pricing/pricing_test.go
+++ b/internal/pricing/pricing_test.go
@@ -98,6 +98,35 @@ func TestInstanceArch(t *testing.T) {
 	}
 }
 
+func TestAutoSwitch(t *testing.T) {
+	tests := []struct {
+		name         string
+		instanceType string
+		arch         string
+		wantResolved string
+		wantSwitched bool
+	}{
+		{"match amd64", "c6i.large", "amd64", "c6i.large", false},
+		{"match arm64", "c7g.large", "arm64", "c7g.large", false},
+		{"mismatch amd64 to arm64", "c6i.large", "arm64", "c7g.large", true},
+		{"mismatch arm64 to amd64", "c7g.large", "amd64", "c6i.large", true},
+		{"unknown instance", "z99.mega", "arm64", "z99.mega", false},
+		{"empty instance", "", "amd64", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resolved, switched := AutoSwitch(tt.instanceType, tt.arch)
+			if resolved != tt.wantResolved {
+				t.Errorf("resolved: got %q, want %q", resolved, tt.wantResolved)
+			}
+			if switched != tt.wantSwitched {
+				t.Errorf("switched: got %v, want %v", switched, tt.wantSwitched)
+			}
+		})
+	}
+}
+
 func TestFormatSuggestion(t *testing.T) {
 	tests := []struct {
 		name      string


### PR DESCRIPTION
## Summary
- Add `pricing.AutoSwitch(instanceType, arch)` that returns `(resolved, switched)` — encapsulates the InstanceArch check + DefaultInstanceType fallback
- Replace 6 identical auto-switch blocks across `cmd/deploy`, `cmd/globals`, and `cmd/mcp` with single-line `AutoSwitch` calls
- Table-driven test covers match, mismatch, unknown, and empty cases

## Test plan
- [x] `go build ./...` compiles cleanly
- [x] `go test ./internal/pricing/...` — all tests pass including 6 new AutoSwitch cases
- [x] `golangci-lint run ./...` zero issues
- [x] Grep confirms zero remaining inline `InstanceArch`+`DefaultInstanceType` patterns