### PR TITLE
chore: add CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Default owner for all files
+* @jpvelasco


### PR DESCRIPTION
## Summary

- Add `.github/CODEOWNERS` assigning `@jpvelasco` as default owner for all files
- Part of repo hardening for open-source standards

## Test plan

- [ ] CI passes
- [ ] CODEOWNERS recognized by GitHub (visible in PR reviewer suggestions)