### PR TITLE
Pin GitHub Actions to commit SHAs and tune Codacy config

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -2,6 +2,6 @@
 engines:
   opengrep:
     exclude_paths:
-      # Game client launcher uses exec.Command with a variable path by design —
-      # binaryPath is resolved from our own build output, not user input.
-      - "cmd/connect/launch_windows.go"
+      - "dist/"
+      - ".codacy/"
+      - "npm/scripts/"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,11 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9
         with:
           version: v2.10.1
 
@@ -26,11 +26,11 @@ jobs:
     name: Lint (Windows)
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
-      - uses: golangci/golangci-lint-action@v9
+      - uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20  # v9
         with:
           version: v2.10.1
 
@@ -41,8 +41,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - run: go build -v ./...
@@ -55,8 +55,8 @@ jobs:
         os: [ubuntu-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v6
-      - uses: actions/setup-go@v6
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
+      - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
       - name: Install hadolint and trivy (Linux)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,24 +14,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6
         with:
           fetch-depth: 0
 
       - name: Set up Go
-        uses: actions/setup-go@v6
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
         with:
           go-version-file: go.mod
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v7
+        uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29  # v7
         with:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f  # v6
         with:
           node-version: "24"
           registry-url: "https://registry.npmjs.org"

--- a/.gitignore
+++ b/.gitignore
@@ -47,6 +47,10 @@ npm/node_modules/
 coverage.out
 coverage.html
 
+# Codacy CLI
+.codacy/
+codacy_issues.json
+
 # Local scratch scripts
 arm64-build-all.sh
 scripts/build-arm64-servers.sh


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions in `ci.yml` and `release.yml` to full commit SHAs (satisfies the opengrep "Enforce Pinning of Third-Party GitHub Actions to Full Commit SHA" rule)
- Update `.codacy.yml`: remove stale `launch_windows.go` exclusion (exec.Cmd rule now disabled in dashboard), add `dist/`, `.codacy/`, `npm/scripts/` exclusions
- Gitignore Codacy CLI artifacts (`.codacy/`, `codacy_issues.json`)

## Context
Codacy quality grade dropped from A to B after stabilization PRs #120-#127. Dashboard tuning completed (disabled false-positive opengrep rules, irrelevant tools, JS/TS languages). This PR triggers a fresh Codacy re-analysis with the updated settings — expecting the grade to return to A.

Coverage upload is intentionally deferred — Codacy does not support OIDC, and we don't store static tokens.

## Pinned SHAs
| Action | Tag | SHA |
|--------|-----|-----|
| `actions/checkout` | v6 | `de0fac2` |
| `actions/setup-go` | v6 | `4a36011` |
| `golangci/golangci-lint-action` | v9 | `1e7e51e` |
| `actions/setup-node` | v6 | `53b8394` |
| `goreleaser/goreleaser-action` | v7 | `ec59f47` |

## Test plan
- [ ] CI passes with pinned SHAs (build, lint, test on both Ubuntu and Windows)
- [ ] Codacy re-analyzes main after merge — issues drop from 117 to ~18
- [ ] Quality grade returns to A