### PR TITLE
Fix binary exporter cross-platform and boost test coverage

### DIFF
--- a/internal/binary/exporter.go
+++ b/internal/binary/exporter.go
@@ -3,8 +3,9 @@ package binary
 import (
 	"context"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
-	"os/exec"
 	"path/filepath"
 
 	"github.com/devrecon/ludus/internal/deploy"
@@ -50,11 +51,7 @@ func (e *Exporter) Deploy(ctx context.Context, input deploy.DeployInput) (*deplo
 		return nil, fmt.Errorf("creating output directory: %w", err)
 	}
 
-	// Use cp -a to preserve permissions and symlinks
-	cmd := exec.CommandContext(ctx, "cp", "-a", input.ServerBuildDir+"/.", absOut)
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
+	if err := copyDir(input.ServerBuildDir, absOut); err != nil {
 		return nil, fmt.Errorf("copying server build: %w", err)
 	}
 
@@ -104,6 +101,55 @@ func (e *Exporter) Status(ctx context.Context) (*deploy.DeployStatus, error) {
 		Status:     "active",
 		Detail:     absOut,
 	}, nil
+}
+
+// copyDir recursively copies src to dst, preserving file permissions.
+func copyDir(src, dst string) error {
+	return filepath.WalkDir(src, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+
+		rel, err := filepath.Rel(src, path)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+
+		if d.IsDir() {
+			return os.MkdirAll(target, 0755)
+		}
+		return copyFile(path, target)
+	})
+}
+
+// copyFile copies a single file from src to dst, preserving permissions.
+func copyFile(src, dst string) (retErr error) {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if cerr := out.Close(); cerr != nil && retErr == nil {
+			retErr = cerr
+		}
+	}()
+
+	if _, err := io.Copy(out, in); err != nil {
+		return err
+	}
+
+	info, err := os.Stat(src)
+	if err != nil {
+		return err
+	}
+	return os.Chmod(dst, info.Mode())
 }
 
 func (e *Exporter) Destroy(ctx context.Context) error {

--- a/internal/binary/exporter_test.go
+++ b/internal/binary/exporter_test.go
@@ -1,0 +1,148 @@
+package binary
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/devrecon/ludus/internal/deploy"
+)
+
+func TestName(t *testing.T) {
+	e := NewExporter("out")
+	if e.Name() != "binary" {
+		t.Errorf("expected name 'binary', got %q", e.Name())
+	}
+}
+
+func TestCapabilities(t *testing.T) {
+	e := NewExporter("out")
+	caps := e.Capabilities()
+	if caps.NeedsContainerBuild {
+		t.Error("binary target should not need container build")
+	}
+	if caps.NeedsContainerPush {
+		t.Error("binary target should not need container push")
+	}
+	if caps.SupportsSession {
+		t.Error("binary target should not support sessions")
+	}
+	if !caps.SupportsDeploy {
+		t.Error("binary target should support deploy")
+	}
+	if !caps.SupportsDestroy {
+		t.Error("binary target should support destroy")
+	}
+}
+
+func TestDeploy_CopiesFiles(t *testing.T) {
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "server.exe"), []byte("binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	subDir := filepath.Join(srcDir, "Data")
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(subDir, "asset.pak"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	outDir := filepath.Join(t.TempDir(), "output")
+	e := NewExporter(outDir)
+
+	result, err := e.Deploy(context.Background(), deploy.DeployInput{
+		ServerBuildDir: srcDir,
+	})
+	if err != nil {
+		t.Fatalf("deploy failed: %v", err)
+	}
+	if result.Status != "exported" {
+		t.Errorf("expected status 'exported', got %q", result.Status)
+	}
+
+	if _, err := os.Stat(filepath.Join(outDir, "server.exe")); err != nil {
+		t.Error("server.exe not copied")
+	}
+	if _, err := os.Stat(filepath.Join(outDir, "Data", "asset.pak")); err != nil {
+		t.Error("Data/asset.pak not copied")
+	}
+}
+
+func TestDeploy_MissingBuildDir(t *testing.T) {
+	e := NewExporter(t.TempDir())
+	_, err := e.Deploy(context.Background(), deploy.DeployInput{
+		ServerBuildDir: "",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty build dir")
+	}
+}
+
+func TestDeploy_NonexistentBuildDir(t *testing.T) {
+	e := NewExporter(t.TempDir())
+	_, err := e.Deploy(context.Background(), deploy.DeployInput{
+		ServerBuildDir: filepath.Join(t.TempDir(), "nonexistent"),
+	})
+	if err == nil {
+		t.Fatal("expected error for nonexistent build dir")
+	}
+}
+
+func TestStatus_Active(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	e := NewExporter(dir)
+	s, err := e.Status(context.Background())
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if s.Status != "active" {
+		t.Errorf("expected status 'active', got %q", s.Status)
+	}
+}
+
+func TestStatus_NotDeployed(t *testing.T) {
+	e := NewExporter(filepath.Join(t.TempDir(), "nonexistent"))
+	s, err := e.Status(context.Background())
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if s.Status != "not_deployed" {
+		t.Errorf("expected status 'not_deployed', got %q", s.Status)
+	}
+}
+
+func TestStatus_EmptyDir(t *testing.T) {
+	dir := t.TempDir()
+	e := NewExporter(dir)
+	s, err := e.Status(context.Background())
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if s.Status != "not_deployed" {
+		t.Errorf("expected status 'not_deployed', got %q", s.Status)
+	}
+}
+
+func TestDestroy(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "output")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	e := NewExporter(dir)
+	if err := e.Destroy(context.Background()); err != nil {
+		t.Fatalf("destroy failed: %v", err)
+	}
+
+	if _, err := os.Stat(dir); !os.IsNotExist(err) {
+		t.Error("directory should have been removed")
+	}
+}

--- a/internal/game/builder_test.go
+++ b/internal/game/builder_test.go
@@ -1,6 +1,9 @@
 package game
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/devrecon/ludus/internal/runner"
@@ -42,4 +45,131 @@ func TestApplyNuGetAuditWorkaround(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestResolveMaxJobs(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxJobs      int
+		crossCompile bool
+		wantExact    int  // -1 means "don't check exact, just check > 0"
+		wantPositive bool // true means result should be > 0
+	}{
+		{"explicit jobs used as-is", 4, false, 4, true},
+		{"explicit jobs with cross-compile", 8, true, 8, true},
+		{"auto-detect native", 0, false, -1, true},
+		{"auto-detect cross-compile", 0, true, -1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := runner.NewRunner(false, true)
+			b := NewBuilder(BuildOptions{MaxJobs: tt.maxJobs}, r)
+			got := b.resolveMaxJobs(tt.crossCompile)
+			if tt.wantExact >= 0 && got != tt.wantExact {
+				t.Errorf("resolveMaxJobs() = %d, want %d", got, tt.wantExact)
+			}
+			if tt.wantPositive && got <= 0 {
+				// Auto-detect may return 0 if RAM detection fails, which is OK
+				t.Logf("resolveMaxJobs() = %d (RAM detection may have failed)", got)
+			}
+		})
+	}
+}
+
+func TestClientBinaryPath(t *testing.T) {
+	tests := []struct {
+		name         string
+		projectName  string
+		clientTarget string
+		platform     string
+		wantSuffix   string
+	}{
+		{"Win64 default", "", "", "Win64", filepath.Join("Windows", "Lyra", "Binaries", "Win64", "LyraGame.exe")},
+		{"Linux default", "", "", "Linux", filepath.Join("Linux", "Lyra", "Binaries", "Linux", "LyraGame")},
+		{"Win64 custom", "MyGame", "MyGameClient", "Win64", filepath.Join("Windows", "MyGame", "Binaries", "Win64", "MyGameClient.exe")},
+		{"Linux custom", "MyGame", "MyGameClient", "Linux", filepath.Join("Linux", "MyGame", "Binaries", "Linux", "MyGameClient")},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := runner.NewRunner(false, true)
+			b := NewBuilder(BuildOptions{
+				ProjectName:  tt.projectName,
+				ClientTarget: tt.clientTarget,
+			}, r)
+			got := b.clientBinaryPath("/out", tt.platform)
+			if !strings.HasSuffix(got, tt.wantSuffix) {
+				t.Errorf("clientBinaryPath() = %q, want suffix %q", got, tt.wantSuffix)
+			}
+		})
+	}
+}
+
+func TestDirHasContent(t *testing.T) {
+	t.Run("non-existent dir", func(t *testing.T) {
+		if dirHasContent(filepath.Join(t.TempDir(), "nope")) {
+			t.Error("expected false for non-existent dir")
+		}
+	})
+
+	t.Run("empty dir", func(t *testing.T) {
+		if dirHasContent(t.TempDir()) {
+			t.Error("expected false for empty dir")
+		}
+	})
+
+	t.Run("dir with content", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "file.txt"), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if !dirHasContent(dir) {
+			t.Error("expected true for dir with content")
+		}
+	})
+}
+
+func TestScanBuildLogs(t *testing.T) {
+	t.Run("empty engine path", func(t *testing.T) {
+		if hints := scanBuildLogs(""); hints != nil {
+			t.Errorf("expected nil for empty path, got %v", hints)
+		}
+	})
+
+	t.Run("no log file", func(t *testing.T) {
+		if hints := scanBuildLogs(t.TempDir()); hints != nil {
+			t.Errorf("expected nil for missing log, got %v", hints)
+		}
+	})
+
+	t.Run("log with known pattern", func(t *testing.T) {
+		dir := t.TempDir()
+		logDir := filepath.Join(dir, "Engine", "Programs", "AutomationTool", "Saved", "Logs")
+		if err := os.MkdirAll(logDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(logDir, "Log.txt"), []byte("error: AddBuildProductsFromManifest failed"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		hints := scanBuildLogs(dir)
+		if len(hints) == 0 {
+			t.Fatal("expected at least one hint")
+		}
+		if !strings.Contains(hints[0], "manifest") {
+			t.Errorf("hint should mention manifest, got: %s", hints[0])
+		}
+	})
+
+	t.Run("log without patterns", func(t *testing.T) {
+		dir := t.TempDir()
+		logDir := filepath.Join(dir, "Engine", "Programs", "AutomationTool", "Saved", "Logs")
+		if err := os.MkdirAll(logDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(logDir, "Log.txt"), []byte("Build succeeded."), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if hints := scanBuildLogs(dir); hints != nil {
+			t.Errorf("expected nil for clean log, got %v", hints)
+		}
+	})
 }

--- a/internal/prereq/checker_test.go
+++ b/internal/prereq/checker_test.go
@@ -1,6 +1,8 @@
 package prereq
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -131,4 +133,100 @@ func TestCheckCrossArchEmulation_CrossArch(t *testing.T) {
 	if result.Message == "" {
 		t.Error("expected non-empty message")
 	}
+}
+
+func TestIsLyraProject(t *testing.T) {
+	t.Run("has Lyra.uproject", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "Lyra.uproject"), []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if !isLyraProject(dir) {
+			t.Error("expected true for dir with Lyra.uproject")
+		}
+	})
+
+	t.Run("has DefaultGameData", func(t *testing.T) {
+		dir := t.TempDir()
+		contentDir := filepath.Join(dir, "Content")
+		if err := os.MkdirAll(contentDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(contentDir, "DefaultGameData.uasset"), []byte("x"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		if !isLyraProject(dir) {
+			t.Error("expected true for dir with DefaultGameData.uasset")
+		}
+	})
+
+	t.Run("empty dir", func(t *testing.T) {
+		if isLyraProject(t.TempDir()) {
+			t.Error("expected false for empty dir")
+		}
+	})
+
+	t.Run("nonexistent dir", func(t *testing.T) {
+		if isLyraProject(filepath.Join(t.TempDir(), "nope")) {
+			t.Error("expected false for nonexistent dir")
+		}
+	})
+}
+
+func TestResolveContentDir(t *testing.T) {
+	t.Run("with project path", func(t *testing.T) {
+		c := &Checker{
+			GameConfig: &config.GameConfig{
+				ProjectPath: filepath.Join("projects", "MyGame", "MyGame.uproject"),
+			},
+		}
+		got := c.resolveContentDir()
+		want := filepath.Join("projects", "MyGame", "Content")
+		if got != want {
+			t.Errorf("resolveContentDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("Lyra with engine source", func(t *testing.T) {
+		c := &Checker{
+			EngineSourcePath: "/ue5",
+			GameConfig:       &config.GameConfig{ProjectName: "Lyra"},
+		}
+		got := c.resolveContentDir()
+		want := filepath.Join("/ue5", "Samples", "Games", "Lyra", "Content")
+		if got != want {
+			t.Errorf("resolveContentDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("default Lyra with engine source", func(t *testing.T) {
+		c := &Checker{
+			EngineSourcePath: "/ue5",
+			GameConfig:       &config.GameConfig{},
+		}
+		got := c.resolveContentDir()
+		want := filepath.Join("/ue5", "Samples", "Games", "Lyra", "Content")
+		if got != want {
+			t.Errorf("resolveContentDir() = %q, want %q", got, want)
+		}
+	})
+
+	t.Run("non-Lyra without project path", func(t *testing.T) {
+		c := &Checker{
+			GameConfig: &config.GameConfig{ProjectName: "CustomGame"},
+		}
+		got := c.resolveContentDir()
+		if got != "" {
+			t.Errorf("resolveContentDir() = %q, want empty", got)
+		}
+	})
+
+	t.Run("nil game config", func(t *testing.T) {
+		c := &Checker{EngineSourcePath: "/ue5"}
+		got := c.resolveContentDir()
+		want := filepath.Join("/ue5", "Samples", "Games", "Lyra", "Content")
+		if got != want {
+			t.Errorf("resolveContentDir() = %q, want %q", got, want)
+		}
+	})
 }

--- a/internal/status/status_test.go
+++ b/internal/status/status_test.go
@@ -1,12 +1,14 @@
 package status
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
 	"testing"
 
 	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/state"
 )
 
 func TestCheckEngineSource_Empty(t *testing.T) {
@@ -153,5 +155,125 @@ func TestCheckServerBuild_Exists(t *testing.T) {
 	}
 	if s.Detail != serverDir {
 		t.Errorf("expected detail %q, got %q", serverDir, s.Detail)
+	}
+}
+
+// writeState writes a state.State to .ludus/state.json in the given directory.
+func writeState(t *testing.T, dir string, s *state.State) {
+	t.Helper()
+	stateDir := filepath.Join(dir, ".ludus")
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.Marshal(s)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "state.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// chdirTemp changes to a temp directory and restores on cleanup.
+func chdirTemp(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(dir); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	return dir
+}
+
+func TestCheckClientBuild_NoState(t *testing.T) {
+	dir := chdirTemp(t)
+	writeState(t, dir, &state.State{})
+
+	s := CheckClientBuild("TestGame")
+	if s.Status != "fail" {
+		t.Errorf("expected status 'fail', got %q", s.Status)
+	}
+	if s.Detail != "not built" {
+		t.Errorf("expected detail 'not built', got %q", s.Detail)
+	}
+}
+
+func TestCheckClientBuild_BinaryMissing(t *testing.T) {
+	dir := chdirTemp(t)
+	writeState(t, dir, &state.State{
+		Client: &state.ClientState{
+			BinaryPath: filepath.Join(dir, "nonexistent", "game.exe"),
+			OutputDir:  filepath.Join(dir, "out"),
+		},
+	})
+
+	s := CheckClientBuild("TestGame")
+	if s.Status != "fail" {
+		t.Errorf("expected status 'fail', got %q", s.Status)
+	}
+}
+
+func TestCheckClientBuild_OK(t *testing.T) {
+	dir := chdirTemp(t)
+	binPath := filepath.Join(dir, "out", "game.exe")
+	if err := os.MkdirAll(filepath.Dir(binPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binPath, []byte("fake"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	writeState(t, dir, &state.State{
+		Client: &state.ClientState{
+			BinaryPath: binPath,
+			OutputDir:  filepath.Join(dir, "out"),
+		},
+	})
+
+	s := CheckClientBuild("TestGame")
+	if s.Status != "ok" {
+		t.Errorf("expected status 'ok', got %q", s.Status)
+	}
+}
+
+func TestCheckGameSession_NoState(t *testing.T) {
+	dir := chdirTemp(t)
+	writeState(t, dir, &state.State{})
+
+	cfg := &config.Config{Deploy: config.DeployConfig{Target: "gamelift"}}
+	s := CheckGameSession(cfg)
+	if s.Status != "fail" {
+		t.Errorf("expected status 'fail', got %q", s.Status)
+	}
+	if s.Detail != "no session" {
+		t.Errorf("expected detail 'no session', got %q", s.Detail)
+	}
+}
+
+func TestCheckGameSession_OK(t *testing.T) {
+	dir := chdirTemp(t)
+	writeState(t, dir, &state.State{
+		Session: &state.SessionState{
+			SessionID: "gsess-123",
+			IPAddress: "1.2.3.4",
+			Port:      7777,
+		},
+	})
+
+	cfg := &config.Config{Deploy: config.DeployConfig{Target: "gamelift"}}
+	s := CheckGameSession(cfg)
+	if s.Status != "ok" {
+		t.Errorf("expected status 'ok', got %q", s.Status)
+	}
+}
+
+func TestCheckGameSession_BinaryTarget(t *testing.T) {
+	cfg := &config.Config{Deploy: config.DeployConfig{Target: "binary"}}
+	s := CheckGameSession(cfg)
+	if s.Status != "unknown" {
+		t.Errorf("expected status 'unknown', got %q", s.Status)
 	}
 }


### PR DESCRIPTION
## Summary
- Replaces `exec.Command("cp", "-a")` in binary exporter with pure Go `copyDir` using `filepath.WalkDir` + `io.Copy` — fixes Windows compatibility and aligns with the Runner convention
- Adds 36 new tests across 4 packages: binary (9), game (15), prereq (9), status (6)

## Test plan
- [x] `go build ./...` passes (including Windows)
- [x] `go vet ./...` clean
- [x] `go test ./...` — all tests pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] Binary exporter tests validate Deploy copies files recursively, Status reports correct states, Destroy removes directory