### PR TITLE
fix: revert npm package.json version to 0.0.0

### DIFF
--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ludus-cli",
-  "version": "0.2.0",
+  "version": "0.0.0",
   "description": "UE5 dedicated server deployment CLI with MCP server",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
Release workflow sets version at publish time. Pre-setting it caused npm publish failure.