### PR TITLE
Bump Go 1.25.8 and reduce complexity across 16 packages

### DIFF
--- a/cmd/connect/connect.go
+++ b/cmd/connect/connect.go
@@ -37,60 +37,84 @@ func runConnect(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	cfg := globals.Cfg
-
-	// Resolve connection address
 	ip, port, err := resolveAddress()
 	if err != nil {
 		return err
 	}
 
-	// Resolve client binary
 	s, err := state.Load()
 	if err != nil {
 		return fmt.Errorf("loading state: %w", err)
 	}
 
-	if s.Client == nil || s.Client.BinaryPath == "" {
-		return fmt.Errorf("no client build found — run 'ludus game client' first")
+	binaryPath, err := resolveClientBinary(s)
+	if err != nil {
+		return err
 	}
 
-	binaryPath := s.Client.BinaryPath
-	if _, err := os.Stat(binaryPath); os.IsNotExist(err) {
-		return fmt.Errorf("client binary not found at %s — run 'ludus game client' first", binaryPath)
-	}
-
-	// Verify game session is still alive (unless using manual address)
-	if address == "" && s.Session != nil {
-		target, err := globals.ResolveTarget(cmd.Context(), cfg, "")
-		if err != nil {
-			fmt.Printf("Warning: could not resolve deploy target: %v\n", err)
-		} else if sm, ok := target.(deploy.SessionManager); ok {
-			status, err := sm.DescribeSession(cmd.Context(), s.Session.SessionID)
-			if err != nil {
-				return fmt.Errorf("game session check failed: %w", err)
-			}
-			if status != "ACTIVE" {
-				return fmt.Errorf("game session %s is %s — run 'ludus deploy session' to create a new one",
-					s.Session.SessionID, status)
-			}
-		}
-		// If target doesn't support sessions, skip verification
-	}
-
-	// If no address flag and no session, but target doesn't support sessions,
-	// give a clear error
-	if address == "" && s.Session == nil {
-		target, resolveErr := globals.ResolveTarget(cmd.Context(), cfg, "")
-		if resolveErr == nil && !target.Capabilities().SupportsSession {
-			return fmt.Errorf("target %q does not support game sessions — use --address to connect directly", target.Name())
-		}
+	if err := verifySession(cmd, s); err != nil {
+		return err
 	}
 
 	connectAddr := fmt.Sprintf("%s:%d", ip, port)
+	return launchClient(binaryPath, s.Client.Platform, s.Client.OutputDir, connectAddr, globals.Cfg.Game.ResolvedClientTarget())
+}
 
-	clientTarget := cfg.Game.ResolvedClientTarget()
-	return launchClient(binaryPath, s.Client.Platform, s.Client.OutputDir, connectAddr, clientTarget)
+// resolveClientBinary validates that a client build exists and returns its path.
+func resolveClientBinary(s *state.State) (string, error) {
+	if s.Client == nil || s.Client.BinaryPath == "" {
+		return "", fmt.Errorf("no client build found — run 'ludus game client' first")
+	}
+	if _, err := os.Stat(s.Client.BinaryPath); os.IsNotExist(err) {
+		return "", fmt.Errorf("client binary not found at %s — run 'ludus game client' first", s.Client.BinaryPath)
+	}
+	return s.Client.BinaryPath, nil
+}
+
+// verifySession checks that an active game session exists and is still alive.
+// When --address is provided, session verification is skipped entirely.
+func verifySession(cmd *cobra.Command, s *state.State) error {
+	if address != "" {
+		return nil
+	}
+	if s.Session != nil {
+		return verifyActiveSession(cmd, s)
+	}
+	return checkSessionlessTarget(cmd)
+}
+
+// verifyActiveSession confirms the stored session is still ACTIVE.
+func verifyActiveSession(cmd *cobra.Command, s *state.State) error {
+	target, err := globals.ResolveTarget(cmd.Context(), globals.Cfg, "")
+	if err != nil {
+		fmt.Printf("Warning: could not resolve deploy target: %v\n", err)
+		return nil
+	}
+	sm, ok := target.(deploy.SessionManager)
+	if !ok {
+		return nil
+	}
+	status, err := sm.DescribeSession(cmd.Context(), s.Session.SessionID)
+	if err != nil {
+		return fmt.Errorf("game session check failed: %w", err)
+	}
+	if status != "ACTIVE" {
+		return fmt.Errorf("game session %s is %s — run 'ludus deploy session' to create a new one",
+			s.Session.SessionID, status)
+	}
+	return nil
+}
+
+// checkSessionlessTarget returns an error if the target does not support sessions.
+func checkSessionlessTarget(cmd *cobra.Command) error {
+	target, err := globals.ResolveTarget(cmd.Context(), globals.Cfg, "")
+	if err != nil {
+		return nil
+	}
+	if !target.Capabilities().SupportsSession {
+		return fmt.Errorf("target %q does not support game sessions — use --address to connect directly", target.Name())
+	}
+	return nil
 }
 
 func resolveAddress() (string, int, error) {

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -62,37 +62,45 @@ type pipelineStage struct {
 }
 
 func runPipeline(cmd *cobra.Command, args []string) error {
+	p, err := newPipelineCtx(cmd)
+	if err != nil {
+		return err
+	}
+
+	stages := buildStages(p)
+
+	if globals.DryRun {
+		fmt.Println("Dry run — would execute:")
+		fmt.Println()
+	}
+
+	if err := executeStages(cmd, stages); err != nil {
+		return err
+	}
+
+	printNextStep()
+	return nil
+}
+
+// newPipelineCtx initializes all pipeline state from config and flags.
+func newPipelineCtx(cmd *cobra.Command) (*pipelineCtx, error) {
 	cfg := globals.Cfg
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)
 
 	engineVersion, _ := toolchain.DetectEngineVersion(cfg.Engine.SourcePath, cfg.Engine.Version)
 
-	// Resolve the deployment target to determine which stages are needed
 	target, err := globals.ResolveTarget(cmd.Context(), cfg, "")
 	if err != nil {
-		return fmt.Errorf("resolving deploy target: %w", err)
+		return nil, fmt.Errorf("resolving deploy target: %w", err)
 	}
-	caps := target.Capabilities()
 
-	// Derive server build directory from project path
 	arch := cfg.Game.ResolvedArch()
-	projectPath := cfg.Game.ProjectPath
-	if projectPath == "" && cfg.Game.ProjectName == "Lyra" {
-		projectPath = filepath.Join(cfg.Engine.SourcePath,
-			"Samples", "Games", "Lyra", "Lyra.uproject")
-	}
-	serverBuildDir := filepath.Join(filepath.Dir(projectPath),
-		"PackagedServer", config.ServerPlatformDir(arch))
+	serverBuildDir := resolveServerBuildDir(cfg, arch)
 
-	// Compute cache hashes upfront
 	engineHash := cache.EngineKey(cfg)
-	serverHash := cache.GameServerKey(cfg, engineHash)
-	clientHash := cache.GameClientKey(cfg, engineHash, "Linux")
-
-	// Load cache once for pipeline-wide checks
 	buildCache, _ := cache.Load()
 
-	p := &pipelineCtx{
+	return &pipelineCtx{
 		cfg:            cfg,
 		r:              r,
 		engineVersion:  engineVersion,
@@ -101,30 +109,42 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 		serverBuildDir: serverBuildDir,
 		target:         target,
 		engineHash:     engineHash,
-		serverHash:     serverHash,
-		clientHash:     clientHash,
+		serverHash:     cache.GameServerKey(cfg, engineHash),
+		clientHash:     cache.GameClientKey(cfg, engineHash, "Linux"),
 		buildCache:     buildCache,
-	}
+	}, nil
+}
 
-	projectName := cfg.Game.ProjectName
-	stages := []pipelineStage{
+// resolveServerBuildDir derives the server build output directory from config.
+func resolveServerBuildDir(cfg *config.Config, arch string) string {
+	projectPath := cfg.Game.ProjectPath
+	if projectPath == "" && cfg.Game.ProjectName == "Lyra" {
+		projectPath = filepath.Join(cfg.Engine.SourcePath,
+			"Samples", "Games", "Lyra", "Lyra.uproject")
+	}
+	return filepath.Join(filepath.Dir(projectPath),
+		"PackagedServer", config.ServerPlatformDir(arch))
+}
+
+// buildStages assembles the ordered list of pipeline stages with skip flags.
+func buildStages(p *pipelineCtx) []pipelineStage {
+	caps := p.target.Capabilities()
+	name := p.cfg.Game.ProjectName
+
+	return []pipelineStage{
 		{name: "Validate prerequisites", fn: p.stageValidate},
 		{name: "Build Unreal Engine", skip: skipEngine, fn: p.stageEngineBuild},
-		{name: fmt.Sprintf("Build %s server (%s)", projectName, config.UEPlatformName(arch)), skip: skipGame, fn: p.stageGameBuild},
-		{name: fmt.Sprintf("Build %s client (Linux)", projectName), skip: !withClient, fn: p.stageClientBuild},
+		{name: fmt.Sprintf("Build %s server (%s)", name, config.UEPlatformName(p.arch)), skip: skipGame, fn: p.stageGameBuild},
+		{name: fmt.Sprintf("Build %s client (Linux)", name), skip: !withClient, fn: p.stageClientBuild},
 		{name: "Build container image", skip: skipContainer || !caps.NeedsContainerBuild, fn: p.stageContainerBuild},
 		{name: "Push to Amazon ECR", skip: skipContainer || !caps.NeedsContainerPush, fn: p.stageContainerPush},
-		{name: fmt.Sprintf("Deploy to %s", target.Name()), skip: skipDeploy, fn: p.stageDeploy},
+		{name: fmt.Sprintf("Deploy to %s", p.target.Name()), skip: skipDeploy, fn: p.stageDeploy},
 		{name: "Create game session", skip: skipDeploy || !withSession || !caps.SupportsSession, fn: p.stageSession},
 	}
+}
 
-	// Dry-run mode: print the plan, then execute with runner in dry-run mode
-	if globals.DryRun {
-		fmt.Println("Dry run — would execute:")
-		fmt.Println()
-	}
-
-	// Execute stages
+// executeStages runs each stage in order, printing progress and timing.
+func executeStages(cmd *cobra.Command, stages []pipelineStage) error {
 	total := len(stages)
 	for i, s := range stages {
 		if s.skip {
@@ -143,12 +163,15 @@ func runPipeline(cmd *cobra.Command, args []string) error {
 		elapsed := time.Since(start)
 		fmt.Printf("[%d/%d] %s complete (%s)\n\n", i+1, total, s.name, elapsed.Truncate(time.Second))
 	}
+	return nil
+}
 
+// printNextStep prints guidance on what to run after the pipeline completes.
+func printNextStep() {
 	fmt.Println("Pipeline complete.")
 	if withSession {
 		fmt.Println("\nNext: ludus connect")
 	} else if !skipDeploy {
 		fmt.Println("\nNext: ludus deploy session")
 	}
-	return nil
 }

--- a/cmd/resources/resources.go
+++ b/cmd/resources/resources.go
@@ -30,31 +30,14 @@ func init() {
 
 func runResources(cmd *cobra.Command, args []string) error {
 	cfg := globals.Cfg
-
-	region := regionFlag
-	if region == "" {
-		region = cfg.AWS.Region
-	}
+	region := resolveRegion(cfg.AWS.Region)
 
 	awsCfg, err := awsutil.LoadAWSConfig(cmd.Context(), region)
 	if err != nil {
 		return fmt.Errorf("loading AWS config: %w", err)
 	}
 
-	// Known ECR repo names
-	ecrRepo := cfg.AWS.ECRRepository
-	if ecrRepo == "" {
-		ecrRepo = "ludus-server"
-	}
-	engineRepo := cfg.Engine.DockerImageName
-	if engineRepo == "" {
-		engineRepo = "ludus-engine"
-	}
-	ecrRepoNames := []string{ecrRepo}
-	if engineRepo != ecrRepo {
-		ecrRepoNames = append(ecrRepoNames, engineRepo)
-	}
-
+	ecrRepoNames := resolveECRRepos(cfg.AWS.ECRRepository, cfg.Engine.DockerImageName)
 	scanner := inventory.NewScanner(awsCfg, region, ecrRepoNames, "ludus-builds-")
 	inv, err := scanner.Scan(cmd.Context())
 	if err != nil {
@@ -67,23 +50,55 @@ func runResources(cmd *cobra.Command, args []string) error {
 		return enc.Encode(inv)
 	}
 
+	printInventory(inv, region)
+	return nil
+}
+
+// resolveRegion returns the CLI flag value or falls back to the config value.
+func resolveRegion(cfgRegion string) string {
+	if regionFlag != "" {
+		return regionFlag
+	}
+	return cfgRegion
+}
+
+// resolveECRRepos builds the deduplicated list of ECR repository names to scan.
+func resolveECRRepos(serverRepo, engineRepo string) []string {
+	if serverRepo == "" {
+		serverRepo = "ludus-server"
+	}
+	if engineRepo == "" {
+		engineRepo = "ludus-engine"
+	}
+	repos := []string{serverRepo}
+	if engineRepo != serverRepo {
+		repos = append(repos, engineRepo)
+	}
+	return repos
+}
+
+// printInventory formats and prints the scanned inventory to stdout.
+func printInventory(inv *inventory.Inventory, region string) {
 	if len(inv.Resources) == 0 {
 		fmt.Printf("No ludus-managed resources found in %s.\n", region)
-		return nil
+		return
 	}
 
 	fmt.Printf("Ludus Resources (%s)\n\n", region)
 	fmt.Printf("  %-30s  %-40s  %s\n", "TYPE", "NAME", "DETAIL")
 	for _, r := range inv.Resources {
-		detail := r.Detail
-		if detail == "" && r.Status != "" {
-			detail = r.Status
-		}
-		if detail == "" {
-			detail = "--"
-		}
-		fmt.Printf("  %-30s  %-40s  %s\n", r.Type, r.Name, detail)
+		fmt.Printf("  %-30s  %-40s  %s\n", r.Type, r.Name, resourceDetail(r))
 	}
 	fmt.Println()
-	return nil
+}
+
+// resourceDetail returns the best available detail string for a resource row.
+func resourceDetail(r inventory.Resource) string {
+	if r.Detail != "" {
+		return r.Detail
+	}
+	if r.Status != "" {
+		return r.Status
+	}
+	return "--"
 }

--- a/cmd/setup/setup.go
+++ b/cmd/setup/setup.go
@@ -89,18 +89,27 @@ func confirm(question string) bool {
 	return answer == "" || answer == "y" || answer == "yes"
 }
 
+// setupAnswers holds all user responses collected during the wizard.
+type setupAnswers struct {
+	cfgFile           string
+	enginePath        string
+	engineVersion     string
+	projectName       string
+	projectPath       string
+	contentSourcePath string
+	deployTarget      string
+	region            string
+	accountID         string
+	instanceType      string
+}
+
 func runSetup(cmd *cobra.Command, args []string) error {
 	fmt.Println("Ludus Setup Wizard")
 	fmt.Println("==================")
 	fmt.Println()
 
-	// Determine output config file name
-	cfgFile := "ludus.yaml"
-	if globals.Profile != "" {
-		cfgFile = "ludus-" + globals.Profile + ".yaml"
-	}
+	cfgFile := resolveConfigFile()
 
-	// Check if config already exists
 	if _, err := os.Stat(cfgFile); err == nil {
 		if !confirm(fmt.Sprintf("%s already exists. Overwrite?", cfgFile)) {
 			fmt.Println("Setup cancelled.")
@@ -108,136 +117,173 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Step 1: Engine source path
-	fmt.Println("Step 1: Unreal Engine Source")
-	fmt.Println("----------------------------")
-	enginePath := promptEnginePath()
-	if enginePath == "" {
-		fmt.Println("\nNo engine source path provided. You can set it later:")
-		fmt.Printf("  ludus config set engine.sourcePath /path/to/UnrealEngine\n\n")
-	}
+	a := collectAnswers(cfgFile)
 
-	// Step 2: Auto-detect engine version
-	var engineVersion string
-	if enginePath != "" {
-		if bv, err := toolchain.ParseBuildVersion(enginePath); err == nil {
-			engineVersion = fmt.Sprintf("%d.%d.%d", bv.MajorVersion, bv.MinorVersion, bv.PatchVersion)
-			fmt.Printf("\nDetected engine version: %s\n", engineVersion)
-		} else {
-			fmt.Println("\nCould not auto-detect engine version from Build.version.")
-			engineVersion = prompt("Engine version (e.g., 5.7.3)", "")
-		}
-	}
-
-	// Step 3: Game project
-	fmt.Println()
-	fmt.Println("Step 2: Game Project")
-	fmt.Println("--------------------")
-	projectName, projectPath, contentSourcePath := promptGameProject(enginePath)
-
-	// Step 4: Deploy target
-	fmt.Println()
-	fmt.Println("Step 3: Deployment Target")
-	fmt.Println("-------------------------")
-	targets := []string{"gamelift", "stack", "ec2", "anywhere", "binary"}
-	deployTarget := promptChoice("Select deployment target:", targets, 0)
-
-	// Step 5: AWS settings
-	fmt.Println()
-	fmt.Println("Step 4: AWS Configuration")
-	fmt.Println("-------------------------")
-	region, accountID := promptAWS()
-
-	// Step 6: Instance type
-	instanceType := "c6i.large"
-	if deployTarget != "binary" && deployTarget != "anywhere" {
-		fmt.Println()
-		instanceType = prompt("GameLift instance type", "c6i.large")
-	}
-
-	// Summary
-	fmt.Println()
-	fmt.Println("Configuration Summary")
-	fmt.Println("=====================")
-	if enginePath != "" {
-		fmt.Printf("  Engine source:  %s\n", enginePath)
-	}
-	if engineVersion != "" {
-		fmt.Printf("  Engine version: %s\n", engineVersion)
-	}
-	fmt.Printf("  Project:        %s\n", projectName)
-	if projectPath != "" {
-		fmt.Printf("  Project path:   %s\n", projectPath)
-	}
-	if contentSourcePath != "" {
-		fmt.Printf("  Content source: %s\n", contentSourcePath)
-	}
-	fmt.Printf("  Deploy target:  %s\n", deployTarget)
-	if region != "" {
-		fmt.Printf("  AWS region:     %s\n", region)
-	}
-	if accountID != "" {
-		fmt.Printf("  AWS account:    %s\n", accountID)
-	}
-	if deployTarget != "binary" && deployTarget != "anywhere" {
-		fmt.Printf("  Instance type:  %s\n", instanceType)
-	}
-	fmt.Printf("  Config file:    %s\n", cfgFile)
-	fmt.Println()
+	printSummary(a)
 
 	if !confirm("Write configuration?") {
 		fmt.Println("Setup cancelled.")
 		return nil
 	}
 
-	// Write config using Viper (same pattern as configcmd)
+	return writeConfig(a)
+}
+
+// resolveConfigFile returns the config file name based on the active profile.
+func resolveConfigFile() string {
+	if globals.Profile != "" {
+		return "ludus-" + globals.Profile + ".yaml"
+	}
+	return "ludus.yaml"
+}
+
+// collectAnswers runs each wizard step and returns the collected responses.
+func collectAnswers(cfgFile string) setupAnswers {
+	a := setupAnswers{cfgFile: cfgFile}
+
+	fmt.Println("Step 1: Unreal Engine Source")
+	fmt.Println("----------------------------")
+	a.enginePath = promptEnginePath()
+	if a.enginePath == "" {
+		fmt.Println("\nNo engine source path provided. You can set it later:")
+		fmt.Printf("  ludus config set engine.sourcePath /path/to/UnrealEngine\n\n")
+	}
+
+	a.engineVersion = detectEngineVersion(a.enginePath)
+
+	fmt.Println()
+	fmt.Println("Step 2: Game Project")
+	fmt.Println("--------------------")
+	a.projectName, a.projectPath, a.contentSourcePath = promptGameProject(a.enginePath)
+
+	fmt.Println()
+	fmt.Println("Step 3: Deployment Target")
+	fmt.Println("-------------------------")
+	targets := []string{"gamelift", "stack", "ec2", "anywhere", "binary"}
+	a.deployTarget = promptChoice("Select deployment target:", targets, 0)
+
+	fmt.Println()
+	fmt.Println("Step 4: AWS Configuration")
+	fmt.Println("-------------------------")
+	a.region, a.accountID = promptAWS()
+
+	a.instanceType = "c6i.large"
+	if a.deployTarget != "binary" && a.deployTarget != "anywhere" {
+		fmt.Println()
+		a.instanceType = prompt("GameLift instance type", "c6i.large")
+	}
+
+	return a
+}
+
+// detectEngineVersion auto-detects or prompts for the engine version.
+func detectEngineVersion(enginePath string) string {
+	if enginePath == "" {
+		return ""
+	}
+	bv, err := toolchain.ParseBuildVersion(enginePath)
+	if err == nil {
+		version := fmt.Sprintf("%d.%d.%d", bv.MajorVersion, bv.MinorVersion, bv.PatchVersion)
+		fmt.Printf("\nDetected engine version: %s\n", version)
+		return version
+	}
+	fmt.Println("\nCould not auto-detect engine version from Build.version.")
+	return prompt("Engine version (e.g., 5.7.3)", "")
+}
+
+// printSummary displays the collected configuration before writing.
+func printSummary(a setupAnswers) {
+	fmt.Println()
+	fmt.Println("Configuration Summary")
+	fmt.Println("=====================")
+	printIfSet("  Engine source:  %s\n", a.enginePath)
+	printIfSet("  Engine version: %s\n", a.engineVersion)
+	fmt.Printf("  Project:        %s\n", a.projectName)
+	printIfSet("  Project path:   %s\n", a.projectPath)
+	printIfSet("  Content source: %s\n", a.contentSourcePath)
+	fmt.Printf("  Deploy target:  %s\n", a.deployTarget)
+	printIfSet("  AWS region:     %s\n", a.region)
+	printIfSet("  AWS account:    %s\n", a.accountID)
+	if a.deployTarget != "binary" && a.deployTarget != "anywhere" {
+		fmt.Printf("  Instance type:  %s\n", a.instanceType)
+	}
+	fmt.Printf("  Config file:    %s\n", a.cfgFile)
+	fmt.Println()
+}
+
+// printIfSet prints format with value only when value is non-empty.
+func printIfSet(format, value string) {
+	if value != "" {
+		fmt.Printf(format, value)
+	}
+}
+
+// writeConfig creates and writes the ludus.yaml configuration file.
+func writeConfig(a setupAnswers) error {
 	v := viper.New()
 	v.SetConfigType("yaml")
-	v.SetConfigFile(cfgFile)
+	v.SetConfigFile(a.cfgFile)
 
-	if enginePath != "" {
-		v.Set("engine.sourcePath", enginePath)
-	}
-	if engineVersion != "" {
-		v.Set("engine.version", engineVersion)
+	setEngineConfig(v, a)
+	setGameConfig(v, a)
+	setDeployConfig(v, a)
+	setContainerConfig(v)
+
+	if err := v.WriteConfigAs(a.cfgFile); err != nil {
+		return fmt.Errorf("writing %s: %w", a.cfgFile, err)
 	}
 
-	v.Set("game.projectName", projectName)
-	if projectPath != "" {
-		v.Set("game.projectPath", projectPath)
+	fmt.Printf("\nConfiguration written to %s\n", a.cfgFile)
+	fmt.Println("\nNext: ludus init")
+	return nil
+}
+
+// setEngineConfig writes engine settings to Viper.
+func setEngineConfig(v *viper.Viper, a setupAnswers) {
+	if a.enginePath != "" {
+		v.Set("engine.sourcePath", a.enginePath)
 	}
-	if contentSourcePath != "" {
-		v.Set("game.contentSourcePath", contentSourcePath)
+	if a.engineVersion != "" {
+		v.Set("engine.version", a.engineVersion)
+	}
+}
+
+// setGameConfig writes game project settings to Viper.
+func setGameConfig(v *viper.Viper, a setupAnswers) {
+	v.Set("game.projectName", a.projectName)
+	if a.projectPath != "" {
+		v.Set("game.projectPath", a.projectPath)
+	}
+	if a.contentSourcePath != "" {
+		v.Set("game.contentSourcePath", a.contentSourcePath)
 	}
 	v.Set("game.serverMap", "L_Expanse")
+}
 
-	v.Set("deploy.target", deployTarget)
+// setDeployConfig writes AWS and deployment settings to Viper.
+func setDeployConfig(v *viper.Viper, a setupAnswers) {
+	v.Set("deploy.target", a.deployTarget)
 
-	if region != "" {
-		v.Set("aws.region", region)
+	if a.region != "" {
+		v.Set("aws.region", a.region)
 	} else {
 		v.Set("aws.region", "us-east-1")
 	}
-	if accountID != "" {
-		v.Set("aws.accountId", accountID)
+	if a.accountID != "" {
+		v.Set("aws.accountId", a.accountID)
 	}
 	v.Set("aws.ecrRepository", "ludus-server")
 
 	v.Set("gamelift.fleetName", "ludus-fleet")
-	v.Set("gamelift.instanceType", instanceType)
+	v.Set("gamelift.instanceType", a.instanceType)
 	v.Set("gamelift.containerGroupName", "ludus-container-group")
+}
 
+// setContainerConfig writes container settings to Viper.
+func setContainerConfig(v *viper.Viper) {
 	v.Set("container.imageName", "ludus-server")
 	v.Set("container.tag", "latest")
 	v.Set("container.serverPort", 7777)
-
-	if err := v.WriteConfigAs(cfgFile); err != nil {
-		return fmt.Errorf("writing %s: %w", cfgFile, err)
-	}
-
-	fmt.Printf("\nConfiguration written to %s\n", cfgFile)
-	fmt.Println("\nNext: ludus init")
-	return nil
 }
 
 // promptEnginePath scans for engine directories and lets the user pick or type a path.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devrecon/ludus
 
-go 1.25.0
+go 1.25.8
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.5

--- a/internal/anywhere/adapter.go
+++ b/internal/anywhere/adapter.go
@@ -37,29 +37,50 @@ func (a *TargetAdapter) Capabilities() deploy.Capabilities {
 	}
 }
 
+// anywhereResources holds the intermediate resources created during deployment.
+type anywhereResources struct {
+	ipAddress     string
+	wrapperBinary string
+	locationARN   string
+	fleetID       string
+	fleetARN      string
+	computeName   string
+	pid           int
+}
+
 func (a *TargetAdapter) Deploy(ctx context.Context, input deploy.DeployInput) (*deploy.DeployResult, error) {
+	res, err := a.createResources(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	a.saveDeployState(res)
+
+	detail := fmt.Sprintf("fleet %s, PID %d, %s:%d", res.fleetID, res.pid, res.ipAddress, a.deployer.opts.ServerPort)
+	return &deploy.DeployResult{
+		TargetName: "anywhere",
+		Status:     "active",
+		Detail:     detail,
+	}, nil
+}
+
+// createResources provisions all Anywhere infrastructure: location, fleet,
+// compute registration, and game server launch.
+func (a *TargetAdapter) createResources(ctx context.Context) (*anywhereResources, error) {
 	d := a.deployer
 	opts := d.opts
 
-	// 1. Detect local IP if not configured
-	ipAddress := opts.IPAddress
-	if ipAddress == "" {
-		var err error
-		ipAddress, err = DetectLocalIP()
-		if err != nil {
-			return nil, fmt.Errorf("auto-detecting local IP: %w", err)
-		}
-		fmt.Printf("Detected local IP: %s\n", ipAddress)
+	ipAddress, err := resolveIPAddress(opts.IPAddress)
+	if err != nil {
+		return nil, err
 	}
 
-	// 2. Ensure game server wrapper binary (anywhere always runs on the local machine's arch)
 	fmt.Println("Ensuring game server wrapper binary...")
 	wrapperBinary, err := wrapper.EnsureBinary(ctx, d.Runner, "")
 	if err != nil {
 		return nil, fmt.Errorf("game server wrapper: %w", err)
 	}
 
-	// 3. Create custom location
 	fmt.Printf("Creating custom location %s...\n", opts.LocationName)
 	locationARN, err := d.CreateLocation(ctx)
 	if err != nil {
@@ -67,23 +88,11 @@ func (a *TargetAdapter) Deploy(ctx context.Context, input deploy.DeployInput) (*
 	}
 	fmt.Printf("Location ready: %s\n", locationARN)
 
-	// 4. Create Anywhere fleet
-	fmt.Printf("Creating Anywhere fleet %s...\n", opts.FleetName)
-	fleetID, fleetARN, err := d.CreateFleet(ctx, opts.LocationName)
+	fleetID, fleetARN, computeName, err := a.registerFleetAndCompute(ctx, ipAddress)
 	if err != nil {
 		return nil, err
 	}
-	fmt.Printf("Fleet created: %s\n", fleetID)
 
-	// 5. Register this machine as a compute
-	fmt.Println("Registering compute...")
-	computeName, wsEndpoint, err := d.RegisterCompute(ctx, fleetID, opts.LocationName, ipAddress)
-	if err != nil {
-		return nil, err
-	}
-	fmt.Printf("Compute registered: %s (endpoint: %s)\n", computeName, wsEndpoint)
-
-	// 6. Launch server via wrapper
 	fmt.Println("Launching game server...")
 	pid, err := d.LaunchServer(ctx, wrapperBinary, fleetARN, locationARN, ipAddress)
 	if err != nil {
@@ -93,11 +102,59 @@ func (a *TargetAdapter) Deploy(ctx context.Context, input deploy.DeployInput) (*
 		fmt.Printf("Server started (PID: %d)\n", pid)
 	}
 
-	// 7. Update state
+	return &anywhereResources{
+		ipAddress:     ipAddress,
+		wrapperBinary: wrapperBinary,
+		locationARN:   locationARN,
+		fleetID:       fleetID,
+		fleetARN:      fleetARN,
+		computeName:   computeName,
+		pid:           pid,
+	}, nil
+}
+
+// resolveIPAddress returns the configured IP or auto-detects it.
+func resolveIPAddress(configured string) (string, error) {
+	if configured != "" {
+		return configured, nil
+	}
+	ip, err := DetectLocalIP()
+	if err != nil {
+		return "", fmt.Errorf("auto-detecting local IP: %w", err)
+	}
+	fmt.Printf("Detected local IP: %s\n", ip)
+	return ip, nil
+}
+
+// registerFleetAndCompute creates the Anywhere fleet and registers this machine.
+func (a *TargetAdapter) registerFleetAndCompute(ctx context.Context, ipAddress string) (fleetID, fleetARN, computeName string, err error) {
+	d := a.deployer
+	opts := d.opts
+
+	fmt.Printf("Creating Anywhere fleet %s...\n", opts.FleetName)
+	fleetID, fleetARN, err = d.CreateFleet(ctx, opts.LocationName)
+	if err != nil {
+		return "", "", "", err
+	}
+	fmt.Printf("Fleet created: %s\n", fleetID)
+
+	fmt.Println("Registering compute...")
+	computeName, wsEndpoint, err := d.RegisterCompute(ctx, fleetID, opts.LocationName, ipAddress)
+	if err != nil {
+		return "", "", "", err
+	}
+	fmt.Printf("Compute registered: %s (endpoint: %s)\n", computeName, wsEndpoint)
+	return fleetID, fleetARN, computeName, nil
+}
+
+// saveDeployState persists fleet, anywhere, and deploy state, logging warnings on failure.
+func (a *TargetAdapter) saveDeployState(res *anywhereResources) {
+	opts := a.deployer.opts
 	now := time.Now().UTC().Format(time.RFC3339)
+	detail := fmt.Sprintf("fleet %s, PID %d, %s:%d", res.fleetID, res.pid, res.ipAddress, opts.ServerPort)
 
 	if err := state.UpdateFleet(&state.FleetState{
-		FleetID:   fleetID,
+		FleetID:   res.fleetID,
 		Status:    "ACTIVE",
 		CreatedAt: now,
 	}); err != nil {
@@ -105,13 +162,13 @@ func (a *TargetAdapter) Deploy(ctx context.Context, input deploy.DeployInput) (*
 	}
 
 	if err := state.UpdateAnywhere(&state.AnywhereState{
-		PID:          pid,
-		ComputeName:  computeName,
-		FleetID:      fleetID,
-		FleetARN:     fleetARN,
+		PID:          res.pid,
+		ComputeName:  res.computeName,
+		FleetID:      res.fleetID,
+		FleetARN:     res.fleetARN,
 		LocationName: opts.LocationName,
-		LocationARN:  locationARN,
-		IPAddress:    ipAddress,
+		LocationARN:  res.locationARN,
+		IPAddress:    res.ipAddress,
 		ServerPort:   opts.ServerPort,
 		StartedAt:    now,
 	}); err != nil {
@@ -121,17 +178,11 @@ func (a *TargetAdapter) Deploy(ctx context.Context, input deploy.DeployInput) (*
 	if err := state.UpdateDeploy(&state.DeployState{
 		TargetName: "anywhere",
 		Status:     "active",
-		Detail:     fmt.Sprintf("fleet %s, PID %d, %s:%d", fleetID, pid, ipAddress, opts.ServerPort),
+		Detail:     detail,
 		DeployedAt: now,
 	}); err != nil {
 		fmt.Printf("Warning: failed to write deploy state: %v\n", err)
 	}
-
-	return &deploy.DeployResult{
-		TargetName: "anywhere",
-		Status:     "active",
-		Detail:     fmt.Sprintf("fleet %s, PID %d, %s:%d", fleetID, pid, ipAddress, opts.ServerPort),
-	}, nil
 }
 
 func (a *TargetAdapter) Status(ctx context.Context) (*deploy.DeployStatus, error) {

--- a/internal/anywhere/deployer.go
+++ b/internal/anywhere/deployer.go
@@ -271,59 +271,78 @@ func (d *Deployer) DescribeGameSession(ctx context.Context, sessionID string) (s
 // Destroy tears down Anywhere resources in reverse order:
 // stop server → deregister compute → delete fleet → delete location.
 func (d *Deployer) Destroy(ctx context.Context, fleetID, computeName, locationName string, pid int) error {
-	// 1. Stop the server process
-	if pid > 0 {
-		fmt.Println("Stopping server process...")
-		if err := StopServer(pid); err != nil {
-			fmt.Printf("Warning: failed to stop server (PID %d): %v\n", pid, err)
-		} else {
-			fmt.Println("Server process stopped.")
-		}
-	}
+	d.stopServerProcess(pid)
+	d.deregisterComputeResource(ctx, fleetID, computeName)
+	d.deleteFleetResource(ctx, fleetID)
+	d.deleteLocationResource(ctx, locationName)
+	cleanupWrapperConfig()
+	return nil
+}
 
-	// 2. Deregister compute
-	if computeName != "" && fleetID != "" {
-		fmt.Println("Deregistering compute...")
-		if err := d.DeregisterCompute(ctx, fleetID, computeName); err != nil {
-			fmt.Printf("Warning: failed to deregister compute: %v\n", err)
-		} else {
-			fmt.Println("Compute deregistered.")
-		}
+// stopServerProcess kills the wrapper process if running.
+func (d *Deployer) stopServerProcess(pid int) {
+	if pid <= 0 {
+		return
 	}
-
-	// 3. Delete fleet
-	if fleetID != "" {
-		fmt.Println("Deleting fleet...")
-		_, err := d.glClient.DeleteFleet(ctx, &gamelift.DeleteFleetInput{
-			FleetId: aws.String(fleetID),
-		})
-		if err != nil && !awsutil.IsNotFound(err) {
-			fmt.Printf("Warning: failed to delete fleet: %v\n", err)
-		} else {
-			fmt.Println("Fleet deleted.")
-		}
+	fmt.Println("Stopping server process...")
+	if err := StopServer(pid); err != nil {
+		fmt.Printf("Warning: failed to stop server (PID %d): %v\n", pid, err)
+		return
 	}
+	fmt.Println("Server process stopped.")
+}
 
-	// 4. Delete custom location
-	if locationName != "" {
-		fmt.Println("Deleting location...")
-		_, err := d.glClient.DeleteLocation(ctx, &gamelift.DeleteLocationInput{
-			LocationName: aws.String(locationName),
-		})
-		if err != nil && !awsutil.IsNotFound(err) {
-			fmt.Printf("Warning: failed to delete location: %v\n", err)
-		} else {
-			fmt.Println("Location deleted.")
-		}
+// deregisterComputeResource removes the compute from the fleet.
+func (d *Deployer) deregisterComputeResource(ctx context.Context, fleetID, computeName string) {
+	if computeName == "" || fleetID == "" {
+		return
 	}
+	fmt.Println("Deregistering compute...")
+	if err := d.DeregisterCompute(ctx, fleetID, computeName); err != nil {
+		fmt.Printf("Warning: failed to deregister compute: %v\n", err)
+		return
+	}
+	fmt.Println("Compute deregistered.")
+}
 
-	// 5. Clean up wrapper config
+// deleteFleetResource deletes the Anywhere fleet.
+func (d *Deployer) deleteFleetResource(ctx context.Context, fleetID string) {
+	if fleetID == "" {
+		return
+	}
+	fmt.Println("Deleting fleet...")
+	_, err := d.glClient.DeleteFleet(ctx, &gamelift.DeleteFleetInput{
+		FleetId: aws.String(fleetID),
+	})
+	if err != nil && !awsutil.IsNotFound(err) {
+		fmt.Printf("Warning: failed to delete fleet: %v\n", err)
+		return
+	}
+	fmt.Println("Fleet deleted.")
+}
+
+// deleteLocationResource deletes the custom location.
+func (d *Deployer) deleteLocationResource(ctx context.Context, locationName string) {
+	if locationName == "" {
+		return
+	}
+	fmt.Println("Deleting location...")
+	_, err := d.glClient.DeleteLocation(ctx, &gamelift.DeleteLocationInput{
+		LocationName: aws.String(locationName),
+	})
+	if err != nil && !awsutil.IsNotFound(err) {
+		fmt.Printf("Warning: failed to delete location: %v\n", err)
+		return
+	}
+	fmt.Println("Location deleted.")
+}
+
+// cleanupWrapperConfig removes the wrapper config directory.
+func cleanupWrapperConfig() {
 	configDir, err := wrapperConfigDir()
 	if err == nil {
 		os.RemoveAll(configDir)
 	}
-
-	return nil
 }
 
 // DetectLocalIP returns the first non-loopback IPv4 address found on the machine.

--- a/internal/cleanup/cleanup.go
+++ b/internal/cleanup/cleanup.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/ecr"
+	ecrtypes "github.com/aws/aws-sdk-go-v2/service/ecr/types"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/devrecon/ludus/internal/awsutil"
@@ -45,55 +46,57 @@ func NewCleaner(awsCfg aws.Config) *Cleaner {
 func (c *Cleaner) DeleteECRRepository(ctx context.Context, repoName string) error {
 	fmt.Printf("Deleting ECR repository %s...\n", repoName)
 
-	// List all images in the repository
 	listOutput, err := c.ecr.ListImages(ctx, &ecr.ListImagesInput{
 		RepositoryName: aws.String(repoName),
 	})
 	if err != nil {
-		if awsutil.IsNotFound(err) {
-			fmt.Printf("  ECR repository %s not found, skipping\n", repoName)
-			return nil
-		}
-		return fmt.Errorf("list images in repository %s: %w", repoName, err)
+		return c.handleECRNotFound(err, repoName, "list images in repository %s: %w")
 	}
 
-	// Delete all images if any exist
-	imageCount := len(listOutput.ImageIds)
-	if imageCount > 0 {
-		// Batch delete supports up to 100 images at a time
-		for i := 0; i < imageCount; i += 100 {
-			end := min(i+100, imageCount)
-			batch := listOutput.ImageIds[i:end]
-
-			_, err = c.ecr.BatchDeleteImage(ctx, &ecr.BatchDeleteImageInput{
-				RepositoryName: aws.String(repoName),
-				ImageIds:       batch,
-			})
-			if err != nil {
-				if awsutil.IsNotFound(err) {
-					fmt.Printf("  ECR repository %s not found, skipping\n", repoName)
-					return nil
-				}
-				return fmt.Errorf("batch delete images in repository %s: %w", repoName, err)
-			}
-		}
-		fmt.Printf("  Deleted %d images\n", imageCount)
+	if err := c.batchDeleteImages(ctx, repoName, listOutput.ImageIds); err != nil {
+		return err
 	}
 
-	// Delete the repository
 	_, err = c.ecr.DeleteRepository(ctx, &ecr.DeleteRepositoryInput{
 		RepositoryName: aws.String(repoName),
 		Force:          true,
 	})
 	if err != nil {
-		if awsutil.IsNotFound(err) {
-			fmt.Printf("  ECR repository %s not found, skipping\n", repoName)
-			return nil
-		}
-		return fmt.Errorf("delete repository %s: %w", repoName, err)
+		return c.handleECRNotFound(err, repoName, "delete repository %s: %w")
 	}
 
 	fmt.Println("ECR repository deleted.")
+	return nil
+}
+
+// handleECRNotFound returns nil with a skip message for not-found errors,
+// or wraps real errors with the given format (must contain %s and %w).
+func (c *Cleaner) handleECRNotFound(err error, repoName, errFmt string) error {
+	if awsutil.IsNotFound(err) {
+		fmt.Printf("  ECR repository %s not found, skipping\n", repoName)
+		return nil
+	}
+	return fmt.Errorf(errFmt, repoName, err)
+}
+
+// batchDeleteImages deletes ECR images in batches of 100.
+func (c *Cleaner) batchDeleteImages(ctx context.Context, repoName string, imageIDs []ecrtypes.ImageIdentifier) error {
+	if len(imageIDs) == 0 {
+		return nil
+	}
+
+	for i := 0; i < len(imageIDs); i += 100 {
+		end := min(i+100, len(imageIDs))
+		_, err := c.ecr.BatchDeleteImage(ctx, &ecr.BatchDeleteImageInput{
+			RepositoryName: aws.String(repoName),
+			ImageIds:       imageIDs[i:end],
+		})
+		if err != nil {
+			return c.handleECRNotFound(err, repoName, "batch delete images in repository %s: %w")
+		}
+	}
+
+	fmt.Printf("  Deleted %d images\n", len(imageIDs))
 	return nil
 }
 
@@ -102,7 +105,6 @@ func (c *Cleaner) DeleteECRRepository(ctx context.Context, repoName string) erro
 func (c *Cleaner) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 	fmt.Printf("Deleting S3 bucket %s...\n", bucketName)
 
-	// Check if bucket exists
 	_, err := c.s3.HeadBucket(ctx, &s3.HeadBucketInput{
 		Bucket: aws.String(bucketName),
 	})
@@ -114,7 +116,23 @@ func (c *Cleaner) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 		return fmt.Errorf("check bucket %s: %w", bucketName, err)
 	}
 
-	// Delete all objects in the bucket
+	if err := c.deleteAllObjects(ctx, bucketName); err != nil {
+		return err
+	}
+
+	_, err = c.s3.DeleteBucket(ctx, &s3.DeleteBucketInput{
+		Bucket: aws.String(bucketName),
+	})
+	if err != nil {
+		return fmt.Errorf("delete bucket %s: %w", bucketName, err)
+	}
+
+	fmt.Println("S3 bucket deleted.")
+	return nil
+}
+
+// deleteAllObjects paginates through all objects in a bucket and deletes them.
+func (c *Cleaner) deleteAllObjects(ctx context.Context, bucketName string) error {
 	var totalDeleted int
 	var continuationToken *string
 
@@ -127,27 +145,10 @@ func (c *Cleaner) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 			return fmt.Errorf("list objects in bucket %s: %w", bucketName, err)
 		}
 
-		if len(listOutput.Contents) > 0 {
-			// Build delete objects input
-			var objectsToDelete []s3types.ObjectIdentifier
-			for _, obj := range listOutput.Contents {
-				objectsToDelete = append(objectsToDelete, s3types.ObjectIdentifier{
-					Key: obj.Key,
-				})
-			}
-
-			_, err = c.s3.DeleteObjects(ctx, &s3.DeleteObjectsInput{
-				Bucket: aws.String(bucketName),
-				Delete: &s3types.Delete{
-					Objects: objectsToDelete,
-					Quiet:   aws.Bool(true),
-				},
-			})
-			if err != nil {
-				return fmt.Errorf("delete objects in bucket %s: %w", bucketName, err)
-			}
-
-			totalDeleted += len(objectsToDelete)
+		if n, err := c.deleteObjectBatch(ctx, bucketName, listOutput.Contents); err != nil {
+			return err
+		} else {
+			totalDeleted += n
 		}
 
 		if !aws.ToBool(listOutput.IsTruncated) {
@@ -159,15 +160,26 @@ func (c *Cleaner) DeleteS3Bucket(ctx context.Context, bucketName string) error {
 	if totalDeleted > 0 {
 		fmt.Printf("  Deleted %d objects\n", totalDeleted)
 	}
+	return nil
+}
 
-	// Delete the bucket
-	_, err = c.s3.DeleteBucket(ctx, &s3.DeleteBucketInput{
-		Bucket: aws.String(bucketName),
-	})
-	if err != nil {
-		return fmt.Errorf("delete bucket %s: %w", bucketName, err)
+// deleteObjectBatch deletes a single page of S3 objects and returns the count deleted.
+func (c *Cleaner) deleteObjectBatch(ctx context.Context, bucketName string, contents []s3types.Object) (int, error) {
+	if len(contents) == 0 {
+		return 0, nil
 	}
 
-	fmt.Println("S3 bucket deleted.")
-	return nil
+	ids := make([]s3types.ObjectIdentifier, len(contents))
+	for i, obj := range contents {
+		ids[i] = s3types.ObjectIdentifier{Key: obj.Key}
+	}
+
+	_, err := c.s3.DeleteObjects(ctx, &s3.DeleteObjectsInput{
+		Bucket: aws.String(bucketName),
+		Delete: &s3types.Delete{Objects: ids, Quiet: aws.Bool(true)},
+	})
+	if err != nil {
+		return 0, fmt.Errorf("delete objects in bucket %s: %w", bucketName, err)
+	}
+	return len(ids), nil
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,46 +21,59 @@ func Load(path string) (*Config, error) {
 	if path != "" {
 		v.SetConfigFile(path)
 	} else {
-		// Use SetConfigFile with explicit .yaml extension to avoid
-		// Viper matching the 'ludus' binary as a config file.
 		v.SetConfigFile("ludus.yaml")
 	}
 
 	if err := v.ReadInConfig(); err != nil {
-		if _, ok := err.(viper.ConfigFileNotFoundError); ok {
-			return cfg, nil
-		}
-		// Also handle the case where SetConfigFile was used but file doesn't exist
-		if os.IsNotExist(err) {
-			return cfg, nil
-		}
-		return nil, fmt.Errorf("reading config: %w", err)
+		return handleReadError(cfg, err)
 	}
 
-	// Detect deprecated 'lyra' key and migrate to 'game' before unmarshalling
-	if v.IsSet("lyra") && !v.IsSet("game") {
-		fmt.Fprintln(os.Stderr, "WARNING: 'lyra:' config key is deprecated, rename to 'game:' in ludus.yaml")
-		// Copy lyra sub-keys into game namespace so Viper unmarshals them correctly
-		for _, key := range []string{"projectPath", "projectName", "contentSourcePath", "serverTarget", "clientTarget", "gameTarget", "platform", "skipCook", "serverMap", "contentValidation"} {
-			if v.IsSet("lyra." + key) {
-				v.Set("game."+key, v.Get("lyra."+key))
-			}
-		}
-	}
+	migrateLyraKey(v)
 
 	if err := v.Unmarshal(cfg); err != nil {
 		return nil, fmt.Errorf("parsing config: %w", err)
 	}
 
-	// Expand relative engine source path to absolute
-	if cfg.Engine.SourcePath != "" && !filepath.IsAbs(cfg.Engine.SourcePath) {
-		cwd, err := os.Getwd()
-		if err == nil {
-			cfg.Engine.SourcePath = filepath.Join(cwd, cfg.Engine.SourcePath)
+	resolveEnginePath(cfg)
+	return cfg, nil
+}
+
+// handleReadError returns defaults for missing files, or wraps real errors.
+func handleReadError(cfg *Config, err error) (*Config, error) {
+	if _, ok := err.(viper.ConfigFileNotFoundError); ok {
+		return cfg, nil
+	}
+	if os.IsNotExist(err) {
+		return cfg, nil
+	}
+	return nil, fmt.Errorf("reading config: %w", err)
+}
+
+// migrateLyraKey copies deprecated 'lyra' keys into 'game' namespace.
+func migrateLyraKey(v *viper.Viper) {
+	if !v.IsSet("lyra") || v.IsSet("game") {
+		return
+	}
+	fmt.Fprintln(os.Stderr, "WARNING: 'lyra:' config key is deprecated, rename to 'game:' in ludus.yaml")
+	for _, key := range []string{
+		"projectPath", "projectName", "contentSourcePath", "serverTarget",
+		"clientTarget", "gameTarget", "platform", "skipCook", "serverMap",
+		"contentValidation",
+	} {
+		if v.IsSet("lyra." + key) {
+			v.Set("game."+key, v.Get("lyra."+key))
 		}
 	}
+}
 
-	return cfg, nil
+// resolveEnginePath expands a relative engine source path to absolute.
+func resolveEnginePath(cfg *Config) {
+	if cfg.Engine.SourcePath == "" || filepath.IsAbs(cfg.Engine.SourcePath) {
+		return
+	}
+	if cwd, err := os.Getwd(); err == nil {
+		cfg.Engine.SourcePath = filepath.Join(cwd, cfg.Engine.SourcePath)
+	}
 }
 
 // Config holds the full Ludus configuration, typically loaded from ludus.yaml.

--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -267,53 +267,79 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		return result, result.Error
 	}
 
-	// 1. Build/fetch the GameLift Game Server Wrapper binary
-	wrapperBin, err := b.ensureWrapper(ctx)
+	cleanup, err := b.generateAndWriteDockerfile(ctx)
 	if err != nil {
-		result.Error = fmt.Errorf("game server wrapper: %w", err)
-		return result, result.Error
+		result.Error = err
+		return result, err
 	}
+	defer cleanup()
 
-	// 2. Copy wrapper binary into server build directory
-	wrapperDst := filepath.Join(b.opts.ServerBuildDir, "amazon-gamelift-servers-game-server-wrapper")
-	if err := copyFile(wrapperBin, wrapperDst); err != nil {
-		result.Error = fmt.Errorf("copying wrapper binary: %w", err)
-		return result, result.Error
-	}
-	defer os.Remove(wrapperDst)
-
-	// 3. Write wrapper config.yaml into server build directory
-	wrapperConfigPath := filepath.Join(b.opts.ServerBuildDir, "config.yaml")
-	if err := os.WriteFile(wrapperConfigPath, []byte(b.GenerateWrapperConfig()), 0644); err != nil {
-		result.Error = fmt.Errorf("writing wrapper config: %w", err)
-		return result, result.Error
-	}
-	defer os.Remove(wrapperConfigPath)
-
-	// 4. Generate Dockerfile in the server build directory
-	dockerfilePath := filepath.Join(b.opts.ServerBuildDir, "Dockerfile")
-	dockerfile := b.GenerateDockerfile()
-	if err := os.WriteFile(dockerfilePath, []byte(dockerfile), 0644); err != nil {
-		result.Error = fmt.Errorf("writing Dockerfile: %w", err)
-		return result, result.Error
-	}
-	defer os.Remove(dockerfilePath)
-
-	// 5. Generate .dockerignore to exclude debug symbols (~1.7 GB savings)
-	dockerignorePath := filepath.Join(b.opts.ServerBuildDir, ".dockerignore")
-	if err := os.WriteFile(dockerignorePath, []byte(b.GenerateDockerignore()), 0644); err != nil {
-		result.Error = fmt.Errorf("writing .dockerignore: %w", err)
-		return result, result.Error
-	}
-	defer os.Remove(dockerignorePath)
-
-	// 6. Docker build
 	imageTag := fmt.Sprintf("%s:%s", b.opts.ImageName, b.opts.Tag)
 	result.ImageTag = imageTag
 
-	// --platform ensures Docker pulls the correct base image variant and sets
-	// architecture metadata in the image manifest (needed even though binaries
-	// are pre-cross-compiled).
+	if err := b.runDockerBuild(ctx, imageTag); err != nil {
+		result.Error = err
+		return result, err
+	}
+
+	result.Success = true
+	result.Duration = time.Since(start).Seconds()
+	return result, nil
+}
+
+// generateAndWriteDockerfile stages the wrapper binary, config, Dockerfile,
+// and .dockerignore into the server build directory. Returns a cleanup
+// function that removes the generated files.
+func (b *Builder) generateAndWriteDockerfile(ctx context.Context) (func(), error) {
+	noop := func() {}
+
+	// Build/fetch the GameLift Game Server Wrapper binary
+	wrapperBin, err := b.ensureWrapper(ctx)
+	if err != nil {
+		return noop, fmt.Errorf("game server wrapper: %w", err)
+	}
+
+	// Copy wrapper binary into server build directory
+	wrapperDst := filepath.Join(b.opts.ServerBuildDir, "amazon-gamelift-servers-game-server-wrapper")
+	if err := copyFile(wrapperBin, wrapperDst); err != nil {
+		return noop, fmt.Errorf("copying wrapper binary: %w", err)
+	}
+
+	// Write wrapper config.yaml
+	wrapperConfigPath := filepath.Join(b.opts.ServerBuildDir, "config.yaml")
+	if err := os.WriteFile(wrapperConfigPath, []byte(b.GenerateWrapperConfig()), 0644); err != nil {
+		os.Remove(wrapperDst)
+		return noop, fmt.Errorf("writing wrapper config: %w", err)
+	}
+
+	// Generate Dockerfile
+	dockerfilePath := filepath.Join(b.opts.ServerBuildDir, "Dockerfile")
+	if err := os.WriteFile(dockerfilePath, []byte(b.GenerateDockerfile()), 0644); err != nil {
+		os.Remove(wrapperDst)
+		os.Remove(wrapperConfigPath)
+		return noop, fmt.Errorf("writing Dockerfile: %w", err)
+	}
+
+	// Generate .dockerignore to exclude debug symbols (~1.7 GB savings)
+	dockerignorePath := filepath.Join(b.opts.ServerBuildDir, ".dockerignore")
+	if err := os.WriteFile(dockerignorePath, []byte(b.GenerateDockerignore()), 0644); err != nil {
+		os.Remove(wrapperDst)
+		os.Remove(wrapperConfigPath)
+		os.Remove(dockerfilePath)
+		return noop, fmt.Errorf("writing .dockerignore: %w", err)
+	}
+
+	cleanup := func() {
+		os.Remove(wrapperDst)
+		os.Remove(wrapperConfigPath)
+		os.Remove(dockerfilePath)
+		os.Remove(dockerignorePath)
+	}
+	return cleanup, nil
+}
+
+// runDockerBuild runs the docker build command with platform and provenance settings.
+func (b *Builder) runDockerBuild(ctx context.Context, imageTag string) error {
 	arch := b.resolveArch()
 	platform := "linux/amd64"
 	if arch == "arm64" {
@@ -323,8 +349,7 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 	// Cross-arch builds (e.g. building arm64 on amd64) require QEMU emulation.
 	if arch != runtime.GOARCH {
 		if err := checkDockerPlatformSupport(platform); err != nil {
-			result.Error = err
-			return result, err
+			return err
 		}
 	}
 
@@ -338,13 +363,9 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 	args = append(args, b.opts.ServerBuildDir)
 
 	if err := b.Runner.Run(ctx, "docker", args...); err != nil {
-		result.Error = fmt.Errorf("docker build failed: %w", err)
-		return result, result.Error
+		return fmt.Errorf("docker build failed: %w", err)
 	}
-
-	result.Success = true
-	result.Duration = time.Since(start).Seconds()
-	return result, nil
+	return nil
 }
 
 // Push authenticates with ECR, tags the image, and pushes it.

--- a/internal/dflint/trivy.go
+++ b/internal/dflint/trivy.go
@@ -34,20 +34,33 @@ func runTrivy(imageRef string) ([]Finding, bool) {
 		return nil, false
 	}
 
-	// Check image exists locally before scanning
+	if !imageExistsLocally(imageRef) {
+		return nil, true
+	}
+
+	output, ok := execTrivyScan(path, imageRef)
+	if !ok {
+		return nil, true
+	}
+
+	return parseVulnerabilities(output), true
+}
+
+// imageExistsLocally checks whether the Docker image is available locally.
+func imageExistsLocally(imageRef string) bool {
 	dockerPath, err := exec.LookPath("docker")
 	if err != nil {
-		return nil, true
+		return false
 	}
 	inspectCmd := exec.Command(dockerPath, "image", "inspect", imageRef)
 	inspectCmd.Stdout = nil
 	inspectCmd.Stderr = nil
-	if err := inspectCmd.Run(); err != nil {
-		// Image doesn't exist locally — skip scan
-		return nil, true
-	}
+	return inspectCmd.Run() == nil
+}
 
-	cmd := exec.Command(path, "image",
+// execTrivyScan runs trivy and parses the JSON output.
+func execTrivyScan(trivyPath, imageRef string) (trivyOutput, bool) {
+	cmd := exec.Command(trivyPath, "image",
 		"--format", "json",
 		"--severity", "HIGH,CRITICAL",
 		"--quiet",
@@ -59,73 +72,91 @@ func runTrivy(imageRef string) ([]Finding, bool) {
 	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
-		// Trivy may exit non-zero when vulnerabilities are found
 		if stdout.Len() == 0 {
-			return nil, true
+			return trivyOutput{}, false
 		}
 	}
 
 	var output trivyOutput
 	if err := json.Unmarshal(stdout.Bytes(), &output); err != nil {
-		return nil, true
+		return trivyOutput{}, false
 	}
+	return output, true
+}
 
-	var findings []Finding
-	critCount := 0
-	highCount := 0
+// vulnCounts tracks how many vulnerabilities have been seen per severity.
+type vulnCounts struct {
+	critical int
+	high     int
+}
+
+// parseVulnerabilities collects findings from trivy output, capping each
+// severity level at maxPerSeverity and appending overflow notes.
+func parseVulnerabilities(output trivyOutput) []Finding {
 	const maxPerSeverity = 5
+	var counts vulnCounts
+	var findings []Finding
 
 	for _, result := range output.Results {
 		for _, vuln := range result.Vulnerabilities {
-			severity := strings.ToUpper(vuln.Severity)
-
-			// Limit display to top 5 per severity level
-			switch severity {
-			case "CRITICAL":
-				critCount++
-				if critCount > maxPerSeverity {
-					continue
-				}
-			case "HIGH":
-				highCount++
-				if highCount > maxPerSeverity {
-					continue
-				}
+			if f, ok := collectVuln(vuln, &counts, maxPerSeverity); ok {
+				findings = append(findings, f)
 			}
+		}
+	}
+	return appendOverflowNotes(findings, counts, maxPerSeverity)
+}
 
-			msg := vuln.Title
-			if vuln.PkgName != "" {
-				msg = fmt.Sprintf("%s (%s)", vuln.Title, vuln.PkgName)
-			}
+// collectVuln evaluates a single vulnerability against the per-severity cap.
+// Returns the finding and true if it should be included.
+func collectVuln(vuln trivyVuln, counts *vulnCounts, max int) (Finding, bool) {
+	severity := strings.ToUpper(vuln.Severity)
 
-			findings = append(findings, Finding{
-				Source:  "trivy",
-				Rule:    vuln.VulnerabilityID,
-				Level:   mapTrivySeverity(severity),
-				Message: msg,
-			})
+	switch severity {
+	case "CRITICAL":
+		counts.critical++
+		if counts.critical > max {
+			return Finding{}, false
+		}
+	case "HIGH":
+		counts.high++
+		if counts.high > max {
+			return Finding{}, false
 		}
 	}
 
-	// Add overflow notes if we truncated
-	if critCount > maxPerSeverity {
-		findings = append(findings, Finding{
-			Source:  "trivy",
-			Rule:    "overflow",
-			Level:   SeverityInfo,
-			Message: fmt.Sprintf("... and %d more CRITICAL vulnerabilities", critCount-maxPerSeverity),
-		})
-	}
-	if highCount > maxPerSeverity {
-		findings = append(findings, Finding{
-			Source:  "trivy",
-			Rule:    "overflow",
-			Level:   SeverityInfo,
-			Message: fmt.Sprintf("... and %d more HIGH vulnerabilities", highCount-maxPerSeverity),
-		})
+	msg := vuln.Title
+	if vuln.PkgName != "" {
+		msg = fmt.Sprintf("%s (%s)", vuln.Title, vuln.PkgName)
 	}
 
-	return findings, true
+	return Finding{
+		Source:  "trivy",
+		Rule:    vuln.VulnerabilityID,
+		Level:   mapTrivySeverity(severity),
+		Message: msg,
+	}, true
+}
+
+// appendOverflowNotes adds summary findings when vulnerabilities were truncated.
+func appendOverflowNotes(findings []Finding, counts vulnCounts, max int) []Finding {
+	if counts.critical > max {
+		findings = append(findings, Finding{
+			Source:  "trivy",
+			Rule:    "overflow",
+			Level:   SeverityInfo,
+			Message: fmt.Sprintf("... and %d more CRITICAL vulnerabilities", counts.critical-max),
+		})
+	}
+	if counts.high > max {
+		findings = append(findings, Finding{
+			Source:  "trivy",
+			Rule:    "overflow",
+			Level:   SeverityInfo,
+			Message: fmt.Sprintf("... and %d more HIGH vulnerabilities", counts.high-max),
+		})
+	}
+	return findings
 }
 
 // mapTrivySeverity converts trivy severity to our Severity type.

--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -96,21 +96,32 @@ func (b *DockerGameBuilder) containerProjectPath() string {
 
 // generateBuildScript creates the shell script that runs inside the container.
 func (b *DockerGameBuilder) generateBuildScript(serverBuild bool) string {
-	projectPath := b.containerProjectPath()
-	serverTarget := b.resolveServerTarget()
-	gameTarget := b.resolveGameTarget()
+	script := b.scriptPreamble()
+	if serverBuild {
+		script += b.serverBuildScript()
+	} else {
+		script += b.clientBuildScript()
+	}
+	return script
+}
 
+// scriptPreamble returns the common header for build scripts (shebang, NuGet workaround).
+func (b *DockerGameBuilder) scriptPreamble() string {
 	script := "#!/bin/bash\nset -e\n\n"
-
-	// Apply NuGetAuditLevel workaround (version-gated: 5.6 or unknown)
 	v := b.opts.EngineVersion
 	if v == "" || v == "5.6" {
 		script += "export NuGetAuditLevel=critical\n\n"
 	}
+	return script
+}
 
-	if serverBuild {
-		// Ensure DefaultServerTarget if needed
-		script += fmt.Sprintf(`# Ensure DefaultServerTarget in DefaultEngine.ini
+// serverBuildScript returns the shell commands for a server build inside Docker.
+func (b *DockerGameBuilder) serverBuildScript() string {
+	projectPath := b.containerProjectPath()
+	serverTarget := b.resolveServerTarget()
+	gameTarget := b.resolveGameTarget()
+
+	script := fmt.Sprintf(`# Ensure DefaultServerTarget in DefaultEngine.ini
 INI_PATH="%s/Config/DefaultEngine.ini"
 if [ -f "$INI_PATH" ] && ! grep -q "DefaultServerTarget" "$INI_PATH"; then
     if grep -q "DefaultGameTarget=%s" "$INI_PATH"; then
@@ -120,61 +131,62 @@ if [ -f "$INI_PATH" ] && ! grep -q "DefaultServerTarget" "$INI_PATH"; then
 fi
 
 `, filepath.Dir(projectPath), gameTarget, gameTarget, gameTarget, serverTarget, serverTarget)
-	}
 
 	script += "cd /engine\n\n"
 
-	if serverBuild {
-		args := fmt.Sprintf(`bash Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
+	args := fmt.Sprintf(`bash Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
   -project="%s" \
   -platform=Linux \
   -server -noclient \
   -servertargetname=%s \
   -build -stage -package -archive \
   -archivedirectory="/output"`,
-			projectPath, serverTarget)
+		projectPath, serverTarget)
 
-		if !b.opts.SkipCook {
-			args += " \\\n  -cook"
-		} else {
-			args += " \\\n  -skipcook"
-		}
-
-		if b.opts.ServerMap != "" {
-			args += fmt.Sprintf(` \
-  -map="%s"`, b.opts.ServerMap)
-		}
-
-		script += args + "\n"
+	if !b.opts.SkipCook {
+		args += " \\\n  -cook"
 	} else {
-		// Client build
-		platform := b.opts.ClientPlatform
-		if platform == "" {
-			platform = "Linux"
-		}
-		clientTarget := b.opts.ClientTarget
-		if clientTarget == "" {
-			clientTarget = b.resolveProjectName() + "Game"
-		}
+		args += " \\\n  -skipcook"
+	}
 
-		args := fmt.Sprintf(`bash Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
+	if b.opts.ServerMap != "" {
+		args += fmt.Sprintf(` \
+  -map="%s"`, b.opts.ServerMap)
+	}
+
+	return script + args + "\n"
+}
+
+// clientBuildScript returns the shell commands for a client build inside Docker.
+func (b *DockerGameBuilder) clientBuildScript() string {
+	projectPath := b.containerProjectPath()
+
+	platform := b.opts.ClientPlatform
+	if platform == "" {
+		platform = "Linux"
+	}
+	clientTarget := b.opts.ClientTarget
+	if clientTarget == "" {
+		clientTarget = b.resolveProjectName() + "Game"
+	}
+
+	script := "cd /engine\n\n"
+
+	args := fmt.Sprintf(`bash Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
   -project="%s" \
   -platform=%s \
   -build -stage -package -archive \
   -archivedirectory="/output"`,
-			projectPath, platform)
+		projectPath, platform)
 
-		if !b.opts.SkipCook {
-			args += " \\\n  -cook"
-		} else {
-			args += " \\\n  -skipcook"
-		}
-
-		_ = clientTarget // target name is implicit in the project for client builds
-		script += args + "\n"
+	if !b.opts.SkipCook {
+		args += " \\\n  -cook"
+	} else {
+		args += " \\\n  -skipcook"
 	}
 
-	return script
+	_ = clientTarget // target name is implicit in the project for client builds
+	return script + args + "\n"
 }
 
 // Build runs the game server build inside a Docker container.
@@ -186,56 +198,15 @@ func (b *DockerGameBuilder) Build(ctx context.Context) (*game.BuildResult, error
 		return nil, fmt.Errorf("engine Docker image not specified")
 	}
 
-	outputDir := b.opts.OutputDir
-	if outputDir == "" {
-		outputDir = filepath.Join(".", "PackagedServer")
-	}
-	// Ensure absolute path for Docker volume mount
-	if !filepath.IsAbs(outputDir) {
-		cwd, err := os.Getwd()
-		if err != nil {
-			return nil, fmt.Errorf("getting working directory: %w", err)
-		}
-		outputDir = filepath.Join(cwd, outputDir)
+	outputDir, err := b.prepareBuildContext(b.opts.OutputDir, "PackagedServer")
+	if err != nil {
+		return nil, err
 	}
 	result.OutputDir = outputDir
 
-	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return nil, fmt.Errorf("creating output directory: %w", err)
-	}
-
-	// Write the build script to a temp file
-	buildScript := b.generateBuildScript(true)
-	tmpFile, err := os.CreateTemp("", "ludus-build-*.sh")
-	if err != nil {
-		return nil, fmt.Errorf("creating temp build script: %w", err)
-	}
-	defer os.Remove(tmpFile.Name())
-
-	if _, err := tmpFile.WriteString(buildScript); err != nil {
-		tmpFile.Close()
-		return nil, fmt.Errorf("writing build script: %w", err)
-	}
-	tmpFile.Close()
-
-	// Build docker run command
-	args := []string{
-		"run", "--rm",
-		"-v", fmt.Sprintf("%s:/output", outputDir),
-		"-v", fmt.Sprintf("%s:/build.sh:ro", tmpFile.Name()),
-	}
-
-	// Mount external project if needed
-	if b.isExternalProject() {
-		projectDir := filepath.Dir(b.opts.ProjectPath)
-		args = append(args, "-v", fmt.Sprintf("%s:/project", projectDir))
-	}
-
-	args = append(args, b.opts.EngineImage, "bash", "/build.sh")
-
-	if err := b.Runner.Run(ctx, "docker", args...); err != nil {
-		result.Error = fmt.Errorf("docker game build failed: %w", err)
-		return result, result.Error
+	if err := b.runServerBuildContainer(ctx, outputDir); err != nil {
+		result.Error = err
+		return result, err
 	}
 
 	result.Success = true
@@ -245,53 +216,43 @@ func (b *DockerGameBuilder) Build(ctx context.Context) (*game.BuildResult, error
 	return result, nil
 }
 
-// BuildClient runs the game client build inside a Docker container.
-// Only Linux client builds are supported in Docker (Win64 cross-compile is out of scope).
-func (b *DockerGameBuilder) BuildClient(ctx context.Context) (*game.ClientBuildResult, error) {
-	start := time.Now()
-	result := &game.ClientBuildResult{}
-
-	platform := b.opts.ClientPlatform
-	if platform == "" {
-		platform = "Linux"
-	}
-	if platform != "Linux" {
-		return nil, fmt.Errorf("Docker game builder only supports Linux client builds (got %q)", platform)
-	}
-	result.Platform = platform
-
-	if b.opts.EngineImage == "" {
-		return nil, fmt.Errorf("engine Docker image not specified")
-	}
-
-	outputDir := b.opts.OutputDir
+// prepareBuildContext resolves the output directory to an absolute path and
+// creates it if needed. defaultSubdir is used when OutputDir is empty.
+func (b *DockerGameBuilder) prepareBuildContext(outputDir, defaultSubdir string) (string, error) {
 	if outputDir == "" {
-		outputDir = filepath.Join(".", "PackagedClient")
+		outputDir = filepath.Join(".", defaultSubdir)
 	}
 	if !filepath.IsAbs(outputDir) {
 		cwd, err := os.Getwd()
 		if err != nil {
-			return nil, fmt.Errorf("getting working directory: %w", err)
+			return "", fmt.Errorf("getting working directory: %w", err)
 		}
 		outputDir = filepath.Join(cwd, outputDir)
 	}
-	result.OutputDir = outputDir
-
 	if err := os.MkdirAll(outputDir, 0755); err != nil {
-		return nil, fmt.Errorf("creating output directory: %w", err)
+		return "", fmt.Errorf("creating output directory: %w", err)
 	}
+	return outputDir, nil
+}
 
-	// Write the build script
-	buildScript := b.generateBuildScript(false)
-	tmpFile, err := os.CreateTemp("", "ludus-client-build-*.sh")
+// runServerBuildContainer writes the build script and runs the Docker container.
+func (b *DockerGameBuilder) runServerBuildContainer(ctx context.Context, outputDir string) error {
+	buildScript := b.generateBuildScript(true)
+	return b.runBuildContainer(ctx, outputDir, buildScript, "docker game build")
+}
+
+// runBuildContainer writes a build script to a temp file and runs it in a
+// Docker container with the output directory and optional project volume-mounted.
+func (b *DockerGameBuilder) runBuildContainer(ctx context.Context, outputDir, script, label string) error {
+	tmpFile, err := os.CreateTemp("", "ludus-build-*.sh")
 	if err != nil {
-		return nil, fmt.Errorf("creating temp build script: %w", err)
+		return fmt.Errorf("creating temp build script: %w", err)
 	}
 	defer os.Remove(tmpFile.Name())
 
-	if _, err := tmpFile.WriteString(buildScript); err != nil {
+	if _, err := tmpFile.WriteString(script); err != nil {
 		tmpFile.Close()
-		return nil, fmt.Errorf("writing build script: %w", err)
+		return fmt.Errorf("writing build script: %w", err)
 	}
 	tmpFile.Close()
 
@@ -309,8 +270,36 @@ func (b *DockerGameBuilder) BuildClient(ctx context.Context) (*game.ClientBuildR
 	args = append(args, b.opts.EngineImage, "bash", "/build.sh")
 
 	if err := b.Runner.Run(ctx, "docker", args...); err != nil {
-		result.Error = fmt.Errorf("docker client build failed: %w", err)
-		return result, result.Error
+		return fmt.Errorf("%s failed: %w", label, err)
+	}
+	return nil
+}
+
+// BuildClient runs the game client build inside a Docker container.
+// Only Linux client builds are supported in Docker (Win64 cross-compile is out of scope).
+func (b *DockerGameBuilder) BuildClient(ctx context.Context) (*game.ClientBuildResult, error) {
+	start := time.Now()
+	result := &game.ClientBuildResult{}
+
+	platform := b.resolveClientPlatform()
+	if platform != "Linux" {
+		return nil, fmt.Errorf("Docker game builder only supports Linux client builds (got %q)", platform)
+	}
+	result.Platform = platform
+
+	if b.opts.EngineImage == "" {
+		return nil, fmt.Errorf("engine Docker image not specified")
+	}
+
+	outputDir, err := b.prepareBuildContext(b.opts.OutputDir, "PackagedClient")
+	if err != nil {
+		return nil, err
+	}
+	result.OutputDir = outputDir
+
+	if err := b.runClientBuildContainer(ctx, outputDir); err != nil {
+		result.Error = err
+		return result, err
 	}
 
 	projectName := b.resolveProjectName()
@@ -318,4 +307,18 @@ func (b *DockerGameBuilder) BuildClient(ctx context.Context) (*game.ClientBuildR
 	result.ClientBinary = filepath.Join(outputDir, "Linux", projectName, "Binaries", "Linux", projectName+"Game")
 	result.Duration = time.Since(start).Seconds()
 	return result, nil
+}
+
+// resolveClientPlatform returns the client platform, defaulting to "Linux".
+func (b *DockerGameBuilder) resolveClientPlatform() string {
+	if b.opts.ClientPlatform != "" {
+		return b.opts.ClientPlatform
+	}
+	return "Linux"
+}
+
+// runClientBuildContainer writes the client build script and runs the Docker container.
+func (b *DockerGameBuilder) runClientBuildContainer(ctx context.Context, outputDir string) error {
+	buildScript := b.generateBuildScript(false)
+	return b.runBuildContainer(ctx, outputDir, buildScript, "docker client build")
 }

--- a/internal/ec2fleet/deployer.go
+++ b/internal/ec2fleet/deployer.go
@@ -341,74 +341,99 @@ func (d *Deployer) GetFleetStatus(ctx context.Context) (*FleetStatus, error) {
 // Destroy tears down EC2 fleet resources in reverse order:
 // fleet → build → S3 object → IAM role.
 func (d *Deployer) Destroy(ctx context.Context, fleetID, buildID, s3Bucket, s3Key string) error {
-	// 1. Delete fleet
-	if fleetID != "" {
-		fmt.Println("Deleting fleet...")
-		_, err := d.glClient.DeleteFleet(ctx, &gamelift.DeleteFleetInput{
-			FleetId: aws.String(fleetID),
-		})
-		if err != nil && !awsutil.IsNotFound(err) {
-			return fmt.Errorf("deleting fleet: %w", err)
-		}
-
-		// Poll until the fleet is gone
-		deadline := time.Now().Add(maxPollWait)
-		for time.Now().Before(deadline) {
-			desc, err := d.glClient.DescribeFleetAttributes(ctx, &gamelift.DescribeFleetAttributesInput{
-				FleetIds: []string{fleetID},
-			})
-			if err != nil {
-				if awsutil.IsNotFound(err) {
-					break
-				}
-				return fmt.Errorf("polling fleet deletion: %w", err)
-			}
-			if len(desc.FleetAttributes) == 0 {
-				break
-			}
-			fmt.Println("  Waiting for fleet deletion...")
-			select {
-			case <-ctx.Done():
-				return ctx.Err()
-			case <-time.After(pollInterval):
-			}
-		}
-		fmt.Println("Fleet deleted.")
+	if err := d.deleteFleetResource(ctx, fleetID); err != nil {
+		return err
 	}
+	d.deleteBuildResource(ctx, buildID)
+	d.deleteS3Object(ctx, s3Bucket, s3Key)
 
-	// 2. Delete build
-	if buildID != "" {
-		fmt.Println("Deleting build...")
-		_, err := d.glClient.DeleteBuild(ctx, &gamelift.DeleteBuildInput{
-			BuildId: aws.String(buildID),
-		})
-		if err != nil && !awsutil.IsNotFound(err) {
-			fmt.Printf("Warning: failed to delete build: %v\n", err)
-		} else {
-			fmt.Println("Build deleted.")
-		}
-	}
-
-	// 3. Delete S3 object
-	if s3Bucket != "" && s3Key != "" {
-		fmt.Printf("Deleting S3 object s3://%s/%s...\n", s3Bucket, s3Key)
-		_, err := d.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-			Bucket: aws.String(s3Bucket),
-			Key:    aws.String(s3Key),
-		})
-		if err != nil {
-			fmt.Printf("Warning: failed to delete S3 object: %v\n", err)
-		} else {
-			fmt.Println("S3 object deleted.")
-		}
-	}
-
-	// 4. Delete IAM role
 	if err := d.deleteIAMRole(ctx); err != nil {
 		fmt.Printf("Warning: failed to delete IAM role: %v\n", err)
 	}
 
 	return nil
+}
+
+// deleteFleetResource deletes the fleet and polls until it is gone.
+func (d *Deployer) deleteFleetResource(ctx context.Context, fleetID string) error {
+	if fleetID == "" {
+		return nil
+	}
+
+	fmt.Println("Deleting fleet...")
+	_, err := d.glClient.DeleteFleet(ctx, &gamelift.DeleteFleetInput{
+		FleetId: aws.String(fleetID),
+	})
+	if err != nil && !awsutil.IsNotFound(err) {
+		return fmt.Errorf("deleting fleet: %w", err)
+	}
+
+	if err := d.waitForFleetDeletion(ctx, fleetID); err != nil {
+		return err
+	}
+	fmt.Println("Fleet deleted.")
+	return nil
+}
+
+// waitForFleetDeletion polls until the fleet no longer exists.
+func (d *Deployer) waitForFleetDeletion(ctx context.Context, fleetID string) error {
+	deadline := time.Now().Add(maxPollWait)
+	for time.Now().Before(deadline) {
+		desc, err := d.glClient.DescribeFleetAttributes(ctx, &gamelift.DescribeFleetAttributesInput{
+			FleetIds: []string{fleetID},
+		})
+		if err != nil {
+			if awsutil.IsNotFound(err) {
+				return nil
+			}
+			return fmt.Errorf("polling fleet deletion: %w", err)
+		}
+		if len(desc.FleetAttributes) == 0 {
+			return nil
+		}
+		fmt.Println("  Waiting for fleet deletion...")
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+	return nil
+}
+
+// deleteBuildResource deletes the GameLift build, logging a warning on failure.
+func (d *Deployer) deleteBuildResource(ctx context.Context, buildID string) {
+	if buildID == "" {
+		return
+	}
+
+	fmt.Println("Deleting build...")
+	_, err := d.glClient.DeleteBuild(ctx, &gamelift.DeleteBuildInput{
+		BuildId: aws.String(buildID),
+	})
+	if err != nil && !awsutil.IsNotFound(err) {
+		fmt.Printf("Warning: failed to delete build: %v\n", err)
+		return
+	}
+	fmt.Println("Build deleted.")
+}
+
+// deleteS3Object removes the server build archive from S3.
+func (d *Deployer) deleteS3Object(ctx context.Context, bucket, key string) {
+	if bucket == "" || key == "" {
+		return
+	}
+
+	fmt.Printf("Deleting S3 object s3://%s/%s...\n", bucket, key)
+	_, err := d.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to delete S3 object: %v\n", err)
+		return
+	}
+	fmt.Println("S3 object deleted.")
 }
 
 func (d *Deployer) deleteIAMRole(ctx context.Context) error {

--- a/internal/ecr/push.go
+++ b/internal/ecr/push.go
@@ -37,7 +37,17 @@ func Push(ctx context.Context, r *runner.Runner, localTag string, opts PushOptio
 	ecrURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s",
 		opts.AWSAccountID, opts.AWSRegion, opts.ECRRepository)
 
-	// Ensure ECR repository exists (create if missing).
+	if err := ensureECRRepository(ctx, r, opts); err != nil {
+		return err
+	}
+	if err := authenticateECR(ctx, r, opts); err != nil {
+		return err
+	}
+	return tagAndPush(ctx, r, localTag, ecrURI, opts.ImageTag)
+}
+
+// ensureECRRepository creates the ECR repository if it does not already exist.
+func ensureECRRepository(ctx context.Context, r *runner.Runner, opts PushOptions) error {
 	if err := r.RunQuiet(ctx, "aws", "ecr", "describe-repositories",
 		"--repository-names", opts.ECRRepository,
 		"--region", opts.AWSRegion); err != nil {
@@ -50,11 +60,14 @@ func Push(ctx context.Context, r *runner.Runner, localTag string, opts PushOptio
 			return fmt.Errorf("creating ECR repository: %w", err)
 		}
 	}
+	return nil
+}
 
-	// Authenticate with ECR — get password then pipe to docker login.
-	// Both steps are retried since ECR auth tokens can fail on transient errors.
+// authenticateECR retrieves an ECR auth token and logs Docker in.
+func authenticateECR(ctx context.Context, r *runner.Runner, opts PushOptions) error {
 	loginURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", opts.AWSAccountID, opts.AWSRegion)
 	retryCfg := retry.Default()
+
 	var password []byte
 	if err := retry.Do(ctx, retryCfg, func() error {
 		var err error
@@ -63,24 +76,28 @@ func Push(ctx context.Context, r *runner.Runner, localTag string, opts PushOptio
 	}); err != nil {
 		return fmt.Errorf("getting ECR password: %w", err)
 	}
+
 	if err := retry.Do(ctx, retryCfg, func() error {
 		return r.RunQuietWithStdin(ctx, strings.NewReader(strings.TrimSpace(string(password))),
 			"docker", "login", "--username", "AWS", "--password-stdin", loginURI)
 	}); err != nil {
 		return fmt.Errorf("ECR login failed: %w", err)
 	}
-	fmt.Println("  ECR login succeeded")
 
-	// Tag and push.
-	remoteTag := fmt.Sprintf("%s:%s", ecrURI, opts.ImageTag)
+	fmt.Println("  ECR login succeeded")
+	return nil
+}
+
+// tagAndPush tags the local image with the remote URI and pushes it.
+func tagAndPush(ctx context.Context, r *runner.Runner, localTag, ecrURI, imageTag string) error {
+	remoteTag := fmt.Sprintf("%s:%s", ecrURI, imageTag)
 	if err := r.RunQuiet(ctx, "docker", "tag", localTag, remoteTag); err != nil {
 		return fmt.Errorf("docker tag failed: %w", err)
 	}
-	if err := retry.Do(ctx, retryCfg, func() error {
+	if err := retry.Do(ctx, retry.Default(), func() error {
 		return r.Run(ctx, "docker", "push", remoteTag)
 	}); err != nil {
 		return fmt.Errorf("docker push failed: %w", err)
 	}
-
 	return nil
 }

--- a/internal/game/builder.go
+++ b/internal/game/builder.go
@@ -152,28 +152,57 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		return result, err
 	}
 
+	if err := b.prepareBuildEnvironment(projectPath); err != nil {
+		result.Error = err
+		return result, err
+	}
+
+	args, outputDir, serverTarget, err := b.resolveServerBuildArgs(projectPath)
+	if err != nil {
+		result.Error = err
+		return result, err
+	}
+	result.OutputDir = outputDir
+
+	if err := b.runBuildStep(ctx, shell, runatPath, args); err != nil {
+		result.Error = err
+		return result, err
+	}
+
+	arch := config.NormalizeArch(b.opts.Arch)
+	result.Success = true
+	result.ServerBinary = filepath.Join(outputDir, config.ServerPlatformDir(arch), serverTarget)
+	result.Duration = time.Since(start).Seconds()
+	return result, nil
+}
+
+// prepareBuildEnvironment applies workarounds and ensures ARM64 settings.
+func (b *Builder) prepareBuildEnvironment(projectPath string) error {
 	b.applyNuGetAuditWorkaround()
 	b.ensureLinuxMultiarchRoot()
 
 	if err := b.ensureDefaultServerTarget(projectPath); err != nil {
-		result.Error = fmt.Errorf("setting default server target: %w", err)
-		return result, result.Error
+		return fmt.Errorf("setting default server target: %w", err)
 	}
 
 	arch := config.NormalizeArch(b.opts.Arch)
 	if arch == "arm64" {
 		if err := b.ensureTargetArchitecture(projectPath); err != nil {
-			result.Error = fmt.Errorf("setting target architecture: %w", err)
-			return result, result.Error
+			return fmt.Errorf("setting target architecture: %w", err)
 		}
 		defer b.disableDumpSyms()()
 	}
+	return nil
+}
 
+// resolveServerBuildArgs assembles the UAT arguments for BuildCookRun.
+// Returns the args slice, resolved output directory, and server target name.
+func (b *Builder) resolveServerBuildArgs(projectPath string) ([]string, string, string, error) {
+	arch := config.NormalizeArch(b.opts.Arch)
 	outputDir := b.opts.OutputDir
 	if outputDir == "" {
 		outputDir = filepath.Join(filepath.Dir(projectPath), "PackagedServer")
 	}
-	result.OutputDir = outputDir
 
 	serverTarget := b.opts.ServerTarget
 	if serverTarget == "" {
@@ -209,7 +238,7 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		args = append(args, fmt.Sprintf(`-map="%s"`, b.opts.ServerMap))
 	}
 
-	// Limit compile parallelism to prevent OOM. During cross-compile (Windows→Linux),
+	// Limit compile parallelism to prevent OOM. During cross-compile (Windows->Linux),
 	// both toolchains are loaded simultaneously, roughly doubling memory per job.
 	isCrossCompile := runtime.GOOS == "windows" // server is always Linux
 	if jobs := b.resolveMaxJobs(isCrossCompile); jobs > 0 {
@@ -217,18 +246,18 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 		fmt.Printf("  Limiting parallel compile actions to %d\n", jobs)
 	}
 
+	return args, outputDir, serverTarget, nil
+}
+
+// runBuildStep executes the UAT build and wraps errors with diagnostics.
+func (b *Builder) runBuildStep(ctx context.Context, shell, runatPath string, args []string) error {
 	ticker := progress.Start("Server build", 2*time.Minute)
 	buildErr := b.execRunUAT(ctx, shell, runatPath, args)
 	ticker.Stop()
 	if buildErr != nil {
-		result.Error = diagnoseBuildError(buildErr, "BuildCookRun", b.opts.EnginePath)
-		return result, result.Error
+		return diagnoseBuildError(buildErr, "BuildCookRun", b.opts.EnginePath)
 	}
-
-	result.Success = true
-	result.ServerBinary = filepath.Join(outputDir, config.ServerPlatformDir(arch), serverTarget)
-	result.Duration = time.Since(start).Seconds()
-	return result, nil
+	return nil
 }
 
 // PartialBuildHint checks for cooked content from a previous server build
@@ -306,18 +335,20 @@ func diagnoseBuildError(err error, action, enginePath string) error {
 	}
 
 	// Scan build logs for additional diagnostics
-	msg := fmt.Sprintf("%s failed", action)
+	var b strings.Builder
+	fmt.Fprintf(&b, "%s failed", action)
 	if hints := scanBuildLogs(enginePath); len(hints) > 0 {
-		msg += "\n\nDiagnostics from build logs:"
+		b.WriteString("\n\nDiagnostics from build logs:")
 		for _, h := range hints {
-			msg += "\n  - " + h
+			b.WriteString("\n  - ")
+			b.WriteString(h)
 		}
 	}
 
 	logDir := filepath.Join(enginePath, "Engine", "Programs", "AutomationTool", "Saved", "Logs")
-	msg += fmt.Sprintf("\n\nFull build log: %s", filepath.Join(logDir, "Log.txt"))
+	fmt.Fprintf(&b, "\n\nFull build log: %s", filepath.Join(logDir, "Log.txt"))
 
-	return fmt.Errorf("%s: %w", msg, err)
+	return fmt.Errorf("%s: %w", b.String(), err)
 }
 
 // knownLogPattern maps a string found in build logs to user-facing guidance.
@@ -402,11 +433,7 @@ func (b *Builder) resolveMaxJobs(crossCompile bool) int {
 		gbPerJob = 16
 	}
 
-	jobs := ramGB / gbPerJob
-	if jobs < 1 {
-		jobs = 1
-	}
-	return jobs
+	return max(ramGB/gbPerJob, 1)
 }
 
 // applyNuGetAuditWorkaround sets NuGetAuditLevel=critical as an environment

--- a/internal/prereq/checker_windows.go
+++ b/internal/prereq/checker_windows.go
@@ -56,110 +56,125 @@ func (c *Checker) platformChecks() []CheckResult {
 	return results
 }
 
+// c4756File describes a source file affected by the C4756 overflow warning.
+type c4756File struct {
+	relPath     string
+	description string
+}
+
+// c4756Files lists the UE 5.4 source files that need the C4756 pragma patch.
+var c4756Files = []c4756File{
+	{
+		filepath.Join("Engine", "Source", "Runtime", "RenderCore", "Private", "RenderGraphPrivate.cpp"),
+		"uses NAN macro",
+	},
+	{
+		filepath.Join("Engine", "Plugins", "Runtime", "AudioSynesthesia", "Source", "AudioSynesthesiaCore", "Private", "PeakPicker.cpp"),
+		"uses INFINITY macro",
+	},
+}
+
+// c4756State holds the detection results for the C4756 patch.
+type c4756State struct {
+	patched, alreadyPatched, notFound int
+	firstUnpatched                    string
+}
+
 // checkC4756Patch checks and optionally fixes C4756 "overflow in constant
 // arithmetic" errors in UE 5.4 source files. This occurs with MSVC 14.38 and
 // Windows SDK >= 26100 because the NAN and INFINITY macros in <math.h> use
 // constant expressions that trigger the warning, promoted to error by /WX.
 func (c *Checker) checkC4756Patch() CheckResult {
-	files := []struct {
-		relPath     string
-		description string
-	}{
-		{
-			filepath.Join("Engine", "Source", "Runtime", "RenderCore", "Private", "RenderGraphPrivate.cpp"),
-			"uses NAN macro",
-		},
-		{
-			filepath.Join("Engine", "Plugins", "Runtime", "AudioSynesthesia", "Source", "AudioSynesthesiaCore", "Private", "PeakPicker.cpp"),
-			"uses INFINITY macro",
-		},
+	state, earlyResult := c.detectC4756State()
+	if earlyResult != nil {
+		return *earlyResult
 	}
+	return c.c4756Result(state)
+}
 
+// detectC4756State scans files for the C4756 pragma and optionally applies it.
+// Returns an early CheckResult pointer if an error occurs mid-scan.
+func (c *Checker) detectC4756State() (c4756State, *CheckResult) {
 	const pragma = "#pragma warning(disable: 4756)"
+	var s c4756State
 
-	var patched, alreadyPatched, notFound int
-	var firstUnpatched string
-	for _, f := range files {
+	for _, f := range c4756Files {
 		fullPath := filepath.Join(c.EngineSourcePath, f.relPath)
 		data, err := os.ReadFile(fullPath)
 		if err != nil {
 			if os.IsNotExist(err) {
-				notFound++
+				s.notFound++
 				continue
 			}
-			return CheckResult{
-				Name:    "C4756 Patch",
-				Passed:  false,
-				Message: fmt.Sprintf("cannot read %s: %v", fullPath, err),
-			}
+			r := CheckResult{Name: "C4756 Patch", Passed: false, Message: fmt.Sprintf("cannot read %s: %v", fullPath, err)}
+			return s, &r
 		}
 
 		content := string(data)
 		if strings.Contains(content, pragma) {
-			alreadyPatched++
+			s.alreadyPatched++
 			continue
 		}
 
 		if !c.Fix {
-			if firstUnpatched == "" {
-				firstUnpatched = f.relPath
+			if s.firstUnpatched == "" {
+				s.firstUnpatched = f.relPath
 			}
 			continue
 		}
 
-		// Insert the pragma before the first #include
-		idx := strings.Index(content, "#include")
-		if idx == -1 {
-			return CheckResult{
-				Name:    "C4756 Patch",
-				Passed:  false,
-				Message: fmt.Sprintf("could not find #include in %s; patch manually", fullPath),
-			}
+		if r := applyC4756Patch(fullPath, content, pragma); r != nil {
+			return s, r
 		}
-
-		patchedContent := content[:idx] + pragma + "\n\n" + content[idx:]
-		if err := os.WriteFile(fullPath, []byte(patchedContent), 0o644); err != nil {
-			return CheckResult{
-				Name:    "C4756 Patch",
-				Passed:  false,
-				Message: fmt.Sprintf("failed to write %s: %v", fullPath, err),
-			}
-		}
-		patched++
+		s.patched++
 	}
 
-	totalFiles := len(files)
+	return s, nil
+}
 
-	if notFound == totalFiles {
+// applyC4756Patch inserts the C4756 pragma before the first #include.
+// Returns a CheckResult on failure, nil on success.
+func applyC4756Patch(fullPath, content, pragma string) *CheckResult {
+	idx := strings.Index(content, "#include")
+	if idx == -1 {
+		r := CheckResult{Name: "C4756 Patch", Passed: false, Message: fmt.Sprintf("could not find #include in %s; patch manually", fullPath)}
+		return &r
+	}
+
+	patchedContent := content[:idx] + pragma + "\n\n" + content[idx:]
+	if err := os.WriteFile(fullPath, []byte(patchedContent), 0o644); err != nil {
+		r := CheckResult{Name: "C4756 Patch", Passed: false, Message: fmt.Sprintf("failed to write %s: %v", fullPath, err)}
+		return &r
+	}
+	return nil
+}
+
+// c4756Result converts a c4756State into a CheckResult.
+func (c *Checker) c4756Result(s c4756State) CheckResult {
+	if s.notFound == len(c4756Files) {
 		return CheckResult{
-			Name:    "C4756 Patch",
-			Passed:  true,
-			Warning: true,
+			Name: "C4756 Patch", Passed: true, Warning: true,
 			Message: "source files not found (engine may be a different version); skipped",
 		}
 	}
 
-	if firstUnpatched != "" {
+	if s.firstUnpatched != "" {
 		return CheckResult{
-			Name:   "C4756 Patch",
-			Passed: false,
+			Name: "C4756 Patch", Passed: false,
 			Message: fmt.Sprintf("C4756 suppression missing in %s; "+
-				"run with --fix to patch (required for MSVC 14.38 + SDK >= 26100)",
-				firstUnpatched),
+				"run with --fix to patch (required for MSVC 14.38 + SDK >= 26100)", s.firstUnpatched),
 		}
 	}
 
-	if patched > 0 {
+	if s.patched > 0 {
 		return CheckResult{
-			Name:    "C4756 Patch",
-			Passed:  true,
-			Message: fmt.Sprintf("patched %d file(s) (added C4756 warning suppression)", patched),
+			Name: "C4756 Patch", Passed: true,
+			Message: fmt.Sprintf("patched %d file(s) (added C4756 warning suppression)", s.patched),
 		}
 	}
 
 	return CheckResult{
-		Name:    "C4756 Patch",
-		Passed:  true,
+		Name: "C4756 Patch", Passed: true,
 		Message: "C4756 warning suppression present in affected files",
 	}
 }
@@ -170,22 +185,9 @@ func (c *Checker) checkNNERuntimeORTPatch() CheckResult {
 		"Source", "NNERuntimeORT", "NNERuntimeORT.Build.cs",
 	)
 
-	data, err := os.ReadFile(buildCSPath)
-	if err != nil {
-		return CheckResult{
-			Name:    "NNERuntimeORT Patch",
-			Passed:  false,
-			Message: fmt.Sprintf("cannot read %s: %v", buildCSPath, err),
-		}
-	}
-
-	content := string(data)
-	if strings.Contains(content, "INITGUID") {
-		return CheckResult{
-			Name:    "NNERuntimeORT Patch",
-			Passed:  true,
-			Message: "INITGUID definition present in NNERuntimeORT.Build.cs",
-		}
+	result := detectORTState(buildCSPath)
+	if result != nil {
+		return *result
 	}
 
 	if !c.Fix {
@@ -198,13 +200,49 @@ func (c *Checker) checkNNERuntimeORTPatch() CheckResult {
 		}
 	}
 
-	// Auto-fix: insert PublicDefinitions.Add("INITGUID"); after ORT_USE_NEW_DXCORE_FEATURES
+	return applyORTPatch(buildCSPath)
+}
+
+// detectORTState reads the Build.cs file and checks if INITGUID is already present.
+// Returns a CheckResult if the state is terminal (error or already patched), nil if patching is needed.
+func detectORTState(buildCSPath string) *CheckResult {
+	data, err := os.ReadFile(buildCSPath)
+	if err != nil {
+		r := CheckResult{
+			Name: "NNERuntimeORT Patch", Passed: false,
+			Message: fmt.Sprintf("cannot read %s: %v", buildCSPath, err),
+		}
+		return &r
+	}
+
+	if strings.Contains(string(data), "INITGUID") {
+		r := CheckResult{
+			Name: "NNERuntimeORT Patch", Passed: true,
+			Message: "INITGUID definition present in NNERuntimeORT.Build.cs",
+		}
+		return &r
+	}
+
+	return nil
+}
+
+// applyORTPatch inserts PublicDefinitions.Add("INITGUID") after the
+// ORT_USE_NEW_DXCORE_FEATURES line in the Build.cs file.
+func applyORTPatch(buildCSPath string) CheckResult {
+	data, err := os.ReadFile(buildCSPath)
+	if err != nil {
+		return CheckResult{
+			Name: "NNERuntimeORT Patch", Passed: false,
+			Message: fmt.Sprintf("cannot read %s: %v", buildCSPath, err),
+		}
+	}
+
+	content := string(data)
 	marker := `PublicDefinitions.Add("ORT_USE_NEW_DXCORE_FEATURES");`
 	idx := strings.Index(content, marker)
 	if idx == -1 {
 		return CheckResult{
-			Name:   "NNERuntimeORT Patch",
-			Passed: false,
+			Name: "NNERuntimeORT Patch", Passed: false,
 			Message: fmt.Sprintf("could not find ORT_USE_NEW_DXCORE_FEATURES in %s; patch manually per UE_SOURCE_PATCHES.md",
 				buildCSPath),
 		}
@@ -229,15 +267,13 @@ func (c *Checker) checkNNERuntimeORTPatch() CheckResult {
 
 	if err := os.WriteFile(buildCSPath, []byte(patchedContent), 0o644); err != nil {
 		return CheckResult{
-			Name:    "NNERuntimeORT Patch",
-			Passed:  false,
+			Name: "NNERuntimeORT Patch", Passed: false,
 			Message: fmt.Sprintf("failed to write patched file: %v", err),
 		}
 	}
 
 	return CheckResult{
-		Name:    "NNERuntimeORT Patch",
-		Passed:  true,
+		Name: "NNERuntimeORT Patch", Passed: true,
 		Message: fmt.Sprintf("patched %s (added INITGUID definition)", buildCSPath),
 	}
 }
@@ -316,15 +352,19 @@ func downloadFile(filepath string, url string) error {
 	}
 	defer out.Close()
 
-	totalBytes := resp.ContentLength
-	var downloaded int64
+	return copyWithProgress(resp.Body, out, resp.ContentLength)
+}
 
+// copyWithProgress copies from reader to writer, printing progress at 10% intervals.
+func copyWithProgress(src io.Reader, dst io.Writer, totalBytes int64) error {
 	buf := make([]byte, 32*1024)
+	var downloaded int64
 	lastPct := -1
+
 	for {
-		n, readErr := resp.Body.Read(buf)
+		n, readErr := src.Read(buf)
 		if n > 0 {
-			if _, writeErr := out.Write(buf[:n]); writeErr != nil {
+			if _, writeErr := dst.Write(buf[:n]); writeErr != nil {
 				return writeErr
 			}
 			downloaded += int64(n)
@@ -338,13 +378,11 @@ func downloadFile(filepath string, url string) error {
 		}
 		if readErr != nil {
 			if readErr == io.EOF {
-				break
+				return nil
 			}
 			return readErr
 		}
 	}
-
-	return nil
 }
 
 func (c *Checker) checkDiskSpace() CheckResult {

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -107,6 +107,15 @@ func buildWrapper(ctx context.Context, r *runner.Runner, cacheDir, arch string) 
 // buildWrapperWindows replicates the Makefile's `build` target on Windows
 // (or for non-amd64 architectures) using curl and Go cross-compilation.
 func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir, arch string) error {
+	if err := downloadWrapperSource(ctx, r, cacheDir); err != nil {
+		return err
+	}
+	return buildWrapperBinary(ctx, r, cacheDir, arch)
+}
+
+// downloadWrapperSource downloads and extracts the GameLift Server SDK
+// into the cache directory if not already present.
+func downloadWrapperSource(ctx context.Context, r *runner.Runner, cacheDir string) error {
 	sdkZip := filepath.Join(cacheDir, "gamelift-servers-server-sdk.zip")
 	sdkDir := filepath.Join(cacheDir, "src", "ext", "gamelift-servers-server-sdk")
 
@@ -120,27 +129,39 @@ func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir, arch s
 		}
 	}
 
-	// Extract the SDK
+	// Extract the SDK if not already present
 	if _, err := os.Stat(sdkDir); err != nil {
 		if err := os.MkdirAll(sdkDir, 0755); err != nil {
 			return fmt.Errorf("creating SDK directory: %w", err)
 		}
-		if runtime.GOOS == "windows" {
-			if err := r.Run(ctx, "powershell", "-NoProfile", "-Command",
-				fmt.Sprintf("Expand-Archive -Path '%s' -DestinationPath '%s' -Force", sdkZip, sdkDir)); err != nil {
-				return fmt.Errorf("extracting server SDK: %w", err)
-			}
-		} else {
-			if err := r.Run(ctx, "unzip", "-o", sdkZip, "-d", sdkDir); err != nil {
-				return fmt.Errorf("extracting server SDK: %w", err)
-			}
+		if err := extractSDK(ctx, r, sdkZip, sdkDir); err != nil {
+			return err
 		}
 	}
 
-	// Cross-compile for linux/<arch>
+	return nil
+}
+
+// extractSDK extracts the SDK zip using the platform-appropriate tool.
+func extractSDK(ctx context.Context, r *runner.Runner, sdkZip, sdkDir string) error {
+	if runtime.GOOS == "windows" {
+		if err := r.Run(ctx, "powershell", "-NoProfile", "-Command",
+			fmt.Sprintf("Expand-Archive -Path '%s' -DestinationPath '%s' -Force", sdkZip, sdkDir)); err != nil {
+			return fmt.Errorf("extracting server SDK: %w", err)
+		}
+		return nil
+	}
+	if err := r.Run(ctx, "unzip", "-o", sdkZip, "-d", sdkDir); err != nil {
+		return fmt.Errorf("extracting server SDK: %w", err)
+	}
+	return nil
+}
+
+// buildWrapperBinary cross-compiles the wrapper for linux/<arch> and copies
+// the config template into the output directory.
+func buildWrapperBinary(ctx context.Context, r *runner.Runner, cacheDir, arch string) error {
 	srcDir := filepath.Join(cacheDir, "src")
-	outDir := filepath.Join(cacheDir, "out", "linux", arch)
-	binaryDir := filepath.Join(outDir, "gamelift-servers-managed-containers")
+	binaryDir := filepath.Join(cacheDir, "out", "linux", arch, "gamelift-servers-managed-containers")
 	if err := os.MkdirAll(binaryDir, 0755); err != nil {
 		return fmt.Errorf("creating output directory: %w", err)
 	}
@@ -168,6 +189,5 @@ func buildWrapperWindows(ctx context.Context, r *runner.Runner, cacheDir, arch s
 	if err := os.WriteFile(configDst, configData, 0644); err != nil {
 		return fmt.Errorf("writing config: %w", err)
 	}
-
 	return nil
 }


### PR DESCRIPTION
## Summary
- **Security**: Go 1.25.0 → 1.25.8 fixes 3 stdlib CVEs (GO-2026-4602, GO-2026-4601, GO-2026-4337). `govulncheck` now reports zero vulnerabilities.
- **Complexity**: Extract helpers across 16 packages to reduce Lizard CCN and NLOC below Codacy thresholds (CCN ≤ 8, NLOC ≤ 50)

### Key CCN reductions
| Function | Before | After |
|----------|--------|-------|
| `runSetup` | 25 | ~4 |
| `Destroy` (ec2fleet) | 17 | ~6 |
| `runConnect` | 17 | ~5 |
| `runTrivy` | 16 | ~5 |
| `runPipeline` | 14 | ~3 |
| `Deploy` (anywhere) | 12 | ~5 |
| `Build` (container) | 12 | ~5 |
| `buildWrapperWindows` | 12 | ~5 |
| `checkC4756Patch` | 12 | ~5 |

### Lizard totals (repo-wide)
| Metric | Before PR #136 | After PR #136 | After this PR |
|--------|----------------|---------------|---------------|
| CCN > 8 | 81 | 51 | 31 |
| NLOC > 50 | 51 | 34 | 11 |
| File > 500 NLOC | 7 | 0 | 0 |

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] `govulncheck ./...` — no vulnerabilities found
- [x] Pre-commit hooks pass (build + lint + tests)