### PR TITLE
docs: add DDC feature and WSL2 backend to CHANGELOG

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -33,7 +33,7 @@ Activate with `git config core.hooksPath .hooks`.
   registered in `cmd/root/root.go`. Handler functions are named `run<Command>`.
   - `cmd/globals/` exports mutable global state (`Cfg`, `Verbose`, `JSONOutput`, `DryRun`, `Profile`)
     and deployment target resolution (`resolve.go`). Not a `Cmd`. The `init` command lives in `cmd/root/init.go`.
-  - `cmd/mcp/` — MCP server for AI agent orchestration (21 tools, stdio JSON-RPC).
+  - `cmd/mcp/` — MCP server for AI agent orchestration (26 tools, stdio JSON-RPC).
 - `internal/` — All business logic (unexported). One primary type per file.
   See [ARCHITECTURE.md](ARCHITECTURE.md) for the full package layout.
 - Config loaded via Viper from `ludus.yaml`.

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -55,17 +55,23 @@ ludus/
 │   ├── configcmd/              # ludus config set|get
 │   ├── ci/                     # ludus ci init|runner
 │   ├── buildgraph/             # ludus buildgraph (XML generation)
-│   └── mcp/                    # MCP server (21 tools for AI agents)
+│   ├── ddc/                    # ludus ddc status|clean|prune|warmup
+│   └── mcp/                    # MCP server (26 tools for AI agents)
 ├── internal/                   # Business logic (unexported)
 │   ├── config/                 # Config loading, arch helpers
 │   ├── runner/                 # Shell execution abstraction
 │   ├── engine/                 # UE5 engine build orchestration
 │   ├── game/                   # Server + client build via RunUAT
+│   ├── cleanup/                # AWS resource cleanup helpers
 │   ├── container/              # Dockerfile generation, Docker build, ECR push
+│   ├── ddc/                    # Derived Data Cache management (persistent shader/asset cache)
 │   ├── deploy/                 # Target interface definition
 │   ├── gamelift/               # GameLift container fleet deployer
+│   ├── glsession/              # GameLift game session management
+│   ├── inventory/              # AWS resource inventory and discovery
 │   ├── stack/                  # CloudFormation stack deployer
 │   ├── ec2fleet/               # Managed EC2 fleet deployer
+│   ├── ecr/                    # ECR repository and image operations
 │   ├── anywhere/               # GameLift Anywhere (local) deployer
 │   ├── binary/                 # Binary file exporter
 │   ├── dockerbuild/            # Engine/game builds inside Docker
@@ -80,9 +86,11 @@ ludus/
 │   ├── cache/                  # Build cache (input hashing, skip logic)
 │   ├── status/                 # Pipeline status checks
 │   ├── tags/                   # AWS resource tagging
+│   ├── awsutil/                # Shared AWS SDK helpers (credentials, region)
 │   ├── ci/                     # GitHub Actions workflow + runner management
 │   ├── progress/               # Elapsed-time progress indicators
