### PR TITLE
feat: integrate WSL2 backend into pipeline runner and MCP tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -362,23 +362,32 @@ Two modes:
 - **High-performance** (`--backend wsl2 --wsl-native`): One-time rsync of engine source to native ext4 inside WSL2 (`~/ludus/engine/<version>/`). DDC cache also lives on ext4. 3-10x faster I/O for builds and cooking.
 
 ```bash
-# Build engine in WSL2 (zero-setup virtiofs mode)
+# Build engine in WSL2 (zero-setup, uses /mnt/ virtiofs)
 ludus engine build --backend wsl2 --verbose
 
-# Build engine with native ext4 for maximum speed
+# Build engine with native ext4 for maximum speed (one-time rsync)
 ludus engine build --backend wsl2 --wsl-native --verbose
 
-# Build game server in WSL2 (uses engine state from previous step)
-ludus game build --backend wsl2 --verbose
+# Build game server in WSL2 with persistent DDC cache
+ludus game build --backend wsl2 --ddc local --verbose
 
 # Full pipeline with WSL2 backend
 ludus run --backend wsl2 --verbose
 
-# Full pipeline with native ext4 sync
+# Full pipeline with native ext4 sync for fastest builds
 ludus run --backend wsl2 --wsl-native --verbose
 ```
 
-Use `--wsl-distro <name>` to target a specific distro (default: first running WSL2 distro). Build dependencies (`gcc`, `make`, `cmake`, `python3`) are installed automatically on first run.
+**Options**:
+
+| Flag | Description |
+|------|-------------|
+| `--backend wsl2` | Use WSL2 instead of native/container build |
+| `--wsl-native` | Rsync source to native ext4 (3-10x faster I/O, requires ~120 GB free) |
+| `--wsl-distro <name>` | Target a specific distro (default: first running WSL2 distro) |
+| `--ddc local` | Persistent DDC cache (default) — works on both virtiofs and native ext4 |
+
+Build dependencies (`gcc`, `make`, `cmake`, `python3`) are installed automatically on first run. If WSL2 is not available, Ludus recommends Podman as a fallback.
 
 Or set WSL2 as the default backend in `ludus.yaml`:
 

--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ Edit `ludus.yaml` with your environment settings. Key fields:
 |---------|-------------|---------|
 | `engine.sourcePath` | Path to UE5 source directory | (required) |
 | `engine.maxJobs` | Max parallel compile jobs (0 = auto-detect from RAM) | `0` |
-| `engine.backend` | Build backend: `native`, `docker`, or `podman` | `native` |
+| `engine.backend` | Build backend: `native`, `docker`, `podman`, or `wsl2` | `native` |
 | `engine.dockerImage` | Pre-built engine Docker image URI (skips engine build) | (empty) |
 | `engine.dockerImageName` | Local Docker image name for engine builds | `ludus-engine` |
 | `engine.dockerBaseImage` | Base Docker image for engine builds | `ubuntu:22.04` |
@@ -351,6 +351,41 @@ ludus run --backend podman --ddc local
 The `--skip-engine` flag generates a lean 2-stage Dockerfile that copies pre-built binaries directly from the host instead of compiling inside the container. Combined with `--ddc local` for persistent shader caching, this is the fastest iteration path on Windows.
 
 **Image size trade-off**: UE5 engine images are large (60-100+ GB) because they include the full editor, shader compiler, build tools, and runtime libraries needed for BuildCookRun. The runtime stage also installs X11, accessibility, and audio libraries (~150 MB) that UnrealEditor-Cmd links against even in headless/server mode. This is inherent to UE5's architecture and applies to both Docker and Podman. Use `.dockerignore` (generated automatically by Ludus) to exclude host-platform binaries, debug symbols, and build intermediates from the build context.
+
+### WSL2 build backend (Windows)
+
+On Windows, Ludus can build the engine and game server directly inside a WSL2 Linux distro, bypassing container runtimes entirely. This gives native Linux I/O performance without Docker or Podman overhead.
+
+Two modes:
+
+- **Default** (`--backend wsl2`): Zero setup. Accesses your engine source via `/mnt/<drive>/` (virtiofs). Works immediately but I/O is slower for large codebases.
+- **High-performance** (`--backend wsl2 --wsl-native`): One-time rsync of engine source to native ext4 inside WSL2 (`~/ludus/engine/<version>/`). DDC cache also lives on ext4. 3-10x faster I/O for builds and cooking.
+
+```bash
+# Build engine in WSL2 (zero-setup virtiofs mode)
+ludus engine build --backend wsl2 --verbose
+
+# Build engine with native ext4 for maximum speed
+ludus engine build --backend wsl2 --wsl-native --verbose
+
+# Build game server in WSL2 (uses engine state from previous step)
+ludus game build --backend wsl2 --verbose
+
+# Full pipeline with WSL2 backend
+ludus run --backend wsl2 --verbose
+
+# Full pipeline with native ext4 sync
+ludus run --backend wsl2 --wsl-native --verbose
+```
+
+Use `--wsl-distro <name>` to target a specific distro (default: first running WSL2 distro). Build dependencies (`gcc`, `make`, `cmake`, `python3`) are installed automatically on first run.
+
+Or set WSL2 as the default backend in `ludus.yaml`:
+
+```yaml
+engine:
+  backend: "wsl2"
+```
 
 ### DDC (Derived Data Cache)
 

