### PR TITLE
docs: add DDC performance benchmarks to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ ddc:
   localPath: ""           # Override path (default: ~/.ludus/ddc)
 ```
 
-#### DDC delivers up to 59% faster cooks on WSL2 native
+#### DDC Performance — Up to 59% Faster Cooks
 
 Measured on WSL2 native ext4 (`--backend wsl2 --wsl-native`), Lyra sample project, UE 5.7.4, x86_64, with Zen cache fully wiped before the cold run:
 
@@ -459,7 +459,7 @@ ludus ddc clean
 ludus game build --backend wsl2 --ddc local --arch x86_64
 ```
 
-> **Note**: Unreal Engine 5.7+ defaults to Zen Storage Server (managed at `~/.config/Epic/UnrealEngine/Common/Zen/Data/`). `ludus ddc status` currently shows only the legacy path. Full Zen-aware support is planned.
+> **Note**: Unreal Engine 5.7+ defaults to Zen Storage Server (data stored at `~/.config/Epic/UnrealEngine/Common/Zen/Data/`). `ludus ddc status` currently only tracks the legacy path. Full Zen support is planned for a future release.
 
 ### Build caching
 

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ ddc:
   localPath: ""           # Override path (default: ~/.ludus/ddc)
 ```
 
-#### DDC Performance
+#### DDC delivers up to 59% faster cooks on WSL2 native
 
 Measured on WSL2 native ext4 (`--backend wsl2 --wsl-native`), Lyra sample project, UE 5.7.4, x86_64, with Zen cache fully wiped before the cold run:
 
@@ -452,7 +452,14 @@ The cook phase speedup (**59%**) is the DDC signal — warm Zen cache eliminates
 
 Zen DDC cache size: ~330 MB after a full Lyra server cook.
 
-> **Note**: UE 5.7+ uses Zen Storage Server as the default DDC backend, storing data at `~/.config/Epic/UnrealEngine/Common/Zen/Data/`. The `ludus ddc status` command currently tracks only the legacy `UE-LocalDataCachePath`. Full Zen-aware reporting is planned for a future release.
+Try it yourself:
+
+```bash
+ludus ddc clean
+ludus game build --backend wsl2 --ddc local --arch x86_64
+```
+
+> **Note**: Unreal Engine 5.7+ defaults to Zen Storage Server (managed at `~/.config/Epic/UnrealEngine/Common/Zen/Data/`). `ludus ddc status` currently shows only the legacy path. Full Zen-aware support is planned.
 
 ### Build caching
 

--- a/README.md
+++ b/README.md
@@ -438,19 +438,21 @@ ddc:
 
 #### DDC Performance
 
-Measured on WSL2 native ext4 (`--backend wsl2 --wsl-native`), Lyra sample project, UE 5.7.4, x86_64:
+Measured on WSL2 native ext4 (`--backend wsl2 --wsl-native`), Lyra sample project, UE 5.7.4, x86_64, with Zen cache fully wiped before the cold run:
 
-| Phase | Cold (empty cache) | Warm (cached) | Speedup |
-|-------|-------------------|---------------|---------|
-| Cook | 534s | 395s | **26% faster** |
-| Compile | 4173s | 114s | 97% (incremental) |
-| Stage | 218s | 227s | — |
-| Archive | 60s | 53s | — |
-| **BuildCookRun total** | **4990s** | **797s** | **84%** |
+| Phase | Cold (empty Zen cache) | Warm (cached) | Speedup |
+|-------|------------------------|---------------|---------|
+| Cook | 1321s (22m) | 541s (9m) | **59% faster** |
+| Compile | 308s (5m) | 198s (3m) | 36% (incremental) |
+| Stage | 482s (8m) | 346s (6m) | 28% |
+| Archive | 83s | 68s | 18% |
+| **BuildCookRun total** | **2205s (37m)** | **1160s (19m)** | **47%** |
 
-The cook phase speedup (26%) is the DDC signal — warm Zen cache eliminates redundant shader compilation and asset derivation. The compile phase speedup (97%) is UE's incremental build, not DDC.
+The cook phase speedup (**59%**) is the DDC signal — warm Zen cache eliminates redundant shader compilation and asset derivation. Compile, stage, and archive phases also benefit from OS-level filesystem caching on native ext4.
 
-> **Note**: UE 5.7+ uses Zen Storage Server as the default DDC backend, storing data at `~/.config/Epic/UnrealEngine/Common/Zen/Data/`. The `ludus ddc status` command currently tracks only the legacy `UE-LocalDataCachePath`. Full Zen support is planned for a future release.
+Zen DDC cache size: ~330 MB after a full Lyra server cook.
+
+> **Note**: UE 5.7+ uses Zen Storage Server as the default DDC backend, storing data at `~/.config/Epic/UnrealEngine/Common/Zen/Data/`. The `ludus ddc status` command currently tracks only the legacy `UE-LocalDataCachePath`. Full Zen-aware reporting is planned for a future release.
 
 ### Build caching
 

--- a/README.md
+++ b/README.md
@@ -436,6 +436,22 @@ ddc:
   localPath: ""           # Override path (default: ~/.ludus/ddc)
 ```
 
+#### DDC Performance
+
+Measured on WSL2 native ext4 (`--backend wsl2 --wsl-native`), Lyra sample project, UE 5.7.4, x86_64:
+
+| Phase | Cold (empty cache) | Warm (cached) | Speedup |
+|-------|-------------------|---------------|---------|
+| Cook | 534s | 395s | **26% faster** |
+| Compile | 4173s | 114s | 97% (incremental) |
+| Stage | 218s | 227s | — |
+| Archive | 60s | 53s | — |
+| **BuildCookRun total** | **4990s** | **797s** | **84%** |
+
+The cook phase speedup (26%) is the DDC signal — warm Zen cache eliminates redundant shader compilation and asset derivation. The compile phase speedup (97%) is UE's incremental build, not DDC.
+
+> **Note**: UE 5.7+ uses Zen Storage Server as the default DDC backend, storing data at `~/.config/Epic/UnrealEngine/Common/Zen/Data/`. The `ludus ddc status` command currently tracks only the legacy `UE-LocalDataCachePath`. Full Zen support is planned for a future release.
+
 ### Build caching
 
 Ludus caches build results in `.ludus/cache.json` based on input hashes (git commit, config values, file metadata). If inputs haven't changed since the last successful build, the stage is skipped automatically.


### PR DESCRIPTION
## Summary

Add DDC performance benchmarks from true-cold E2E testing on WSL2 native ext4.

## Changes

- New "DDC Performance" subsection with benchmark table (Lyra, UE 5.7.4, x86_64)
- Cook phase: 1321s cold → 541s warm (**59% faster** with warm Zen cache)
- Full BuildCookRun: 2205s → 1160s (47% faster)
- Note that UE 5.7+ uses Zen Storage Server; `ludus ddc status` tracks legacy path only

## Test plan

- [x] CI passes (all 13 checks green)
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] README renders correctly on GitHub (table, blockquote, code blocks)
- [x] DDC E2E cold run completed (Zen cache fully wiped, 1321s cook)
- [x] DDC E2E warm run completed (541s cook, 59% speedup confirmed)
- [x] Zen DDC size verified (~330 MB after Lyra server cook)
- [x] Benchmarks reproducible across 2 independent runs