### PR TITLE
fix: upgrade Go toolchain to 1.25.9 (CVE-2026-32283)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/devrecon/ludus
 
-go 1.25.8
+go 1.25.9
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7


### PR DESCRIPTION
## Summary

- Bumps `go` directive in `go.mod` from `1.25.8` → `1.25.9`
- Patches CVE-2026-32283 (HIGH, CVSS 7.5): TLS 1.3 deadlock when multiple key update messages are sent in a single post-handshake record — denial of service via uncontrolled resource consumption
- `go mod tidy` run with Go 1.25.9 toolchain; no dependency changes

## Test plan

- [x] `go build ./...` passes locally with `GOTOOLCHAIN=go1.25.9`
- [x] Pre-commit hook: build + lint + all tests pass
- [ ] CI: all 6 required checks on ubuntu/windows/macos