### PR TITLE
Add v0.2.1 to CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2026-05-01
+
+### Dependencies
+- Bump github.com/aws/aws-sdk-go-v2/service/sts from 1.41.10 to 1.42.1 (#169)
+- Bump github.com/aws/aws-sdk-go-v2/service/iam from 1.53.7 to 1.53.10 (#168)
+- Bump github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi from 1.31.10 to 1.31.12 (#167)
+- Bump github.com/aws/aws-sdk-go-v2/service/s3 from 1.99.0 to 1.100.1 (#166)
+- Bump github.com/aws/aws-sdk-go-v2 core from 1.41.5 to 1.41.7 (transitive, supersedes #170)
+- Bump github.com/aws/smithy-go from 1.24.3 to 1.25.1 (transitive)
+- Bump actions/setup-node from 6.3.0 to 6.4.0 (#164)
+- Bump goreleaser/goreleaser-action from 7.0.0 to 7.2.1 (#171)
+
 ## [0.2.0] - 2026-04-15
 
 ### Added
@@ -200,6 +212,8 @@ Initial public release.
 - BuildGraph XML generation — for Horde/UET CI pipelines
 - npm package (`ludus-cli`) with pre-built binaries for Linux, macOS, and Windows
 
+[0.2.1]: https://github.com/jpvelasco/ludus/compare/v0.2.0...v0.2.1
+[0.2.0]: https://github.com/jpvelasco/ludus/compare/v0.1.17...v0.2.0
 [0.1.8]: https://github.com/jpvelasco/ludus/compare/v0.1.7...v0.1.8
 [0.1.7]: https://github.com/jpvelasco/ludus/compare/v0.1.6...v0.1.7
 [0.1.6]: https://github.com/jpvelasco/ludus/compare/v0.1.5...v0.1.6


### PR DESCRIPTION
## Summary

CHANGELOG entry for v0.2.1 — a security/maintenance release bundling 6 merged dependabot PRs plus transitive AWS SDK core bumps.

### Dependencies rolled in
- aws-sdk-go-v2/service/sts 1.41.10 → 1.42.1 (#169)
- aws-sdk-go-v2/service/iam 1.53.7 → 1.53.10 (#168)
- aws-sdk-go-v2/service/resourcegroupstaggingapi 1.31.10 → 1.31.12 (#167)
- aws-sdk-go-v2/service/s3 1.99.0 → 1.100.1 (#166)
- aws-sdk-go-v2 core 1.41.5 → 1.41.7 (transitive, supersedes #170)
- smithy-go 1.24.3 → 1.25.1 (transitive)
- actions/setup-node 6.3.0 → 6.4.0 (#164)
- goreleaser/goreleaser-action 7.0.0 → 7.2.1 (#171)

## Test plan
- [x] go build, golangci-lint, go test all pass on main
- [x] CI green on this PR