### PR TITLE
chore(release): v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,24 +7,38 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-15
+
 ### Added
-- DDC (Derived Data Cache) support for container and WSL2 game builds — `ludus ddc` subcommand with `status`, `clean`, `prune`, and `warmup` commands (#151)
-- WSL2 native build backend — `--backend wsl2` compiles engine and game servers directly inside a WSL2 distro, with optional `--wsl-native` ext4 fast path (#151)
-- WSL2 backend integrated into pipeline runner — `ludus run --backend wsl2` now orchestrates engine and game builds through WSL2, with `--wsl-native` and `--wsl-distro` flags (#158)
-- WSL2 backend integrated into MCP tools — `ludus_engine_build` and `ludus_game_build` accept `backend=wsl2` with `wsl_native` and `wsl_distro` parameters; async build tools reject WSL2 with actionable error messages (#158)
-- Automatic runtime dependency installation in WSL2 distros — `EnsureRuntimeDeps` installs libnss3, libdbus, and other UnrealEditor-Cmd requirements via `wsl.exe -u root`, with Ubuntu 24.04 t64 package fallback (#151)
-- MCP tools for DDC management: `ludus_ddc_status`, `ludus_ddc_clean`, `ludus_ddc_configure`, `ludus_ddc_warm` (#151)
-- Centralized UE5 dependency lists in `internal/dockerbuild/deps.go` — single source of truth for apt/dnf build and runtime packages (#151)
-- Multi-stage engine Dockerfile with 5 stages (deps, source, generate, builder, runtime) and prebuilt variant for skip-engine mode (#151)
-- CODEOWNERS file assigning `@jpvelasco` as default code owner (#158)
+- **DDC Support** (`ludus ddc` commands + `--ddc local` flag)
+  - Persistent Derived Data Cache across builds
+  - Up to **59% faster cook times** on warm Zen cache (true cold benchmark)
+  - Subcommands: `status`, `clean`, `prune`, `warmup`
+  - MCP tools: `ludus_ddc_status`, `ludus_ddc_clean`, `ludus_ddc_configure`, `ludus_ddc_warm`
+- **WSL2 Native Build Backend** (`--backend wsl2`)
+  - Fast native ext4 builds, bypassing Docker/Podman virtiofs bottlenecks
+  - Two modes: default (virtiofs) + `--wsl-native` (rsync to native ext4)
+  - Full pipeline integration: `ludus run --backend wsl2 [--wsl-native]`
+  - MCP integration: `ludus_engine_build` and `ludus_game_build` accept `backend=wsl2`
+  - Automatic runtime dependency installation (`libnss3`, `libdbus`, etc.) via `wsl.exe -u root`
+- Full integration of DDC with WSL2 native path
+- Centralized UE5 dependency lists in `internal/dockerbuild/deps.go` — single source of truth for apt/dnf packages
+- Multi-stage engine Dockerfile with 5 stages and prebuilt variant for `--skip-engine` mode
+- CODEOWNERS file assigning `@jpvelasco` as default code owner
 
 ### Changed
-- Promote Podman to recommended container backend in all help text, flag descriptions, and error messages (#151)
-- E2E validated: DDC local mode delivers 16.6% cook-phase speedup on warm builds (311s cold, 260s warm — Lyra server, UE 5.7.4, WSL2/Podman)
+- `ludus game build` and `ludus run` now support `--backend wsl2 --ddc local`
+- Promote Podman to recommended container backend in all help text and error messages
+- Improved runtime dependency handling for WSL2 and container builds (Ubuntu 24.04 t64 package fallback)
 
 ### Fixed
-- Fix macOS CI failure where docker-not-found crashed prereq checker instead of producing a warning (#151)
-- Fix Codacy cyclomatic complexity and NLOC violations — extracted helpers across 8 files, split long test functions (#151)
+- Fix macOS CI failure where docker-not-found crashed prereq checker instead of producing a warning
+- Fix Codacy cyclomatic complexity and NLOC violations — extracted helpers across 8 files
+
+### Benchmarks
+- True cold vs warm DDC test (Lyra, x86_64, WSL2 native):
+  - Cook: 1321s → **541s** (**59% faster**)
+  - Full BuildCookRun: 2205s → 1160s (**47% faster**)
 
 ### Dependencies
 - Bump github.com/aws/smithy-go from 1.24.2 to 1.24.3 (#156)

--- a/README.md
+++ b/README.md
@@ -436,7 +436,7 @@ ddc:
   localPath: ""           # Override path (default: ~/.ludus/ddc)
 ```
 
-#### DDC Performance — Up to 59% Faster Cooks
+#### DDC Performance — Up to 59% Faster Cooks on WSL2 Native
 
 Measured on WSL2 native ext4 (`--backend wsl2 --wsl-native`), Lyra sample project, UE 5.7.4, x86_64, with Zen cache fully wiped before the cold run:
 
@@ -460,6 +460,18 @@ ludus game build --backend wsl2 --ddc local --arch x86_64
 ```
 
 > **Note**: Unreal Engine 5.7+ defaults to Zen Storage Server (data stored at `~/.config/Epic/UnrealEngine/Common/Zen/Data/`). `ludus ddc status` currently only tracks the legacy path. Full Zen support is planned for a future release.
+
+**Recommended for best performance (Windows users):**
+
+Download and build UE directly inside WSL2 to avoid virtiofs entirely:
+
+```bash
+# Inside WSL2
+mkdir -p ~/ludus/engine
+# Download/extract UE 5.7.4 directly into WSL2 (recommended)
+ludus engine build --backend wsl2 --wsl-native
+ludus game build --backend wsl2 --ddc local
+```
 
 ### Build caching
 

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludus-cli",
-  "version": "0.0.0",
+  "version": "0.2.0",
   "description": "UE5 dedicated server deployment CLI with MCP server",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary

Release v0.2.0 — DDC + WSL2 Native Build Backend.

## Changes

- CHANGELOG.md: Add v0.2.0 section with DDC, WSL2 backend, benchmarks
- npm/package.json: Bump version to 0.2.0
- README.md: Stronger DDC headline, recommended WSL2 workflow

## Test plan

- [x] `go build` compiles
- [x] `go test ./...` — 40 packages pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] DDC E2E validated (59% cook speedup, 2 independent runs)
- [x] CI passes