--- a/cmd/mcp/tools_async.go
+++ b/cmd/mcp/tools_async.go
@@ -23,14 +23,14 @@ var builds *buildManager
 
 type engineBuildStartInput struct {
 	Jobs    int    `json:"jobs,omitempty" jsonschema:"Max parallel compile jobs (0 = auto-detect from RAM)"`
-	Backend string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, or podman (default: from config)"`
+	Backend string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, podman, or wsl2 (default: from config)"`
 	NoCache bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
 	DryRun  bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
 
 type gameBuildStartInput struct {
 	SkipCook bool   `json:"skip_cook,omitempty" jsonschema:"Skip content cooking (use previously cooked content)"`
-	Backend  string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, or podman (default: from config)"`
+	Backend  string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, podman, or wsl2 (default: from config)"`
 	Arch     string `json:"arch,omitempty" jsonschema:"Target CPU architecture: amd64 or arm64 (default: from config)"`
 	Config   string `json:"config,omitempty" jsonschema:"Build configuration: Development or Shipping (default: Development)"`
 	Jobs     int    `json:"jobs,omitempty" jsonschema:"Max parallel compile actions (0 = auto-detect from RAM, halved for cross-compile)"`
@@ -41,7 +41,7 @@ type gameBuildStartInput struct {
 type gameClientStartInput struct {
 	Platform string `json:"platform,omitempty" jsonschema:"Target platform: Linux or Win64"`
 	SkipCook bool   `json:"skip_cook,omitempty" jsonschema:"Skip content cooking"`
-	Backend  string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, or podman (default: from config)"`
+	Backend  string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, podman, or wsl2 (default: from config)"`
 	Jobs     int    `json:"jobs,omitempty" jsonschema:"Max parallel compile actions (0 = auto-detect from RAM, halved for cross-compile)"`
 	NoCache  bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
 	DryRun   bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
@@ -140,6 +140,9 @@ func handleEngineBuildStart(_ context.Context, _ *mcp.CallToolRequest, input eng
 	if dockerbuild.IsContainerBackend(be) {
 		return toolError("async container engine builds are not yet supported; use ludus_engine_build for container backends")
 	}
+	if dockerbuild.IsWSL2Backend(be) {
+		return toolError("async WSL2 engine builds are not yet supported; use ludus_engine_build with backend=wsl2")
+	}
 
 	// Check cache before launching
 	engineHash := cache.EngineKey(cfg)
@@ -204,6 +207,9 @@ func handleGameBuildStart(_ context.Context, _ *mcp.CallToolRequest, input gameB
 	be := resolveBackend(input.Backend, cfg.Engine.Backend)
 	if dockerbuild.IsContainerBackend(be) {
 		return toolError("async container game builds are not yet supported; use ludus_game_build for container backends")
+	}
+	if dockerbuild.IsWSL2Backend(be) {
+		return toolError("async WSL2 game builds are not yet supported; use ludus_game_build with backend=wsl2")
 	}
 
 	// Check cache before launching
@@ -270,6 +276,9 @@ func handleGameClientStart(_ context.Context, _ *mcp.CallToolRequest, input game
 	be := resolveBackend(input.Backend, cfg.Engine.Backend)
 	if dockerbuild.IsContainerBackend(be) {
 		return toolError("async container client builds are not yet supported; use ludus_game_client for container backends")
+	}
+	if dockerbuild.IsWSL2Backend(be) {
+		return toolError("async WSL2 client builds are not yet supported; use ludus_game_client for WSL2 backends")
 	}
 
 	// Check cache before launching

--- a/cmd/mcp/tools_async_test.go
+++ b/cmd/mcp/tools_async_test.go
@@ -10,63 +10,53 @@ import (
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func TestAsyncWSL2Rejection(t *testing.T) {
+// assertWSL2Rejected verifies that a tool call returns an error containing wantErr.
+func assertWSL2Rejected(t *testing.T, result *mcpsdk.CallToolResult, err error, wantErr string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if !result.IsError {
+		t.Error("expected IsError = true")
+	}
+	if len(result.Content) == 0 {
+		t.Fatal("expected at least one content item")
+	}
+	tc, ok := result.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("expected *mcpsdk.TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(tc.Text, wantErr) {
+		t.Errorf("error message %q should contain %q", tc.Text, wantErr)
+	}
+}
+
+func TestAsyncWSL2RejectionEngine(t *testing.T) {
 	origCfg := globals.Cfg
 	t.Cleanup(func() { globals.Cfg = origCfg })
-	globals.Cfg = &config.Config{
-		Engine: config.EngineConfig{Backend: "wsl2"},
-	}
+	globals.Cfg = &config.Config{}
 
-	tests := []struct {
-		name    string
-		fn      func(context.Context, *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, any, error)
-		wantErr string
-	}{
-		{
-			"engine build start rejects wsl2",
-			func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, any, error) {
-				return handleEngineBuildStart(ctx, req, engineBuildStartInput{Backend: "wsl2"})
-			},
-			"WSL2",
-		},
-		{
-			"game build start rejects wsl2",
-			func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, any, error) {
-				return handleGameBuildStart(ctx, req, gameBuildStartInput{Backend: "wsl2"})
-			},
-			"WSL2",
-		},
-		{
-			"game client start rejects wsl2",
-			func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, any, error) {
-				return handleGameClientStart(ctx, req, gameClientStartInput{Backend: "wsl2"})
-			},
-			"WSL2",
-		},
-	}
+	result, _, err := handleEngineBuildStart(context.Background(), nil, engineBuildStartInput{Backend: "wsl2"})
+	assertWSL2Rejected(t, result, err, "WSL2")
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			result, _, err := tt.fn(context.Background(), nil)
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-			if result == nil {
-				t.Fatal("expected non-nil result")
-			}
-			if !result.IsError {
-				t.Error("expected IsError = true")
-			}
-			if len(result.Content) == 0 {
-				t.Fatal("expected at least one content item")
-			}
-			tc, ok := result.Content[0].(*mcpsdk.TextContent)
-			if !ok {
-				t.Fatalf("expected *mcpsdk.TextContent, got %T", result.Content[0])
-			}
-			if !strings.Contains(tc.Text, tt.wantErr) {
-				t.Errorf("error message %q should contain %q", tc.Text, tt.wantErr)
-			}
-		})
-	}
+func TestAsyncWSL2RejectionGame(t *testing.T) {
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = &config.Config{}
+
+	result, _, err := handleGameBuildStart(context.Background(), nil, gameBuildStartInput{Backend: "wsl2"})
+	assertWSL2Rejected(t, result, err, "WSL2")
+}
+
+func TestAsyncWSL2RejectionClient(t *testing.T) {
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = &config.Config{}
+
+	result, _, err := handleGameClientStart(context.Background(), nil, gameClientStartInput{Backend: "wsl2"})
+	assertWSL2Rejected(t, result, err, "WSL2")
 }

--- a/cmd/mcp/tools_async_test.go
+++ b/cmd/mcp/tools_async_test.go
@@ -1,0 +1,72 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/devrecon/ludus/cmd/globals"
+	"github.com/devrecon/ludus/internal/config"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestAsyncWSL2Rejection(t *testing.T) {
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = &config.Config{
+		Engine: config.EngineConfig{Backend: "wsl2"},
+	}
+
+	tests := []struct {
+		name    string
+		fn      func(context.Context, *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, any, error)
+		wantErr string
+	}{
+		{
+			"engine build start rejects wsl2",
+			func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, any, error) {
+				return handleEngineBuildStart(ctx, req, engineBuildStartInput{Backend: "wsl2"})
+			},
+			"WSL2",
+		},
+		{
+			"game build start rejects wsl2",
+			func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, any, error) {
+				return handleGameBuildStart(ctx, req, gameBuildStartInput{Backend: "wsl2"})
+			},
+			"WSL2",
+		},
+		{
+			"game client start rejects wsl2",
+			func(ctx context.Context, req *mcpsdk.CallToolRequest) (*mcpsdk.CallToolResult, any, error) {
+				return handleGameClientStart(ctx, req, gameClientStartInput{Backend: "wsl2"})
+			},
+			"WSL2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, _, err := tt.fn(context.Background(), nil)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if result == nil {
+				t.Fatal("expected non-nil result")
+			}
+			if !result.IsError {
+				t.Error("expected IsError = true")
+			}
+			if len(result.Content) == 0 {
+				t.Fatal("expected at least one content item")
+			}
+			tc, ok := result.Content[0].(*mcpsdk.TextContent)
+			if !ok {
+				t.Fatalf("expected *mcpsdk.TextContent, got %T", result.Content[0])
+			}
+			if !strings.Contains(tc.Text, tt.wantErr) {
+				t.Errorf("error message %q should contain %q", tc.Text, tt.wantErr)
+			}
+		})
+	}
+}

