### PR TITLE
Fix global config mutation via pointer copy

### DIFF
--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -84,7 +84,7 @@ func checkBuildCache(stage cache.StageKey, hash string) bool {
 }
 
 func runBuild(cmd *cobra.Command, args []string) error {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 
 	if archFlag != "" {
 		cfg.Game.Arch = archFlag
@@ -138,7 +138,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 }
 
 func runPush(cmd *cobra.Command, args []string) error {
-	cfg := globals.Cfg
+	cfg := globals.Cfg.Clone()
 
 	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
 	if err := prereq.Validate(checker.CheckPushReady()); err != nil {

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -105,7 +105,7 @@ func makeDeployer(cmd *cobra.Command) (*gamelift.Deployer, error) {
 // resolveTarget resolves a deploy.Target, applying --target flag override and
 // flag overrides for GameLift-specific flags (--region, --instance-type, --fleet-name).
 func resolveTarget(cmd *cobra.Command) (deploy.Target, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 
 	// Apply flag overrides to config before resolving
 	if region != "" {

--- a/cmd/deploy/deploy_anywhere.go
+++ b/cmd/deploy/deploy_anywhere.go
@@ -43,7 +43,7 @@ func applyAnywhereFlags(cfg *config.Config) {
 }
 
 func runAnywhere(cmd *cobra.Command, args []string) error {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	applyAnywhereFlags(&cfg)
 
 	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)

--- a/cmd/deploy/deploy_destroy.go
+++ b/cmd/deploy/deploy_destroy.go
@@ -51,7 +51,7 @@ func runDestroy(cmd *cobra.Command, args []string) error {
 	}
 
 	if target.Capabilities().NeedsContainerPush {
-		cfg := *globals.Cfg
+		cfg := globals.Cfg.Clone()
 		if region != "" {
 			cfg.AWS.Region = region
 		}
@@ -63,7 +63,7 @@ func runDestroy(cmd *cobra.Command, args []string) error {
 }
 
 func runDestroyAll(cmd *cobra.Command) error {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	if region != "" {
 		cfg.AWS.Region = region
 	}

--- a/cmd/deploy/deploy_ec2.go
+++ b/cmd/deploy/deploy_ec2.go
@@ -49,7 +49,7 @@ func applyEC2Flags(cfg *config.Config) {
 }
 
 func runEC2(cmd *cobra.Command, args []string) error {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	applyEC2Flags(&cfg)
 
 	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)

--- a/cmd/deploy/deploy_stack.go
+++ b/cmd/deploy/deploy_stack.go
@@ -87,7 +87,7 @@ func saveStackState(result *stack.StackResult) {
 }
 
 func runStack(cmd *cobra.Command, args []string) error {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	imageURI, sn, fn := applyStackFlags(&cfg)
 
 	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -28,7 +28,7 @@ func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 		fleetName = "new-fleet"
 		ec2Arch = "arm64"
 
-		cfg := *globals.Cfg
+		cfg := globals.Cfg.Clone()
 		applyEC2Flags(&cfg)
 
 		if cfg.AWS.Region != "eu-west-1" {
@@ -53,7 +53,7 @@ func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 		fleetName = "anywhere-fleet"
 		anywhereIP = "192.168.1.1"
 
-		cfg := *globals.Cfg
+		cfg := globals.Cfg.Clone()
 		applyAnywhereFlags(&cfg)
 
 		if cfg.Anywhere.IPAddress != "192.168.1.1" {
@@ -71,7 +71,7 @@ func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 		region = "us-west-2"
 		instanceType = "m5.xlarge"
 
-		cfg := *globals.Cfg
+		cfg := globals.Cfg.Clone()
 		applyStackFlags(&cfg)
 
 		if cfg.AWS.Region != "us-west-2" {
@@ -100,7 +100,7 @@ func TestPrereqCheckerUsesOverriddenConfig(t *testing.T) {
 	t.Cleanup(func() { ec2Arch = origArch })
 	ec2Arch = "arm64"
 
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	applyEC2Flags(&cfg)
 
 	// Prereq checker should use overridden values from local cfg

--- a/cmd/mcp/helpers_test.go
+++ b/cmd/mcp/helpers_test.go
@@ -147,7 +147,7 @@ func TestOverridesDoNotMutateGlobal(t *testing.T) {
 	}
 
 	// Simulate the handler pattern: value copy + overrides
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	applyRegionOverride(&cfg, "eu-west-1")
 	applyInstanceOverride(&cfg, "c7g.large")
 	applyFleetNameOverride(&cfg, "new-fleet")
@@ -171,7 +171,7 @@ func TestDockerDispatchUsesIsolatedConfig(t *testing.T) {
 	}
 
 	// Simulate handleGameBuild: value copy, arch override, then dispatch
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	applyArchOverride(&cfg, "arm64")
 
 	// The cfg passed to handleDockerGameBuild should have arm64

--- a/cmd/mcp/tools_container.go
+++ b/cmd/mcp/tools_container.go
@@ -44,7 +44,7 @@ func registerContainerTools(s *mcp.Server) {
 }
 
 func handleContainerBuild(ctx context.Context, _ *mcp.CallToolRequest, input containerBuildInput) (*mcp.CallToolResult, any, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	r := newToolRunner(input.DryRun)
 
 	applyArchOverride(&cfg, input.Arch)

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -168,7 +168,7 @@ func registerDeployTools(s *mcp.Server) {
 }
 
 func handleDeployFleet(ctx context.Context, _ *mcp.CallToolRequest, input deployFleetInput) (*mcp.CallToolResult, any, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	start := time.Now()
 
 	applyRegionOverride(&cfg, input.Region)
@@ -223,7 +223,7 @@ func handleDeployFleet(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 }
 
 func handleDeployStack(ctx context.Context, _ *mcp.CallToolRequest, input deployStackInput) (*mcp.CallToolResult, any, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	start := time.Now()
 
 	applyRegionOverride(&cfg, input.Region)
@@ -290,7 +290,7 @@ func handleDeployStack(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 }
 
 func handleDeployAnywhere(ctx context.Context, _ *mcp.CallToolRequest, input deployAnywhereInput) (*mcp.CallToolResult, any, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 
 	applyRegionOverride(&cfg, input.Region)
 	applyFleetNameOverride(&cfg, input.FleetName)
@@ -341,7 +341,7 @@ func handleDeployAnywhere(ctx context.Context, _ *mcp.CallToolRequest, input dep
 }
 
 func handleDeployEC2(ctx context.Context, _ *mcp.CallToolRequest, input deployEC2Input) (*mcp.CallToolResult, any, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 	start := time.Now()
 
 	applyRegionOverride(&cfg, input.Region)

--- a/cmd/mcp/tools_engine.go
+++ b/cmd/mcp/tools_engine.go
@@ -65,7 +65,7 @@ func registerEngineTools(s *mcp.Server) {
 }
 
 func handleEngineSetup(ctx context.Context, _ *mcp.CallToolRequest, input engineSetupInput) (*mcp.CallToolResult, any, error) {
-	cfg := globals.Cfg
+	cfg := globals.Cfg.Clone()
 	r := newToolRunner(input.DryRun)
 
 	b := engine.NewBuilder(engine.BuildOptions{
@@ -91,7 +91,7 @@ func handleEngineSetup(ctx context.Context, _ *mcp.CallToolRequest, input engine
 }
 
 func handleEngineBuild(ctx context.Context, _ *mcp.CallToolRequest, input engineBuildInput) (*mcp.CallToolResult, any, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 
 	be := resolveBackend(input.Backend, cfg.Engine.Backend)
 

--- a/cmd/mcp/tools_game.go
+++ b/cmd/mcp/tools_game.go
@@ -100,7 +100,7 @@ func mcpResolveEngineImage(cfg *config.Config) (string, error) {
 }
 
 func handleGameBuild(ctx context.Context, _ *mcp.CallToolRequest, input gameBuildInput) (*mcp.CallToolResult, any, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 
 	applyArchOverride(&cfg, input.Arch)
 
@@ -201,7 +201,7 @@ func handleDockerGameBuild(ctx context.Context, cfg *config.Config, input gameBu
 }
 
 func handleGameClient(ctx context.Context, _ *mcp.CallToolRequest, input gameClientInput) (*mcp.CallToolResult, any, error) {
-	cfg := *globals.Cfg
+	cfg := globals.Cfg.Clone()
 
 	platform := input.Platform
 	if platform == "" {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -2,8 +2,10 @@ package config
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -307,6 +309,23 @@ type CIConfig struct {
 	RunnerDir string `yaml:"runnerDir"`
 	// RunnerLabels are the labels applied to the self-hosted runner.
 	RunnerLabels []string `yaml:"runnerLabels"`
+}
+
+// Clone returns a deep copy of the Config, ensuring nested maps, slices, and
+// pointers are independently owned by the copy.
+func (c *Config) Clone() Config {
+	cp := *c
+
+	cp.AWS.Tags = maps.Clone(c.AWS.Tags)
+	cp.CI.RunnerLabels = slices.Clone(c.CI.RunnerLabels)
+
+	if c.Game.ContentValidation != nil {
+		cv := *c.Game.ContentValidation
+		cv.PluginContentDirs = slices.Clone(c.Game.ContentValidation.PluginContentDirs)
+		cp.Game.ContentValidation = &cv
+	}
+
+	return cp
 }
 
 // Defaults returns a Config with sensible defaults.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -243,6 +243,99 @@ func TestGameConfig_ResolvedArch(t *testing.T) {
 	}
 }
 
+func newTestConfig() *Config {
+	return &Config{
+		AWS: AWSConfig{
+			Region: "us-east-1",
+			Tags:   map[string]string{"ManagedBy": "ludus", "Env": "prod"},
+		},
+		CI: CIConfig{
+			RunnerLabels: []string{"self-hosted", "linux"},
+		},
+		Game: GameConfig{
+			Arch:        "amd64",
+			ProjectName: "Lyra",
+			ContentValidation: &ContentValidationConfig{
+				ContentMarkerFile: "Content/Default.uasset",
+				PluginContentDirs: []string{"ShooterCore", "ShooterMaps"},
+			},
+		},
+		GameLift: GameLiftConfig{InstanceType: "c6i.large"},
+	}
+}
+
+func TestClone_ScalarFields(t *testing.T) {
+	orig := newTestConfig()
+	cp := orig.Clone()
+
+	if cp.AWS.Region != "us-east-1" {
+		t.Errorf("Region = %q, want %q", cp.AWS.Region, "us-east-1")
+	}
+	if cp.GameLift.InstanceType != "c6i.large" {
+		t.Errorf("InstanceType = %q, want %q", cp.GameLift.InstanceType, "c6i.large")
+	}
+}
+
+func TestClone_MapIsolation(t *testing.T) {
+	orig := newTestConfig()
+	cp := orig.Clone()
+
+	cp.AWS.Tags["Env"] = "staging"
+	cp.AWS.Tags["New"] = "value"
+
+	if orig.AWS.Tags["Env"] != "prod" {
+		t.Errorf("original Tags[Env] mutated: got %q", orig.AWS.Tags["Env"])
+	}
+	if _, ok := orig.AWS.Tags["New"]; ok {
+		t.Error("original Tags gained key from clone mutation")
+	}
+}
+
+func TestClone_SliceIsolation(t *testing.T) {
+	orig := newTestConfig()
+	cp := orig.Clone()
+
+	cp.CI.RunnerLabels[0] = "changed"
+	cp.CI.RunnerLabels = append(cp.CI.RunnerLabels, "extra")
+
+	if orig.CI.RunnerLabels[0] != "self-hosted" {
+		t.Errorf("original RunnerLabels[0] mutated: got %q", orig.CI.RunnerLabels[0])
+	}
+	if len(orig.CI.RunnerLabels) != 2 {
+		t.Errorf("original RunnerLabels length changed: got %d", len(orig.CI.RunnerLabels))
+	}
+}
+
+func TestClone_PointerIsolation(t *testing.T) {
+	orig := newTestConfig()
+	cp := orig.Clone()
+
+	cp.Game.ContentValidation.ContentMarkerFile = "changed.uasset"
+	cp.Game.ContentValidation.PluginContentDirs[0] = "Modified"
+
+	if orig.Game.ContentValidation.ContentMarkerFile != "Content/Default.uasset" {
+		t.Errorf("original ContentMarkerFile mutated: got %q", orig.Game.ContentValidation.ContentMarkerFile)
+	}
+	if orig.Game.ContentValidation.PluginContentDirs[0] != "ShooterCore" {
+		t.Errorf("original PluginContentDirs[0] mutated: got %q", orig.Game.ContentValidation.PluginContentDirs[0])
+	}
+}
+
+func TestClone_NilFieldsStayNil(t *testing.T) {
+	bare := &Config{}
+	cp := bare.Clone()
+
+	if cp.AWS.Tags != nil {
+		t.Error("expected nil Tags in clone of bare config")
+	}
+	if cp.CI.RunnerLabels != nil {
+		t.Error("expected nil RunnerLabels in clone of bare config")
+	}
+	if cp.Game.ContentValidation != nil {
+		t.Error("expected nil ContentValidation in clone of bare config")
+	}
+}
+
 func TestLoad_MissingFile(t *testing.T) {
 	t.Chdir(t.TempDir())
 


### PR DESCRIPTION
## Summary

- `cfg := globals.Cfg` copies the pointer, so flag overrides (region, instance type, arch, fleet name, IP) silently mutate the shared global config
- In CLI commands this is harmless (process exits after one command), but in the **MCP server** (long-lived process) one tool call corrupts config for all subsequent calls
- Fix: `cfg := *globals.Cfg` (struct value copy) at every mutation site across 9 files -- 5 CLI commands + 4 MCP handlers

**Files changed:**
- `cmd/container/container.go` -- `runBuild` arch override
- `cmd/deploy/deploy.go` -- `resolveTarget` region/instance/fleet overrides
- `cmd/deploy/deploy_ec2.go` -- `runEC2` via `applyEC2Flags`
- `cmd/deploy/deploy_anywhere.go` -- `runAnywhere` via `applyAnywhereFlags`
- `cmd/deploy/deploy_stack.go` -- `runStack` via `applyStackFlags`
- `cmd/mcp/tools_deploy.go` -- 4 handlers (fleet, stack, anywhere, ec2)
- `cmd/mcp/tools_container.go` -- `handleContainerBuild` arch override
- `cmd/mcp/tools_game.go` -- `handleGameBuild` arch override

## Test plan

- [x] `TestOverridesDoNotMutateGlobal` -- MCP helpers: applies all 5 override types to value copy, verifies global untouched
- [x] `TestApplyFlagsDoNotMutateGlobal` -- CLI deploy: tests `applyEC2Flags`, `applyAnywhereFlags`, `applyStackFlags` isolation
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` -- 0 issues