### PR TITLE
Document Codacy local analysis scope

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,6 +1,88 @@
 ---
+# Codacy repository configuration.
+#
+# Source of truth: live Codacy settings for jpvelasco/ludus on main,
+# checked via the Codacy API on 2026-05-09.
+#
+# Enabled analyzers in Codacy:
+# - Server-side/configurable here: Biome, Trivy, Opengrep, ShellCheck, Lizard
+# - Server-side/not documented for root config: Agentlinter
+# - Client-side/not configurable here: Aligncheck, Deadcode
+#
+# Active Lizard patterns in Codacy Code Patterns:
+# - Lizard_ccn-medium: threshold 8
+# - Lizard_nloc-medium: threshold 50
+# - Lizard_file-nloc-medium: threshold 500
+# - Lizard_parameter-count-medium: threshold 8
+#
+# Codacy does not enable/disable tools or set Lizard thresholds from this file;
+# those remain Code Patterns settings. This file keeps repository and
+# tool-specific ignores versioned so cloud and local runs analyze the same paths.
+
+# Exclude generated/local artifacts and non-application package assets.
+# Tests stay included so NLOC/complexity warnings are not hidden locally.
 exclude_paths:
-  - "dist/"
-  - ".codacy/"
-  - "npm/"
-  - "scripts/"
+  - ".codacy/**"
+  - "dist/**"
+  - "npm/**"
+  - "scripts/**"
+  - "codacy_issues_*.json"
+  - "coverage*.tmp"
+
+engines:
+  # Codacy refers to repository cyclomatic complexity analysis as "metric".
+  # Keep the same path exclusions as the global analysis scope.
+  metric:
+    exclude_paths:
+      - ".codacy/**"
+      - "dist/**"
+      - "npm/**"
+      - "scripts/**"
+      - "codacy_issues_*.json"
+      - "coverage*.tmp"
+
+  # Lizard flags the active Code Patterns listed above. Thresholds are managed
+  # in Codacy Code Patterns, so only path scope is versioned here.
+  lizard:
+    exclude_paths:
+      - ".codacy/**"
+      - "dist/**"
+      - "npm/**"
+      - "scripts/**"
+      - "codacy_issues_*.json"
+      - "coverage*.tmp"
+
+  # Enabled server-side analyzers. These entries make tool-level scope explicit
+  # without changing the repository's active Code Patterns.
+  biome:
+    exclude_paths:
+      - ".codacy/**"
+      - "dist/**"
+      - "npm/**"
+      - "scripts/**"
+      - "codacy_issues_*.json"
+      - "coverage*.tmp"
+  opengrep:
+    exclude_paths:
+      - ".codacy/**"
+      - "dist/**"
+      - "npm/**"
+      - "scripts/**"
+      - "codacy_issues_*.json"
+      - "coverage*.tmp"
+  shellcheck:
+    exclude_paths:
+      - ".codacy/**"
+      - "dist/**"
+      - "npm/**"
+      - "scripts/**"
+      - "codacy_issues_*.json"
+      - "coverage*.tmp"
+  trivy:
+    exclude_paths:
+      - ".codacy/**"
+      - "dist/**"
+      - "npm/**"
+      - "scripts/**"
+      - "codacy_issues_*.json"
+      - "coverage*.tmp"

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -18,10 +18,12 @@
 # Codacy does not enable/disable tools or set Lizard thresholds from this file;
 # those remain Code Patterns settings. This file keeps repository and
 # tool-specific ignores versioned so cloud and local runs analyze the same paths.
+#
+# Future plan: gradually lower Lizard thresholds as repository complexity drops.
 
 # Exclude generated/local artifacts and non-application package assets.
 # Tests stay included so NLOC/complexity warnings are not hidden locally.
-exclude_paths:
+exclude_paths: &analysis_exclude_paths
   - ".codacy/**"
   - "dist/**"
   - "npm/**"
@@ -33,56 +35,20 @@ engines:
   # Codacy refers to repository cyclomatic complexity analysis as "metric".
   # Keep the same path exclusions as the global analysis scope.
   metric:
-    exclude_paths:
-      - ".codacy/**"
-      - "dist/**"
-      - "npm/**"
-      - "scripts/**"
-      - "codacy_issues_*.json"
-      - "coverage*.tmp"
+    exclude_paths: *analysis_exclude_paths
 
   # Lizard flags the active Code Patterns listed above. Thresholds are managed
   # in Codacy Code Patterns, so only path scope is versioned here.
   lizard:
-    exclude_paths:
-      - ".codacy/**"
-      - "dist/**"
-      - "npm/**"
-      - "scripts/**"
-      - "codacy_issues_*.json"
-      - "coverage*.tmp"
+    exclude_paths: *analysis_exclude_paths
 
   # Enabled server-side analyzers. These entries make tool-level scope explicit
   # without changing the repository's active Code Patterns.
   biome:
-    exclude_paths:
-      - ".codacy/**"
-      - "dist/**"
-      - "npm/**"
-      - "scripts/**"
-      - "codacy_issues_*.json"
-      - "coverage*.tmp"
+    exclude_paths: *analysis_exclude_paths
   opengrep:
-    exclude_paths:
-      - ".codacy/**"
-      - "dist/**"
-      - "npm/**"
-      - "scripts/**"
-      - "codacy_issues_*.json"
-      - "coverage*.tmp"
+    exclude_paths: *analysis_exclude_paths
   shellcheck:
-    exclude_paths:
-      - ".codacy/**"
-      - "dist/**"
-      - "npm/**"
-      - "scripts/**"
-      - "codacy_issues_*.json"
-      - "coverage*.tmp"
+    exclude_paths: *analysis_exclude_paths
   trivy:
-    exclude_paths:
-      - ".codacy/**"
-      - "dist/**"
-      - "npm/**"
-      - "scripts/**"
-      - "codacy_issues_*.json"
-      - "coverage*.tmp"
+    exclude_paths: *analysis_exclude_paths


### PR DESCRIPTION
## Summary

- Expand .codacy.yml with the live Codacy analyzer snapshot for the repository.
- Document the active Lizard thresholds from Codacy Code Patterns.
- Version repository and tool-level excludes for local/generated artifacts while keeping tests in scope.

## Validation

- go test . -run TestCodacyYAMLParses -count=1 using a temporary parser test, then removed the test
- go test . -run TestNonExistent -count=0
- Pre-commit hook on commit:
  - go build
  - golangci-lint run ./...
  - go test ./...