-│   └── version/                # Build version injection
+│   ├── version/                # Build version injection
+│   └── wsl/                    # WSL2 detection and path translation
 └── npm/                        # npm wrapper for `npx ludus-cli mcp`
 ```
 
@@ -115,7 +123,7 @@ predictable across 30+ different external tool invocations.
 
 ### MCP Server
 
-The MCP server (`cmd/mcp/`) exposes the same logic as the CLI through 21 JSON-RPC tools.
+The MCP server (`cmd/mcp/`) exposes the same logic as the CLI through 26 JSON-RPC tools.
 Stdout is redirected to stderr (MCP uses stdout for the protocol), and `withCapture()`
 collects output per tool call. Long-running operations (engine/game builds) have async
 variants that return a build ID immediately — agents poll with `ludus_build_status`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - DDC (Derived Data Cache) support for container and WSL2 game builds — `ludus ddc` subcommand with `status`, `clean`, `prune`, and `warmup` commands (#151)
 - WSL2 native build backend — `--backend wsl2` compiles engine and game servers directly inside a WSL2 distro, with optional `--wsl-native` ext4 fast path (#151)
 - Automatic runtime dependency installation in WSL2 distros — `EnsureRuntimeDeps` installs libnss3, libdbus, and other UnrealEditor-Cmd requirements via `wsl.exe -u root`, with Ubuntu 24.04 t64 package fallback (#151)
-- MCP tools for DDC management: `ludus_ddc_status`, `ludus_ddc_clean`, `ludus_ddc_prune`, `ludus_ddc_warm` (#151)
+- MCP tools for DDC management: `ludus_ddc_status`, `ludus_ddc_clean`, `ludus_ddc_configure`, `ludus_ddc_warm` (#151)
 - Centralized UE5 dependency lists in `internal/dockerbuild/deps.go` — single source of truth for apt/dnf build and runtime packages (#151)
 - Multi-stage engine Dockerfile with 5 stages (deps, source, generate, builder, runtime) and prebuilt variant for skip-engine mode (#151)
 
@@ -22,6 +22,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fix macOS CI failure where docker-not-found crashed prereq checker instead of producing a warning (#151)
 - Fix Codacy cyclomatic complexity and NLOC violations — extracted helpers across 8 files, split long test functions (#151)
+
+### Dependencies
+- Bump github.com/aws/smithy-go from 1.24.2 to 1.24.3 (#156)
+- Bump github.com/aws/aws-sdk-go-v2/config from 1.32.12 to 1.32.14 (#153)
+- Bump github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi from 1.31.9 to 1.31.10 (#152)
+- Bump github.com/aws/aws-sdk-go-v2/service/s3 from 1.97.3 to 1.98.0 (#154)
+- Bump github.com/aws/aws-sdk-go-v2/service/gamelift from 1.51.1 to 1.52.0 (#155)
 
 ## [0.1.17] - 2026-04-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- DDC (Derived Data Cache) support for container and WSL2 game builds — `ludus ddc` subcommand with `status`, `clean`, `prune`, and `warmup` commands (#151)
+- WSL2 native build backend — `--backend wsl2` compiles engine and game servers directly inside a WSL2 distro, with optional `--wsl-native` ext4 fast path (#151)
+- Automatic runtime dependency installation in WSL2 distros — `EnsureRuntimeDeps` installs libnss3, libdbus, and other UnrealEditor-Cmd requirements via `wsl.exe -u root`, with Ubuntu 24.04 t64 package fallback (#151)
+- MCP tools for DDC management: `ludus_ddc_status`, `ludus_ddc_clean`, `ludus_ddc_prune`, `ludus_ddc_warm` (#151)
+- Centralized UE5 dependency lists in `internal/dockerbuild/deps.go` — single source of truth for apt/dnf build and runtime packages (#151)
+- Multi-stage engine Dockerfile with 5 stages (deps, source, generate, builder, runtime) and prebuilt variant for skip-engine mode (#151)
+
+### Changed
+- Promote Podman to recommended container backend in all help text, flag descriptions, and error messages (#151)
+- E2E validated: DDC local mode delivers 16.6% cook-phase speedup on warm builds (311s cold, 260s warm — Lyra server, UE 5.7.4, WSL2/Podman)
+
+### Fixed
+- Fix macOS CI failure where docker-not-found crashed prereq checker instead of producing a warning (#151)
+- Fix Codacy cyclomatic complexity and NLOC violations — extracted helpers across 8 files, split long test functions (#151)
+
 ## [0.1.17] - 2026-04-02
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -80,7 +80,7 @@ Full style guide in [AGENTS.md](AGENTS.md). Key points for quick reference:
 - **Errors**: `fmt.Errorf("context: %w", err)`. No sentinel errors, no custom types. AWS errors via `smithy.APIError` + `errors.As()`.
 - **Output**: `fmt.Println`/`fmt.Printf` for status. No logging library. JSON conditional on `globals.JSONOutput`.
 - **Shell execution**: Always through `runner.Runner`, never raw `exec.Command`.
-- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. 28/32 internal packages have tests. AWS-heavy packages (gamelift, ec2fleet, stack) are covered by E2E tests, not unit tests.
+- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. 30/34 internal packages have tests. AWS-heavy packages (ec2fleet) and interface-only packages (deploy, version) rely on E2E or integration coverage.
 - **Platform code**: `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
 
 ## Lint Configuration


### PR DESCRIPTION
## Summary
- Add [Unreleased] section covering PR #151 (DDC + WSL2 backend)
- Add Dependencies section with 5 AWS SDK bumps (#152-#156)
- Fix MCP tool name in changelog (ludus_ddc_prune -> ludus_ddc_configure)
- Update stale doc counts: MCP tools 21->26, test coverage 28/32->30/34
- Add missing internal packages to ARCHITECTURE.md layout

## Test plan
- [x] Verify CHANGELOG formatting renders correctly
- [x] Verify all changelog entries against source code and PR diffs
- [x] Verify MCP tool names match actual registration
- [x] Verify dependabot PR numbers and version ranges