--- a/cmd/mcp/tools_engine.go
+++ b/cmd/mcp/tools_engine.go
@@ -260,7 +260,7 @@ func handleWSL2EngineBuild(ctx context.Context, cfg *config.Config, input engine
 
 	w, err := wsl.New(r, input.WSLDistro)
 	if err != nil {
-		return resultErr(engineResult{Error: fmt.Sprintf("WSL2 init failed: %v", err)})
+		return resultErr(engineResult{Error: fmt.Sprintf("WSL2 init failed: %v\n\nIf WSL2 is not available, use Podman instead: ludus_engine_build with backend=podman", err)})
 	}
 
 	version, _ := toolchain.DetectEngineVersion(cfg.Engine.SourcePath, cfg.Engine.Version)

--- a/cmd/mcp/tools_engine.go
+++ b/cmd/mcp/tools_engine.go
@@ -12,6 +12,7 @@ import (
 	"github.com/devrecon/ludus/internal/dockerbuild"
 	"github.com/devrecon/ludus/internal/ecr"
 	"github.com/devrecon/ludus/internal/engine"
+	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/state"
 	"github.com/devrecon/ludus/internal/toolchain"
 	"github.com/devrecon/ludus/internal/wsl"
@@ -213,6 +214,41 @@ func handleContainerEngineBuild(ctx context.Context, cfg *config.Config, input e
 	return resultOK(result)
 }
 
+// resolveWSL2Paths resolves the engine and DDC paths for a WSL2 build.
+// When wslNative is true, it syncs the source to native ext4; otherwise it
+// uses the /mnt/ virtiofs path.
+func resolveWSL2Paths(ctx context.Context, r *runner.Runner, w *wsl.WSL2, sourcePath, version string, wslNative bool) (enginePath, ddcPath string, err error) {
+	if wslNative {
+		syncResult, syncErr := wsl.SyncEngine(ctx, r, w.Distro, wsl.SyncOptions{
+			SourcePath: sourcePath,
+			Version:    version,
+		})
+		if syncErr != nil {
+			return "", "", syncErr
+		}
+		return syncResult.WSLPath, syncResult.DDCPath, nil
+	}
+	ep := w.ToWSLPath(sourcePath)
+	dp := w.ToWSLPath(filepath.Join(filepath.Dir(sourcePath), ".ludus", "ddc"))
+	return ep, dp, nil
+}
+
+// saveWSL2EngineResult persists WSL2 engine build state and cache entry.
+func saveWSL2EngineResult(enginePath, ddcPath, engineHash string, wslNative bool) {
+	syncTime := ""
+	if wslNative {
+		syncTime = time.Now().UTC().Format(time.RFC3339)
+	}
+	_ = state.UpdateWSL2Engine(&state.WSL2EngineState{
+		EnginePath: enginePath,
+		IsNative:   wslNative,
+		DDCPath:    ddcPath,
+		SyncTime:   syncTime,
+		BuiltAt:    time.Now().UTC().Format(time.RFC3339),
+	})
+	saveCache(cache.StageEngine, engineHash)
+}
+
 func handleWSL2EngineBuild(ctx context.Context, cfg *config.Config, input engineBuildInput) (*mcp.CallToolResult, any, error) {
 	engineHash := cache.EngineKey(cfg)
 	if hit := checkCacheHit(input.NoCache, cache.StageEngine, engineHash,
@@ -233,22 +269,9 @@ func handleWSL2EngineBuild(ctx context.Context, cfg *config.Config, input engine
 		jobs = cfg.Engine.MaxJobs
 	}
 
-	// Resolve engine and DDC paths. When --wsl-native is set, sync source
-	// to native ext4 first for faster I/O; otherwise use /mnt/ virtiofs.
-	var enginePath, ddcPath string
-	if input.WSLNative {
-		syncResult, syncErr := wsl.SyncEngine(ctx, r, w.Distro, wsl.SyncOptions{
-			SourcePath: cfg.Engine.SourcePath,
-			Version:    version,
-		})
-		if syncErr != nil {
-			return resultErr(engineResult{Error: fmt.Sprintf("WSL2 sync failed: %v", syncErr)})
-		}
-		enginePath = syncResult.WSLPath
-		ddcPath = syncResult.DDCPath
-	} else {
-		enginePath = w.ToWSLPath(cfg.Engine.SourcePath)
-		ddcPath = w.ToWSLPath(filepath.Join(filepath.Dir(cfg.Engine.SourcePath), ".ludus", "ddc"))
+	enginePath, ddcPath, err := resolveWSL2Paths(ctx, r, w, cfg.Engine.SourcePath, version, input.WSLNative)
+	if err != nil {
+		return resultErr(engineResult{Error: fmt.Sprintf("WSL2 sync failed: %v", err)})
 	}
 
 	var result engineResult
@@ -275,18 +298,7 @@ func handleWSL2EngineBuild(ctx context.Context, cfg *config.Config, input engine
 	}
 
 	if result.Success {
-		syncTime := ""
-		if input.WSLNative {
-			syncTime = time.Now().UTC().Format(time.RFC3339)
-		}
-		_ = state.UpdateWSL2Engine(&state.WSL2EngineState{
-			EnginePath: enginePath,
-			IsNative:   input.WSLNative,
-			DDCPath:    ddcPath,
-			SyncTime:   syncTime,
-			BuiltAt:    time.Now().UTC().Format(time.RFC3339),
-		})
-		saveCache(cache.StageEngine, engineHash)
+		saveWSL2EngineResult(enginePath, ddcPath, engineHash, input.WSLNative)
 	}
 
 	return resultOK(result)

--- a/cmd/mcp/tools_engine.go
+++ b/cmd/mcp/tools_engine.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/devrecon/ludus/cmd/globals"
@@ -13,6 +14,7 @@ import (
 	"github.com/devrecon/ludus/internal/engine"
 	"github.com/devrecon/ludus/internal/state"
 	"github.com/devrecon/ludus/internal/toolchain"
+	"github.com/devrecon/ludus/internal/wsl"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
@@ -21,10 +23,12 @@ type engineSetupInput struct {
 }
 
 type engineBuildInput struct {
-	Jobs    int    `json:"jobs,omitempty" jsonschema:"Max parallel compile jobs (0 = auto-detect from RAM)"`
-	Backend string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, or podman (default: from config)"`
-	NoCache bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
-	DryRun  bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
+	Jobs      int    `json:"jobs,omitempty" jsonschema:"Max parallel compile jobs (0 = auto-detect from RAM)"`
+	Backend   string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, podman, or wsl2 (default: from config)"`
+	NoCache   bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
+	DryRun    bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
+	WSLNative bool   `json:"wsl_native,omitempty" jsonschema:"Sync engine source to WSL2 native ext4 for faster builds (requires backend=wsl2)"`
+	WSLDistro string `json:"wsl_distro,omitempty" jsonschema:"WSL2 distro override (default: first running WSL2 distro)"`
 }
 
 type engineResult struct {
@@ -55,7 +59,7 @@ func registerEngineTools(s *mcp.Server) {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "ludus_engine_build",
-		Description: "Build Unreal Engine from source. Runs Setup, GenerateProjectFiles, and compiles ShaderCompileWorker + UnrealEditor. Use backend='podman' or 'docker' to build inside a container. This is a long-running operation.",
+		Description: "Build Unreal Engine from source. Runs Setup, GenerateProjectFiles, and compiles ShaderCompileWorker + UnrealEditor. Use backend='podman' or 'docker' to build inside a container, or backend='wsl2' to build in a WSL2 Linux distro. This is a long-running operation.",
 	}, handleEngineBuild)
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -97,6 +101,9 @@ func handleEngineBuild(ctx context.Context, _ *mcp.CallToolRequest, input engine
 
 	if dockerbuild.IsContainerBackend(be) {
 		return handleContainerEngineBuild(ctx, &cfg, input, be)
+	}
+	if dockerbuild.IsWSL2Backend(be) {
+		return handleWSL2EngineBuild(ctx, &cfg, input)
 	}
 
 	engineHash := cache.EngineKey(&cfg)
@@ -199,6 +206,85 @@ func handleContainerEngineBuild(ctx context.Context, cfg *config.Config, input e
 			ImageTag: result.ImageTag,
 			Version:  version,
 			BuiltAt:  time.Now().UTC().Format(time.RFC3339),
+		})
+		saveCache(cache.StageEngine, engineHash)
+	}
+
+	return resultOK(result)
+}
+
+func handleWSL2EngineBuild(ctx context.Context, cfg *config.Config, input engineBuildInput) (*mcp.CallToolResult, any, error) {
+	engineHash := cache.EngineKey(cfg)
+	if hit := checkCacheHit(input.NoCache, cache.StageEngine, engineHash,
+		engineResult{Success: true, EnginePath: cfg.Engine.SourcePath, Output: "Engine WSL2 build is up to date (cached), skipping."}); hit != nil {
+		return hit, nil, nil
+	}
+
+	r := newToolRunner(input.DryRun)
+
+	w, err := wsl.New(r, input.WSLDistro)
+	if err != nil {
+		return resultErr(engineResult{Error: fmt.Sprintf("WSL2 init failed: %v", err)})
+	}
+
+	version, _ := toolchain.DetectEngineVersion(cfg.Engine.SourcePath, cfg.Engine.Version)
+	jobs := input.Jobs
+	if jobs == 0 {
+		jobs = cfg.Engine.MaxJobs
+	}
+
+	// Resolve engine and DDC paths. When --wsl-native is set, sync source
+	// to native ext4 first for faster I/O; otherwise use /mnt/ virtiofs.
+	var enginePath, ddcPath string
+	if input.WSLNative {
+		syncResult, syncErr := wsl.SyncEngine(ctx, r, w.Distro, wsl.SyncOptions{
+			SourcePath: cfg.Engine.SourcePath,
+			Version:    version,
+		})
+		if syncErr != nil {
+			return resultErr(engineResult{Error: fmt.Sprintf("WSL2 sync failed: %v", syncErr)})
+		}
+		enginePath = syncResult.WSLPath
+		ddcPath = syncResult.DDCPath
+	} else {
+		enginePath = w.ToWSLPath(cfg.Engine.SourcePath)
+		ddcPath = w.ToWSLPath(filepath.Join(filepath.Dir(cfg.Engine.SourcePath), ".ludus", "ddc"))
+	}
+
+	var result engineResult
+	result.EnginePath = cfg.Engine.SourcePath
+
+	captured, err := withCapture(func() error {
+		br, buildErr := wsl.BuildEngine(ctx, w, wsl.EngineOptions{
+			SourcePath: cfg.Engine.SourcePath,
+			MaxJobs:    jobs,
+			WSLNative:  input.WSLNative,
+			Version:    version,
+		})
+		if br != nil {
+			result.DurationSeconds = br.Duration
+			result.Success = br.Success
+		}
+		return buildErr
+	})
+	result.Output = mergeOutput(captured)
+
+	if err != nil {
+		result.Error = fmt.Sprintf("WSL2 engine build failed: %v", err)
+		return resultErr(result)
+	}
+
+	if result.Success {
+		syncTime := ""
+		if input.WSLNative {
+			syncTime = time.Now().UTC().Format(time.RFC3339)
+		}
+		_ = state.UpdateWSL2Engine(&state.WSL2EngineState{
+			EnginePath: enginePath,
+			IsNative:   input.WSLNative,
+			DDCPath:    ddcPath,
+			SyncTime:   syncTime,
+			BuiltAt:    time.Now().UTC().Format(time.RFC3339),
 		})
 		saveCache(cache.StageEngine, engineHash)
 	}

--- a/cmd/mcp/tools_engine_test.go
+++ b/cmd/mcp/tools_engine_test.go
@@ -1,9 +1,14 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/devrecon/ludus/cmd/globals"
+	"github.com/devrecon/ludus/internal/config"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 func TestEngineBuildInputWSL2Fields(t *testing.T) {
@@ -48,5 +53,45 @@ func TestEngineBuildInputWSL2FieldsOmitEmpty(t *testing.T) {
 	}
 	if strings.Contains(s, "wsl_distro") {
 		t.Errorf("wsl_distro should be omitted when empty, got: %s", s)
+	}
+}
+
+// TestEngineBuildWSL2Dispatch verifies that backend=wsl2 dispatches to the
+// WSL2 handler (not the native path). On non-Windows / no-WSL2 CI, the handler
+// returns a WSL2-specific error — proving the dispatch took the right branch.
+func TestEngineBuildWSL2Dispatch(t *testing.T) {
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = &config.Config{
+		Engine: config.EngineConfig{SourcePath: "/nonexistent/engine"},
+	}
+
+	result, _, err := handleEngineBuild(context.Background(), nil, engineBuildInput{
+		Backend: "wsl2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// The WSL2 handler calls wsl.New() which fails on non-Windows with
+	// "WSL2 is not available" — this proves the dispatch reached the WSL2
+	// path, not the native path (which would fail differently).
+	assertResultContains(t, result, "WSL2")
+}
+
+// assertResultContains checks that a CallToolResult's text content contains substr.
+func assertResultContains(t *testing.T, result *mcpsdk.CallToolResult, substr string) {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("expected at least one content item")
+	}
+	tc, ok := result.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("expected *mcpsdk.TextContent, got %T", result.Content[0])
+	}
+	if !strings.Contains(tc.Text, substr) {
+		t.Errorf("result text %q should contain %q", tc.Text, substr)
 	}
 }

--- a/cmd/mcp/tools_engine_test.go
+++ b/cmd/mcp/tools_engine_test.go
@@ -1,0 +1,52 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestEngineBuildInputWSL2Fields(t *testing.T) {
+	input := engineBuildInput{
+		Backend:   "wsl2",
+		WSLNative: true,
+		WSLDistro: "Ubuntu-24.04",
+	}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded engineBuildInput
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.Backend != "wsl2" {
+		t.Errorf("Backend = %q, want %q", decoded.Backend, "wsl2")
+	}
+	if !decoded.WSLNative {
+		t.Error("expected WSLNative = true")
+	}
+	if decoded.WSLDistro != "Ubuntu-24.04" {
+		t.Errorf("WSLDistro = %q, want %q", decoded.WSLDistro, "Ubuntu-24.04")
+	}
+}
+
+func TestEngineBuildInputWSL2FieldsOmitEmpty(t *testing.T) {
+	input := engineBuildInput{Backend: "native"}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	s := string(data)
+	if strings.Contains(s, "wsl_native") {
+		t.Errorf("wsl_native should be omitted when false, got: %s", s)
+	}
+	if strings.Contains(s, "wsl_distro") {
+		t.Errorf("wsl_distro should be omitted when empty, got: %s", s)
+	}
+}

--- a/cmd/mcp/tools_game.go
+++ b/cmd/mcp/tools_game.go
@@ -8,21 +8,24 @@ import (
 	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/devrecon/ludus/internal/cache"
 	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/ddc"
 	"github.com/devrecon/ludus/internal/dockerbuild"
 	"github.com/devrecon/ludus/internal/game"
 	"github.com/devrecon/ludus/internal/state"
 	"github.com/devrecon/ludus/internal/toolchain"
+	"github.com/devrecon/ludus/internal/wsl"
 	"github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
 type gameBuildInput struct {
-	SkipCook bool   `json:"skip_cook,omitempty" jsonschema:"Skip content cooking (use previously cooked content)"`
-	Backend  string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, or podman (default: from config)"`
-	Arch     string `json:"arch,omitempty" jsonschema:"Target CPU architecture: amd64 or arm64 (default: from config)"`
-	Config   string `json:"config,omitempty" jsonschema:"Build configuration: Development or Shipping (default: Development)"`
-	Jobs     int    `json:"jobs,omitempty" jsonschema:"Max parallel compile actions (0 = auto-detect from RAM, halved for cross-compile)"`
-	NoCache  bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
-	DryRun   bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
+	SkipCook  bool   `json:"skip_cook,omitempty" jsonschema:"Skip content cooking (use previously cooked content)"`
+	Backend   string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, podman, or wsl2 (default: from config)"`
+	Arch      string `json:"arch,omitempty" jsonschema:"Target CPU architecture: amd64 or arm64 (default: from config)"`
+	Config    string `json:"config,omitempty" jsonschema:"Build configuration: Development or Shipping (default: Development)"`
+	Jobs      int    `json:"jobs,omitempty" jsonschema:"Max parallel compile actions (0 = auto-detect from RAM, halved for cross-compile)"`
+	NoCache   bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
+	DryRun    bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
+	WSLDistro string `json:"wsl_distro,omitempty" jsonschema:"WSL2 distro override (default: first running WSL2 distro)"`
 }
 
 type gameClientInput struct {
@@ -46,7 +49,7 @@ type gameBuildResult struct {
 func registerGameTools(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "ludus_game_build",
-		Description: "Build the UE5 game as a Linux dedicated server via RunUAT BuildCookRun. Use backend='podman' or 'docker' to build inside a pre-built engine container image. This is a long-running operation.",
+		Description: "Build the UE5 game as a Linux dedicated server via RunUAT BuildCookRun. Use backend='podman' or 'docker' to build inside a pre-built engine container image, or backend='wsl2' to build in a WSL2 Linux distro. This is a long-running operation.",
 	}, handleGameBuild)
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -92,6 +95,9 @@ func handleGameBuild(ctx context.Context, _ *mcp.CallToolRequest, input gameBuil
 
 	if dockerbuild.IsContainerBackend(be) {
 		return handleContainerGameBuild(ctx, &cfg, input, be)
+	}
+	if dockerbuild.IsWSL2Backend(be) {
+		return handleWSL2GameBuild(ctx, &cfg, input)
 	}
 
 	engineHash := cache.EngineKey(&cfg)
@@ -170,6 +176,80 @@ func handleContainerGameBuild(ctx context.Context, cfg *config.Config, input gam
 
 	if err != nil {
 		result.Error = fmt.Sprintf("container game build failed: %v", err)
+		return resultErr(result)
+	}
+
+	if result.Success {
+		saveCache(cache.StageGameServer, serverHash)
+	}
+
+	return resultOK(result)
+}
+
+func handleWSL2GameBuild(ctx context.Context, cfg *config.Config, input gameBuildInput) (*mcp.CallToolResult, any, error) {
+	engineHash := cache.EngineKey(cfg)
+	serverHash := cache.GameServerKey(cfg, engineHash)
+	if hit := checkCacheHit(input.NoCache, cache.StageGameServer, serverHash,
+		gameBuildResult{Success: true, Output: "Game server build is up to date (cached), skipping."}); hit != nil {
+		return hit, nil, nil
+	}
+
+	s, err := state.Load()
+	if err != nil {
+		return resultErr(gameBuildResult{Error: fmt.Sprintf("loading state: %v", err)})
+	}
+	if s.WSL2Engine == nil {
+		return resultErr(gameBuildResult{Error: "no WSL2 engine build found; run ludus_engine_build with backend=wsl2 first"})
+	}
+
+	r := newToolRunner(input.DryRun)
+	w, err := wsl.New(r, input.WSLDistro)
+	if err != nil {
+		return resultErr(gameBuildResult{Error: fmt.Sprintf("WSL2 init failed: %v", err)})
+	}
+
+	ddcMode, ddcPath, err := globals.ResolveDDC()
+	if err != nil {
+		return resultErr(gameBuildResult{Error: fmt.Sprintf("resolving DDC: %v", err)})
+	}
+	// Use the DDC path from state (respects IsNative from engine build).
+	// Fall back to virtiofs-converted host path if state DDC path is empty.
+	wslDDCPath := s.WSL2Engine.DDCPath
+	if ddcMode == ddc.ModeLocal && wslDDCPath == "" {
+		wslDDCPath = w.ToWSLPath(ddcPath)
+	}
+
+	opts := wsl.GameOptions{
+		EnginePath:   s.WSL2Engine.EnginePath,
+		ProjectPath:  cfg.Game.ProjectPath,
+		ProjectName:  cfg.Game.ProjectName,
+		ServerTarget: cfg.Game.ResolvedServerTarget(),
+		Platform:     cfg.Game.Platform,
+		Arch:         cfg.Game.ResolvedArch(),
+		SkipCook:     input.SkipCook,
+		ServerMap:    cfg.Game.ServerMap,
+		DDCMode:      ddcMode,
+		DDCPath:      wslDDCPath,
+		ServerConfig: input.Config,
+		MaxJobs:      input.Jobs,
+	}
+
+	var result gameBuildResult
+
+	captured, err := withCapture(func() error {
+		br, buildErr := wsl.BuildGame(ctx, w, opts)
+		if br != nil {
+			result.Success = br.Success
+			result.OutputDir = br.OutputDir
+			result.Binary = br.ServerBinary
+			result.DurationSeconds = br.Duration
+		}
+		return buildErr
+	})
+	result.Output = mergeOutput(captured)
+
+	if err != nil {
+		result.Error = fmt.Sprintf("WSL2 game build failed: %v", err)
 		return resultErr(result)
 	}
 

--- a/cmd/mcp/tools_game.go
+++ b/cmd/mcp/tools_game.go
@@ -186,6 +186,17 @@ func handleContainerGameBuild(ctx context.Context, cfg *config.Config, input gam
 	return resultOK(result)
 }
 
+// resolveWSL2DDCPath returns the WSL DDC path for a game build. It prefers
+// the path stored in state (which respects IsNative from the engine build),
+// falling back to a virtiofs-converted host path.
+func resolveWSL2DDCPath(w *wsl.WSL2, engineState *state.WSL2EngineState, ddcMode, hostDDCPath string) string {
+	wslDDCPath := engineState.DDCPath
+	if ddcMode == ddc.ModeLocal && wslDDCPath == "" {
+		wslDDCPath = w.ToWSLPath(hostDDCPath)
+	}
+	return wslDDCPath
+}
+
 func handleWSL2GameBuild(ctx context.Context, cfg *config.Config, input gameBuildInput) (*mcp.CallToolResult, any, error) {
 	engineHash := cache.EngineKey(cfg)
 	serverHash := cache.GameServerKey(cfg, engineHash)
@@ -212,12 +223,6 @@ func handleWSL2GameBuild(ctx context.Context, cfg *config.Config, input gameBuil
 	if err != nil {
 		return resultErr(gameBuildResult{Error: fmt.Sprintf("resolving DDC: %v", err)})
 	}
-	// Use the DDC path from state (respects IsNative from engine build).
-	// Fall back to virtiofs-converted host path if state DDC path is empty.
-	wslDDCPath := s.WSL2Engine.DDCPath
-	if ddcMode == ddc.ModeLocal && wslDDCPath == "" {
-		wslDDCPath = w.ToWSLPath(ddcPath)
-	}
 
 	opts := wsl.GameOptions{
 		EnginePath:   s.WSL2Engine.EnginePath,
@@ -229,7 +234,7 @@ func handleWSL2GameBuild(ctx context.Context, cfg *config.Config, input gameBuil
 		SkipCook:     input.SkipCook,
 		ServerMap:    cfg.Game.ServerMap,
 		DDCMode:      ddcMode,
-		DDCPath:      wslDDCPath,
+		DDCPath:      resolveWSL2DDCPath(w, s.WSL2Engine, ddcMode, ddcPath),
 		ServerConfig: input.Config,
 		MaxJobs:      input.Jobs,
 	}

--- a/cmd/mcp/tools_game.go
+++ b/cmd/mcp/tools_game.go
@@ -216,7 +216,7 @@ func handleWSL2GameBuild(ctx context.Context, cfg *config.Config, input gameBuil
 	r := newToolRunner(input.DryRun)
 	w, err := wsl.New(r, input.WSLDistro)
 	if err != nil {
-		return resultErr(gameBuildResult{Error: fmt.Sprintf("WSL2 init failed: %v", err)})
+		return resultErr(gameBuildResult{Error: fmt.Sprintf("WSL2 init failed: %v\n\nIf WSL2 is not available, use Podman instead: ludus_game_build with backend=podman", err)})
 	}
 
 	ddcMode, ddcPath, err := globals.ResolveDDC()

--- a/cmd/mcp/tools_game_test.go
+++ b/cmd/mcp/tools_game_test.go
@@ -1,0 +1,45 @@
+package mcp
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+)
+
+func TestGameBuildInputWSL2Fields(t *testing.T) {
+	input := gameBuildInput{
+		Backend:   "wsl2",
+		WSLDistro: "Debian",
+	}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded gameBuildInput
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.Backend != "wsl2" {
+		t.Errorf("Backend = %q, want %q", decoded.Backend, "wsl2")
+	}
+	if decoded.WSLDistro != "Debian" {
+		t.Errorf("WSLDistro = %q, want %q", decoded.WSLDistro, "Debian")
+	}
+}
+
+func TestGameBuildInputWSL2FieldsOmitEmpty(t *testing.T) {
+	input := gameBuildInput{Backend: "native"}
+
+	data, err := json.Marshal(input)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	s := string(data)
+	if strings.Contains(s, "wsl_distro") {
+		t.Errorf("wsl_distro should be omitted when empty, got: %s", s)
+	}
+}

--- a/cmd/mcp/tools_game_test.go
+++ b/cmd/mcp/tools_game_test.go
@@ -1,9 +1,13 @@
 package mcp
 
 import (
+	"context"
 	"encoding/json"
 	"strings"
 	"testing"
+
+	"github.com/devrecon/ludus/cmd/globals"
+	"github.com/devrecon/ludus/internal/config"
 )
 
 func TestGameBuildInputWSL2Fields(t *testing.T) {
@@ -42,4 +46,30 @@ func TestGameBuildInputWSL2FieldsOmitEmpty(t *testing.T) {
 	if strings.Contains(s, "wsl_distro") {
 		t.Errorf("wsl_distro should be omitted when empty, got: %s", s)
 	}
+}
+
+// TestGameBuildWSL2Dispatch verifies that backend=wsl2 dispatches to the
+// WSL2 handler. On non-Windows / no-WSL2 CI, the handler returns a
+// WSL2-specific error — proving the dispatch took the right branch.
+func TestGameBuildWSL2Dispatch(t *testing.T) {
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = &config.Config{
+		Engine: config.EngineConfig{SourcePath: "/nonexistent/engine"},
+		Game:   config.GameConfig{ProjectName: "TestGame"},
+	}
+
+	result, _, err := handleGameBuild(context.Background(), nil, gameBuildInput{
+		Backend: "wsl2",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// The WSL2 handler either fails at state.Load (no WSL2 engine state)
+	// or at wsl.New() (no WSL2 available). Either way, the error message
+	// should reference WSL2, proving the dispatch reached the right branch.
+	assertResultContains(t, result, "WSL2")
 }

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -23,6 +23,8 @@ var (
 	withSession   bool
 	backend       string
 	noCache       bool
+	wslNative     bool
+	wslDistro     string
 )
 
 // Cmd is the full pipeline command.
@@ -40,6 +42,8 @@ var Cmd = &cobra.Command{
 
 Use --skip-* flags to skip stages that are already complete.
 Use --backend docker or --backend podman to build engine and game inside containers.
+Use --backend wsl2 to build inside a WSL2 Linux distro (Windows only).
+Use --wsl-native with --backend wsl2 to sync source to native ext4 for faster builds.
 Use the global --dry-run flag to see what commands would be executed.`,
 	RunE: runPipeline,
 }
@@ -51,8 +55,10 @@ func init() {
 	Cmd.Flags().BoolVar(&skipDeploy, "skip-deploy", false, "skip deployment (build only)")
 	Cmd.Flags().BoolVar(&withClient, "with-client", false, "also build a standalone Linux game client")
 	Cmd.Flags().BoolVar(&withSession, "with-session", false, "create a game session after deployment")
-	Cmd.Flags().StringVar(&backend, "backend", "", `build backend: "native", "podman" (recommended), or "docker" (default: from ludus.yaml)`)
+	Cmd.Flags().StringVar(&backend, "backend", "", `build backend: "native", "podman" (recommended), "docker", or "wsl2" (default: from ludus.yaml)`)
 	Cmd.Flags().BoolVar(&noCache, "no-cache", false, "disable build caching (force rebuild of all stages)")
+	Cmd.Flags().BoolVar(&wslNative, "wsl-native", false, "sync engine source to WSL2 native ext4 for faster builds")
+	Cmd.Flags().StringVar(&wslDistro, "wsl-distro", "", "WSL2 distro override (default: first running WSL2 distro)")
 }
 
 type pipelineStage struct {
@@ -121,6 +127,8 @@ func newPipelineCtx(cmd *cobra.Command) (*pipelineCtx, error) {
 		serverHash:       cache.GameServerKey(cfg, engineHash),
 		clientHash:       cache.GameClientKey(cfg, engineHash, "Linux"),
 		buildCache:       buildCache,
+		wslNative:        wslNative,
+		wslDistro:        wslDistro,
 	}, nil
 }
 

--- a/cmd/pipeline/stages.go
+++ b/cmd/pipeline/stages.go
@@ -380,17 +380,24 @@ func (p *pipelineCtx) stageSession(ctx context.Context) error {
 	return nil
 }
 
+// wsl2Fallback wraps a WSL2 init error with a Podman fallback recommendation.
+func wsl2Fallback(err error) error {
+	return fmt.Errorf("%w\n\nIf WSL2 is not available, use Podman instead:\n  ludus engine build --backend podman", err)
+}
+
 // buildEngineWSL2 compiles Unreal Engine inside a WSL2 distro.
+// Mirrors the logic in cmd/engine/engine.go:runWSL2Build.
 func (p *pipelineCtx) buildEngineWSL2(ctx context.Context) (*engBuilder.BuildResult, error) {
 	w, err := wsl.New(p.r, p.wslDistro)
 	if err != nil {
-		return nil, err
+		return nil, wsl2Fallback(err)
 	}
 	fmt.Printf("    Using WSL2 distro: %s\n", w.Distro)
 
 	sourcePath := p.cfg.Engine.SourcePath
 
-	enginePath, ddcPath, err := p.resolveWSL2EnginePaths(ctx, w, sourcePath, p.engineVersion)
+	// Resolve WSL2 paths: --wsl-native syncs to ext4, otherwise uses /mnt/ virtiofs.
+	wslEnginePath, wslDDCPath, err := p.resolveWSL2EnginePaths(ctx, w, sourcePath, p.engineVersion)
 	if err != nil {
 		return nil, err
 	}
@@ -405,41 +412,44 @@ func (p *pipelineCtx) buildEngineWSL2(ctx context.Context) (*engBuilder.BuildRes
 		return nil, err
 	}
 
-	p.saveWSL2EngineState(enginePath, ddcPath)
+	// Persist engine location so game build can find it via state.Load().
+	p.saveWSL2EngineState(wslEnginePath, wslDDCPath)
 	return result, nil
 }
 
 // resolveWSL2EnginePaths returns the WSL2 engine and DDC paths for the build.
-// When --wsl-native is set it rsyncs the source to ext4 first; otherwise it
-// converts the Windows source path to a /mnt/ virtiofs path.
-func (p *pipelineCtx) resolveWSL2EnginePaths(ctx context.Context, w *wsl.WSL2, sourcePath, version string) (enginePath, ddcPath string, err error) {
+// When --wsl-native is set it rsyncs the source to native ext4 first (fast I/O);
+// otherwise it converts the Windows source path to a /mnt/ virtiofs path.
+func (p *pipelineCtx) resolveWSL2EnginePaths(ctx context.Context, w *wsl.WSL2, sourcePath, version string) (wslEnginePath, wslDDCPath string, err error) {
 	if p.wslNative {
 		fmt.Println("    Syncing engine source to WSL2 native ext4...")
-		syncResult, err := wsl.SyncEngine(ctx, p.r, w.Distro, wsl.SyncOptions{
+		syncResult, syncErr := wsl.SyncEngine(ctx, p.r, w.Distro, wsl.SyncOptions{
 			SourcePath: sourcePath,
 			Version:    version,
 		})
-		if err != nil {
-			return "", "", err
+		if syncErr != nil {
+			return "", "", syncErr
 		}
 		fmt.Printf("    Synced to %s in %.0fs\n", syncResult.WSLPath, syncResult.Duration.Seconds())
 		return syncResult.WSLPath, syncResult.DDCPath, nil
 	}
-	ep := w.ToWSLPath(sourcePath)
-	dp := w.ToWSLPath(filepath.Join(filepath.Dir(sourcePath), ".ludus", "ddc"))
-	return ep, dp, nil
+	// Default mode: convert Windows paths to /mnt/<drive>/ virtiofs mounts.
+	enginePath := w.ToWSLPath(sourcePath)
+	ddcPath := w.ToWSLPath(filepath.Join(filepath.Dir(sourcePath), ".ludus", "ddc"))
+	return enginePath, ddcPath, nil
 }
 
-// saveWSL2EngineState persists the engine and DDC paths to .ludus/state.json.
-func (p *pipelineCtx) saveWSL2EngineState(enginePath, ddcPath string) {
+// saveWSL2EngineState persists the WSL2 engine and DDC paths to .ludus/state.json
+// so that subsequent game builds can locate the engine without re-detection.
+func (p *pipelineCtx) saveWSL2EngineState(wslEnginePath, wslDDCPath string) {
 	syncTime := ""
 	if p.wslNative {
 		syncTime = time.Now().UTC().Format(time.RFC3339)
 	}
 	if err := state.UpdateWSL2Engine(&state.WSL2EngineState{
-		EnginePath: enginePath,
+		EnginePath: wslEnginePath,
 		IsNative:   p.wslNative,
-		DDCPath:    ddcPath,
+		DDCPath:    wslDDCPath,
 		SyncTime:   syncTime,
 		BuiltAt:    time.Now().UTC().Format(time.RFC3339),
 	}); err != nil {
@@ -448,7 +458,9 @@ func (p *pipelineCtx) saveWSL2EngineState(enginePath, ddcPath string) {
 }
 
 // buildGameWSL2 builds a dedicated server inside WSL2 using RunUAT.
+// Mirrors the logic in cmd/game/game.go:runWSL2GameBuild.
 func (p *pipelineCtx) buildGameWSL2(ctx context.Context, projectName string) (*gameBuilder.BuildResult, error) {
+	// Load state written by buildEngineWSL2 to find the engine path.
 	s, err := state.Load()
 	if err != nil {
 		return nil, fmt.Errorf("loading state: %w", err)
@@ -459,13 +471,12 @@ func (p *pipelineCtx) buildGameWSL2(ctx context.Context, projectName string) (*g
 
 	w, err := wsl.New(p.r, p.wslDistro)
 	if err != nil {
-		return nil, err
+		return nil, wsl2Fallback(err)
 	}
 	fmt.Printf("    Using WSL2 distro: %s\n", w.Distro)
 
-	// Resolve DDC path. When the engine was built with --wsl-native, the
-	// DDC path in state points to native ext4. Otherwise fall back to the
-	// virtiofs-converted host path.
+	// Resolve DDC path: prefer the path from state (which reflects --wsl-native
+	// if the engine was built that way), falling back to virtiofs host path.
 	wslDDCPath := s.WSL2Engine.DDCPath
 	if p.ddcMode == ddc.ModeLocal && wslDDCPath == "" {
 		wslDDCPath = w.ToWSLPath(p.ddcPath)

--- a/cmd/pipeline/stages.go
+++ b/cmd/pipeline/stages.go
@@ -3,12 +3,14 @@ package pipeline
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"time"
 
 	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/devrecon/ludus/internal/cache"
 	"github.com/devrecon/ludus/internal/config"
 	ctrBuilder "github.com/devrecon/ludus/internal/container"
+	"github.com/devrecon/ludus/internal/ddc"
 	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/dflint"
 	"github.com/devrecon/ludus/internal/dockerbuild"
@@ -19,6 +21,7 @@ import (
 	"github.com/devrecon/ludus/internal/pricing"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/state"
+	"github.com/devrecon/ludus/internal/wsl"
 )
 
 // pipelineCtx holds shared state for pipeline stage execution.
@@ -36,6 +39,8 @@ type pipelineCtx struct {
 	serverHash       string
 	clientHash       string
 	buildCache       *cache.Cache
+	wslNative        bool
+	wslDistro        string
 }
 
 // resolveBackend returns the effective backend, preferring CLI flag over config.
@@ -87,7 +92,8 @@ func (p *pipelineCtx) stageEngineBuild(ctx context.Context) error {
 		return nil
 	}
 
-	if dockerbuild.IsContainerBackend(p.containerBackend) {
+	switch {
+	case dockerbuild.IsContainerBackend(p.containerBackend):
 		imageName := p.cfg.Engine.DockerImageName
 		if imageName == "" {
 			imageName = "ludus-engine"
@@ -119,7 +125,15 @@ func (p *pipelineCtx) stageEngineBuild(ctx context.Context) error {
 		}
 		cli := dockerbuild.ContainerCLI(p.containerBackend)
 		fmt.Printf("    Engine %s image built in %.0fs: %s\n", cli, result.Duration, result.ImageTag)
-	} else {
+
+	case dockerbuild.IsWSL2Backend(p.containerBackend):
+		result, err := p.buildEngineWSL2(ctx)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("    Engine built in WSL2 in %.0fs: %s\n", result.Duration, result.EnginePath)
+
+	default:
 		builder := engBuilder.NewBuilder(engBuilder.BuildOptions{
 			SourcePath: p.cfg.Engine.SourcePath,
 			MaxJobs:    p.cfg.Engine.MaxJobs,
@@ -143,14 +157,23 @@ func (p *pipelineCtx) stageGameBuild(ctx context.Context) error {
 		return nil
 	}
 
-	if dockerbuild.IsContainerBackend(p.containerBackend) {
+	switch {
+	case dockerbuild.IsContainerBackend(p.containerBackend):
 		result, err := p.buildGameContainer(ctx)
 		if err != nil {
 			return err
 		}
 		p.serverBuildDir = result.OutputDir
 		fmt.Printf("    %s server built in %s in %.0fs at %s\n", projectName, dockerbuild.ContainerCLI(p.containerBackend), result.Duration, result.OutputDir)
-	} else {
+
+	case dockerbuild.IsWSL2Backend(p.containerBackend):
+		result, err := p.buildGameWSL2(ctx, projectName)
+		if err != nil {
+			return err
+		}
+		fmt.Printf("    %s server built in WSL2 in %.0fs at %s\n", projectName, result.Duration, result.OutputDir)
+
+	default:
 		result, err := p.buildGameNative(ctx, projectName)
 		if err != nil {
 			return err
@@ -355,4 +378,110 @@ func (p *pipelineCtx) stageSession(ctx context.Context) error {
 	fmt.Printf("    Game session created: %s\n", info.SessionID)
 	fmt.Printf("    Connect: %s:%d\n", info.IPAddress, info.Port)
 	return nil
+}
+
+// buildEngineWSL2 compiles Unreal Engine inside a WSL2 distro.
+func (p *pipelineCtx) buildEngineWSL2(ctx context.Context) (*engBuilder.BuildResult, error) {
+	w, err := wsl.New(p.r, p.wslDistro)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("    Using WSL2 distro: %s\n", w.Distro)
+
+	sourcePath := p.cfg.Engine.SourcePath
+
+	enginePath, ddcPath, err := p.resolveWSL2EnginePaths(ctx, w, sourcePath, p.engineVersion)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := wsl.BuildEngine(ctx, w, wsl.EngineOptions{
+		SourcePath: sourcePath,
+		MaxJobs:    p.cfg.Engine.MaxJobs,
+		WSLNative:  p.wslNative,
+		Version:    p.engineVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	p.saveWSL2EngineState(enginePath, ddcPath)
+	return result, nil
+}
+
+// resolveWSL2EnginePaths returns the WSL2 engine and DDC paths for the build.
+// When --wsl-native is set it rsyncs the source to ext4 first; otherwise it
+// converts the Windows source path to a /mnt/ virtiofs path.
+func (p *pipelineCtx) resolveWSL2EnginePaths(ctx context.Context, w *wsl.WSL2, sourcePath, version string) (enginePath, ddcPath string, err error) {
+	if p.wslNative {
+		fmt.Println("    Syncing engine source to WSL2 native ext4...")
+		syncResult, err := wsl.SyncEngine(ctx, p.r, w.Distro, wsl.SyncOptions{
+			SourcePath: sourcePath,
+			Version:    version,
+		})
+		if err != nil {
+			return "", "", err
+		}
+		fmt.Printf("    Synced to %s in %.0fs\n", syncResult.WSLPath, syncResult.Duration.Seconds())
+		return syncResult.WSLPath, syncResult.DDCPath, nil
+	}
+	ep := w.ToWSLPath(sourcePath)
+	dp := w.ToWSLPath(filepath.Join(filepath.Dir(sourcePath), ".ludus", "ddc"))
+	return ep, dp, nil
+}
+
+// saveWSL2EngineState persists the engine and DDC paths to .ludus/state.json.
+func (p *pipelineCtx) saveWSL2EngineState(enginePath, ddcPath string) {
+	syncTime := ""
+	if p.wslNative {
+		syncTime = time.Now().UTC().Format(time.RFC3339)
+	}
+	if err := state.UpdateWSL2Engine(&state.WSL2EngineState{
+		EnginePath: enginePath,
+		IsNative:   p.wslNative,
+		DDCPath:    ddcPath,
+		SyncTime:   syncTime,
+		BuiltAt:    time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		fmt.Printf("    Warning: failed to write state: %v\n", err)
+	}
+}
+
+// buildGameWSL2 builds a dedicated server inside WSL2 using RunUAT.
+func (p *pipelineCtx) buildGameWSL2(ctx context.Context, projectName string) (*gameBuilder.BuildResult, error) {
+	s, err := state.Load()
+	if err != nil {
+		return nil, fmt.Errorf("loading state: %w", err)
+	}
+	if s.WSL2Engine == nil {
+		return nil, fmt.Errorf("no WSL2 engine build found; engine build stage must run first")
+	}
+
+	w, err := wsl.New(p.r, p.wslDistro)
+	if err != nil {
+		return nil, err
+	}
+	fmt.Printf("    Using WSL2 distro: %s\n", w.Distro)
+
+	// Resolve DDC path. When the engine was built with --wsl-native, the
+	// DDC path in state points to native ext4. Otherwise fall back to the
+	// virtiofs-converted host path.
+	wslDDCPath := s.WSL2Engine.DDCPath
+	if p.ddcMode == ddc.ModeLocal && wslDDCPath == "" {
+		wslDDCPath = w.ToWSLPath(p.ddcPath)
+	}
+
+	opts := wsl.GameOptions{
+		EnginePath:   s.WSL2Engine.EnginePath,
+		ProjectPath:  p.cfg.Game.ProjectPath,
+		ProjectName:  projectName,
+		ServerTarget: p.cfg.Game.ResolvedServerTarget(),
+		Platform:     p.cfg.Game.Platform,
+		Arch:         p.arch,
+		ServerMap:    p.cfg.Game.ServerMap,
+		DDCMode:      p.ddcMode,
+		DDCPath:      wslDDCPath,
+	}
+
+	return wsl.BuildGame(ctx, w, opts)
 }

--- a/cmd/pipeline/stages_test.go
+++ b/cmd/pipeline/stages_test.go
@@ -1,0 +1,52 @@
+package pipeline
+
+import (
+	"context"
+	"testing"
+
+	"github.com/devrecon/ludus/internal/config"
+	"github.com/devrecon/ludus/internal/deploy"
+)
+
+// stubTarget is a minimal deploy.Target for testing buildStages.
+type stubTarget struct {
+	name string
+	caps deploy.Capabilities
+}
+
+func (t *stubTarget) Name() string                      { return t.name }
+func (t *stubTarget) Capabilities() deploy.Capabilities { return t.caps }
+func (t *stubTarget) Deploy(_ context.Context, _ deploy.DeployInput) (*deploy.DeployResult, error) {
+	return nil, nil
+}
+func (t *stubTarget) Status(_ context.Context) (*deploy.DeployStatus, error) { return nil, nil }
+func (t *stubTarget) Destroy(_ context.Context) error                        { return nil }
+
+func TestBuildStagesCount(t *testing.T) {
+	p := &pipelineCtx{
+		cfg: &config.Config{Game: config.GameConfig{ProjectName: "TestGame"}},
+		target: &stubTarget{
+			name: "binary",
+			caps: deploy.Capabilities{},
+		},
+		arch: "amd64",
+	}
+
+	stages := buildStages(p)
+	if len(stages) != 8 {
+		t.Errorf("buildStages() returned %d stages, want 8", len(stages))
+	}
+}
+
+func TestPipelineCtxWSL2Fields(t *testing.T) {
+	p := &pipelineCtx{
+		wslNative: true,
+		wslDistro: "Ubuntu-24.04",
+	}
+	if !p.wslNative {
+		t.Error("expected wslNative = true")
+	}
+	if p.wslDistro != "Ubuntu-24.04" {
+		t.Errorf("wslDistro = %q, want %q", p.wslDistro, "Ubuntu-24.04")
+	}
+}


### PR DESCRIPTION
## Summary

- Wire the existing `internal/wsl/` package into the pipeline runner (`ludus run --backend wsl2`) and MCP tool handlers (`backend=wsl2`)
- The core WSL2 package was already fully implemented; this PR closes the two integration gaps: pipeline orchestration and MCP tool dispatch
- Add `--wsl-native` and `--wsl-distro` flags to `ludus run` for parity with `ludus engine build`

## Changes

**Pipeline (`cmd/pipeline/`)**
- Add `--wsl-native` and `--wsl-distro` flags
- Add WSL2 branches to `stageEngineBuild` and `stageGameBuild` (refactored to `switch` per gocritic)
- Add `buildEngineWSL2`, `buildGameWSL2`, `resolveWSL2EnginePaths`, `saveWSL2EngineState` methods on `pipelineCtx`

**MCP tools (`cmd/mcp/`)**
- Add `handleWSL2EngineBuild` with sync, build, and state persistence
- Add `handleWSL2GameBuild` respecting `IsNative` from `WSL2EngineState` for DDC path
- Add WSL2 rejection guards to all 3 async build handlers
- Update tool descriptions and jsonschema hints

**Tests (4 new files)**
- `cmd/pipeline/stages_test.go` — stage count, `pipelineCtx` WSL2 fields
- `cmd/mcp/tools_engine_test.go` — WSL2 input field serialization
- `cmd/mcp/tools_game_test.go` — WSL2 input field serialization
- `cmd/mcp/tools_async_test.go` — WSL2 rejection for all async handlers

## Test plan

- [ ] `go build -o ludus.exe -v .` compiles cleanly
- [ ] `go test ./...` — all 40 test packages pass
- [ ] `golangci-lint run ./...` — 0 issues
- [ ] `ludus run --help` shows `--wsl-native` and `--wsl-distro` flags
- [ ] CI passes on ubuntu and windows (Build, Lint, Test)