### PR TITLE
refactor(pipeline): split WSL2 and stage helpers into focused files

### DIFF
--- a/cmd/pipeline/stages.go
+++ b/cmd/pipeline/stages.go
@@ -3,14 +3,12 @@ package pipeline
 import (
 	"context"
 	"fmt"
-	"path/filepath"
 	"time"
 
 	"github.com/devrecon/ludus/cmd/globals"
 	"github.com/devrecon/ludus/internal/cache"
 	"github.com/devrecon/ludus/internal/config"
 	ctrBuilder "github.com/devrecon/ludus/internal/container"
-	"github.com/devrecon/ludus/internal/ddc"
 	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/dflint"
 	"github.com/devrecon/ludus/internal/dockerbuild"
@@ -21,7 +19,6 @@ import (
 	"github.com/devrecon/ludus/internal/pricing"
 	"github.com/devrecon/ludus/internal/runner"
 	"github.com/devrecon/ludus/internal/state"
-	"github.com/devrecon/ludus/internal/wsl"
 )
 
 // pipelineCtx holds shared state for pipeline stage execution.
@@ -238,20 +235,27 @@ func (p *pipelineCtx) stageClientBuild(ctx context.Context) error {
 		return nil
 	}
 
-	var result *gameBuilder.ClientBuildResult
-	var err error
-	var label string
-
-	if dockerbuild.IsContainerBackend(p.containerBackend) {
-		result, err = p.buildClientDocker(ctx)
-		label = fmt.Sprintf("in %s ", dockerbuild.ContainerCLI(p.containerBackend))
-	} else {
-		result, err = p.buildClientNative(ctx, projectName)
-	}
+	result, label, err := p.dispatchClientBuild(ctx, projectName)
 	if err != nil {
 		return err
 	}
 
+	p.saveClientState(result)
+	fmt.Printf("    %s client built %sin %.0fs at %s\n", projectName, label, result.Duration, result.OutputDir)
+	p.recordCache(cache.StageGameClient, p.clientHash)
+	return nil
+}
+
+func (p *pipelineCtx) dispatchClientBuild(ctx context.Context, projectName string) (*gameBuilder.ClientBuildResult, string, error) {
+	if dockerbuild.IsContainerBackend(p.containerBackend) {
+		result, err := p.buildClientDocker(ctx)
+		return result, fmt.Sprintf("in %s ", dockerbuild.ContainerCLI(p.containerBackend)), err
+	}
+	result, err := p.buildClientNative(ctx, projectName)
+	return result, "", err
+}
+
+func (p *pipelineCtx) saveClientState(result *gameBuilder.ClientBuildResult) {
 	if err := state.UpdateClient(&state.ClientState{
 		BinaryPath: result.ClientBinary,
 		OutputDir:  result.OutputDir,
@@ -260,10 +264,6 @@ func (p *pipelineCtx) stageClientBuild(ctx context.Context) error {
 	}); err != nil {
 		fmt.Printf("    Warning: failed to write state: %v\n", err)
 	}
-	fmt.Printf("    %s client built %sin %.0fs at %s\n", projectName, label, result.Duration, result.OutputDir)
-
-	p.recordCache(cache.StageGameClient, p.clientHash)
-	return nil
 }
 
 func (p *pipelineCtx) buildClientDocker(ctx context.Context) (*gameBuilder.ClientBuildResult, error) {
@@ -349,11 +349,8 @@ func (p *pipelineCtx) stageDeploy(ctx context.Context) error {
 		fmt.Printf("    %s\n", sug)
 	}
 
-	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		p.cfg.AWS.AccountID, p.cfg.AWS.Region, p.cfg.AWS.ECRRepository, p.cfg.Container.Tag)
-
 	result, err := p.target.Deploy(ctx, deploy.DeployInput{
-		ImageURI:       imageURI,
+		ImageURI:       p.buildImageURI(),
 		ServerBuildDir: p.serverBuildDir,
 		ServerPort:     p.cfg.Container.ServerPort,
 	})
@@ -361,6 +358,17 @@ func (p *pipelineCtx) stageDeploy(ctx context.Context) error {
 		return err
 	}
 
+	p.saveDeployState(result)
+	fmt.Printf("    Deployed to %s: %s\n", result.TargetName, result.Detail)
+	return nil
+}
+
+func (p *pipelineCtx) buildImageURI() string {
+	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
+		p.cfg.AWS.AccountID, p.cfg.AWS.Region, p.cfg.AWS.ECRRepository, p.cfg.Container.Tag)
+}
+
+func (p *pipelineCtx) saveDeployState(result *deploy.DeployResult) {
 	if err := state.UpdateDeploy(&state.DeployState{
 		TargetName: result.TargetName,
 		Status:     result.Status,
@@ -369,9 +377,6 @@ func (p *pipelineCtx) stageDeploy(ctx context.Context) error {
 	}); err != nil {
 		fmt.Printf("    Warning: failed to write state: %v\n", err)
 	}
-
-	fmt.Printf("    Deployed to %s: %s\n", result.TargetName, result.Detail)
-	return nil
 }
 
 func (p *pipelineCtx) stageSession(ctx context.Context) error {
@@ -393,121 +398,4 @@ func (p *pipelineCtx) stageSession(ctx context.Context) error {
 	fmt.Printf("    Game session created: %s\n", info.SessionID)
 	fmt.Printf("    Connect: %s:%d\n", info.IPAddress, info.Port)
 	return nil
-}
-
-// wsl2Fallback wraps a WSL2 init error with a Podman fallback recommendation.
-func wsl2Fallback(err error) error {
-	return fmt.Errorf("%w\n\nIf WSL2 is not available, use Podman instead:\n  ludus engine build --backend podman", err)
-}
-
-// buildEngineWSL2 compiles Unreal Engine inside a WSL2 distro.
-// Mirrors the logic in cmd/engine/engine.go:runWSL2Build.
-func (p *pipelineCtx) buildEngineWSL2(ctx context.Context) (*engBuilder.BuildResult, error) {
-	w, err := wsl.New(p.r, p.wslDistro)
-	if err != nil {
-		return nil, wsl2Fallback(err)
-	}
-	fmt.Printf("    Using WSL2 distro: %s\n", w.Distro)
-
-	sourcePath := p.cfg.Engine.SourcePath
-
-	// Resolve WSL2 paths: --wsl-native syncs to ext4, otherwise uses /mnt/ virtiofs.
-	wslEnginePath, wslDDCPath, err := p.resolveWSL2EnginePaths(ctx, w, sourcePath, p.engineVersion)
-	if err != nil {
-		return nil, err
-	}
-
-	result, err := wsl.BuildEngine(ctx, w, wsl.EngineOptions{
-		SourcePath: sourcePath,
-		MaxJobs:    p.cfg.Engine.MaxJobs,
-		WSLNative:  p.wslNative,
-		Version:    p.engineVersion,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	// Persist engine location so game build can find it via state.Load().
-	p.saveWSL2EngineState(wslEnginePath, wslDDCPath)
-	return result, nil
-}
-
-// resolveWSL2EnginePaths returns the WSL2 engine and DDC paths for the build.
-// When --wsl-native is set it rsyncs the source to native ext4 first (fast I/O);
-// otherwise it converts the Windows source path to a /mnt/ virtiofs path.
-func (p *pipelineCtx) resolveWSL2EnginePaths(ctx context.Context, w *wsl.WSL2, sourcePath, version string) (wslEnginePath, wslDDCPath string, err error) {
-	if p.wslNative {
-		fmt.Println("    Syncing engine source to WSL2 native ext4...")
-		syncResult, syncErr := wsl.SyncEngine(ctx, p.r, w.Distro, wsl.SyncOptions{
-			SourcePath: sourcePath,
-			Version:    version,
-		})
-		if syncErr != nil {
-			return "", "", syncErr
-		}
-		fmt.Printf("    Synced to %s in %.0fs\n", syncResult.WSLPath, syncResult.Duration.Seconds())
-		return syncResult.WSLPath, syncResult.DDCPath, nil
-	}
-	// Default mode: convert Windows paths to /mnt/<drive>/ virtiofs mounts.
-	enginePath := w.ToWSLPath(sourcePath)
-	ddcPath := w.ToWSLPath(filepath.Join(filepath.Dir(sourcePath), ".ludus", "ddc"))
-	return enginePath, ddcPath, nil
-}
-
-// saveWSL2EngineState persists the WSL2 engine and DDC paths to .ludus/state.json
-// so that subsequent game builds can locate the engine without re-detection.
-func (p *pipelineCtx) saveWSL2EngineState(wslEnginePath, wslDDCPath string) {
-	syncTime := ""
-	if p.wslNative {
-		syncTime = time.Now().UTC().Format(time.RFC3339)
-	}
-	if err := state.UpdateWSL2Engine(&state.WSL2EngineState{
-		EnginePath: wslEnginePath,
-		IsNative:   p.wslNative,
-		DDCPath:    wslDDCPath,
-		SyncTime:   syncTime,
-		BuiltAt:    time.Now().UTC().Format(time.RFC3339),
-	}); err != nil {
-		fmt.Printf("    Warning: failed to write state: %v\n", err)
-	}
-}
-
-// buildGameWSL2 builds a dedicated server inside WSL2 using RunUAT.
-// Mirrors the logic in cmd/game/game.go:runWSL2GameBuild.
-func (p *pipelineCtx) buildGameWSL2(ctx context.Context, projectName string) (*gameBuilder.BuildResult, error) {
-	// Load state written by buildEngineWSL2 to find the engine path.
-	s, err := state.Load()
-	if err != nil {
-		return nil, fmt.Errorf("loading state: %w", err)
-	}
-	if s.WSL2Engine == nil {
-		return nil, fmt.Errorf("no WSL2 engine build found; engine build stage must run first")
-	}
-
-	w, err := wsl.New(p.r, p.wslDistro)
-	if err != nil {
-		return nil, wsl2Fallback(err)
-	}
-	fmt.Printf("    Using WSL2 distro: %s\n", w.Distro)
-
-	// Resolve DDC path: prefer the path from state (which reflects --wsl-native
-	// if the engine was built that way), falling back to virtiofs host path.
-	wslDDCPath := s.WSL2Engine.DDCPath
-	if p.ddcMode == ddc.ModeLocal && wslDDCPath == "" {
-		wslDDCPath = w.ToWSLPath(p.ddcPath)
-	}
-
-	opts := wsl.GameOptions{
-		EnginePath:   s.WSL2Engine.EnginePath,
-		ProjectPath:  p.cfg.Game.ProjectPath,
-		ProjectName:  projectName,
-		ServerTarget: p.cfg.Game.ResolvedServerTarget(),
-		Platform:     p.cfg.Game.Platform,
-		Arch:         p.arch,
-		ServerMap:    p.cfg.Game.ServerMap,
-		DDCMode:      p.ddcMode,
-		DDCPath:      wslDDCPath,
-	}
-
-	return wsl.BuildGame(ctx, w, opts)
 }

--- a/cmd/pipeline/stages_test.go
+++ b/cmd/pipeline/stages_test.go
@@ -6,6 +6,8 @@ import (
 
 	"github.com/devrecon/ludus/internal/config"
 	"github.com/devrecon/ludus/internal/deploy"
+	"github.com/devrecon/ludus/internal/state"
+	"github.com/devrecon/ludus/internal/wsl"
 )
 
 // stubTarget is a minimal deploy.Target for testing buildStages.
@@ -48,5 +50,92 @@ func TestPipelineCtxWSL2Fields(t *testing.T) {
 	}
 	if p.wslDistro != "Ubuntu-24.04" {
 		t.Errorf("wslDistro = %q, want %q", p.wslDistro, "Ubuntu-24.04")
+	}
+}
+
+func TestBuildImageURI(t *testing.T) {
+	tests := []struct {
+		name      string
+		accountID string
+		region    string
+		repo      string
+		tag       string
+		want      string
+	}{
+		{
+			name:      "standard",
+			accountID: "123456789012",
+			region:    "us-east-1",
+			repo:      "my-game",
+			tag:       "latest",
+			want:      "123456789012.dkr.ecr.us-east-1.amazonaws.com/my-game:latest",
+		},
+		{
+			name:      "eu-region",
+			accountID: "000000000001",
+			region:    "eu-west-1",
+			repo:      "server",
+			tag:       "v1.2.3",
+			want:      "000000000001.dkr.ecr.eu-west-1.amazonaws.com/server:v1.2.3",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &pipelineCtx{
+				cfg: &config.Config{
+					AWS: config.AWSConfig{
+						AccountID:     tt.accountID,
+						Region:        tt.region,
+						ECRRepository: tt.repo,
+					},
+					Container: config.ContainerConfig{Tag: tt.tag},
+				},
+			}
+			if got := p.buildImageURI(); got != tt.want {
+				t.Errorf("buildImageURI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveWSL2GameDDCPath(t *testing.T) {
+	w := &wsl.WSL2{}
+
+	tests := []struct {
+		name        string
+		engineState *state.WSL2EngineState
+		ddcMode     string
+		ddcPath     string
+		want        string
+	}{
+		{
+			name:        "state DDC path takes priority",
+			engineState: &state.WSL2EngineState{DDCPath: "/home/user/ludus/ddc"},
+			ddcMode:     "local",
+			ddcPath:     "C:/ludus/ddc",
+			want:        "/home/user/ludus/ddc",
+		},
+		{
+			name:        "fallback to virtiofs when state empty and mode is local",
+			engineState: &state.WSL2EngineState{DDCPath: ""},
+			ddcMode:     "local",
+			ddcPath:     `C:\ludus\ddc`,
+			want:        "/mnt/c/ludus/ddc",
+		},
+		{
+			name:        "empty when mode is none and no state path",
+			engineState: &state.WSL2EngineState{DDCPath: ""},
+			ddcMode:     "none",
+			ddcPath:     `C:\ludus\ddc`,
+			want:        "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveWSL2GameDDCPath(tt.engineState, tt.ddcMode, tt.ddcPath, w)
+			if got != tt.want {
+				t.Errorf("resolveWSL2GameDDCPath() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/pipeline/stages_wsl.go
+++ b/cmd/pipeline/stages_wsl.go
@@ -1,0 +1,134 @@
+package pipeline
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"time"
+
+	"github.com/devrecon/ludus/internal/ddc"
+	engBuilder "github.com/devrecon/ludus/internal/engine"
+	gameBuilder "github.com/devrecon/ludus/internal/game"
+	"github.com/devrecon/ludus/internal/state"
+	"github.com/devrecon/ludus/internal/wsl"
+)
+
+// wsl2Fallback wraps a WSL2 init error with a Podman fallback recommendation.
+func wsl2Fallback(err error) error {
+	return fmt.Errorf("%w\n\nIf WSL2 is not available, use Podman instead:\n  ludus engine build --backend podman", err)
+}
+
+// buildEngineWSL2 compiles Unreal Engine inside a WSL2 distro.
+// Mirrors the logic in cmd/engine/engine.go:runWSL2Build.
+func (p *pipelineCtx) buildEngineWSL2(ctx context.Context) (*engBuilder.BuildResult, error) {
+	w, err := wsl.New(p.r, p.wslDistro)
+	if err != nil {
+		return nil, wsl2Fallback(err)
+	}
+	fmt.Printf("    Using WSL2 distro: %s\n", w.Distro)
+
+	wslEnginePath, wslDDCPath, err := p.resolveWSL2EnginePaths(ctx, w)
+	if err != nil {
+		return nil, err
+	}
+
+	result, err := wsl.BuildEngine(ctx, w, wsl.EngineOptions{
+		SourcePath: p.cfg.Engine.SourcePath,
+		MaxJobs:    p.cfg.Engine.MaxJobs,
+		WSLNative:  p.wslNative,
+		Version:    p.engineVersion,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	p.saveWSL2EngineState(wslEnginePath, wslDDCPath)
+	return result, nil
+}
+
+// resolveWSL2EnginePaths returns the WSL2 engine and DDC paths for the build.
+// When --wsl-native is set it rsyncs the source to native ext4 first (fast I/O);
+// otherwise it converts the Windows source path to a /mnt/ virtiofs path.
+func (p *pipelineCtx) resolveWSL2EnginePaths(ctx context.Context, w *wsl.WSL2) (wslEnginePath, wslDDCPath string, err error) {
+	if p.wslNative {
+		fmt.Println("    Syncing engine source to WSL2 native ext4...")
+		syncResult, syncErr := wsl.SyncEngine(ctx, p.r, w.Distro, wsl.SyncOptions{
+			SourcePath: p.cfg.Engine.SourcePath,
+			Version:    p.engineVersion,
+		})
+		if syncErr != nil {
+			return "", "", syncErr
+		}
+		fmt.Printf("    Synced to %s in %.0fs\n", syncResult.WSLPath, syncResult.Duration.Seconds())
+		return syncResult.WSLPath, syncResult.DDCPath, nil
+	}
+	enginePath := w.ToWSLPath(p.cfg.Engine.SourcePath)
+	ddcPath := w.ToWSLPath(filepath.Join(filepath.Dir(p.cfg.Engine.SourcePath), ".ludus", "ddc"))
+	return enginePath, ddcPath, nil
+}
+
+// saveWSL2EngineState persists the WSL2 engine and DDC paths to .ludus/state.json
+// so that subsequent game builds can locate the engine without re-detection.
+func (p *pipelineCtx) saveWSL2EngineState(wslEnginePath, wslDDCPath string) {
+	syncTime := ""
+	if p.wslNative {
+		syncTime = time.Now().UTC().Format(time.RFC3339)
+	}
+	if err := state.UpdateWSL2Engine(&state.WSL2EngineState{
+		EnginePath: wslEnginePath,
+		IsNative:   p.wslNative,
+		DDCPath:    wslDDCPath,
+		SyncTime:   syncTime,
+		BuiltAt:    time.Now().UTC().Format(time.RFC3339),
+	}); err != nil {
+		fmt.Printf("    Warning: failed to write state: %v\n", err)
+	}
+}
+
+// buildGameWSL2 builds a dedicated server inside WSL2 using RunUAT.
+// Mirrors the logic in cmd/game/game.go:runWSL2GameBuild.
+func (p *pipelineCtx) buildGameWSL2(ctx context.Context, projectName string) (*gameBuilder.BuildResult, error) {
+	// Load state written by buildEngineWSL2 to find the engine path.
+	s, err := state.Load()
+	if err != nil {
+		return nil, fmt.Errorf("loading state: %w", err)
+	}
+	if s.WSL2Engine == nil {
+		return nil, fmt.Errorf("no WSL2 engine build found; engine build stage must run first")
+	}
+
+	w, err := wsl.New(p.r, p.wslDistro)
+	if err != nil {
+		return nil, wsl2Fallback(err)
+	}
+	fmt.Printf("    Using WSL2 distro: %s\n", w.Distro)
+
+	wslDDCPath := resolveWSL2GameDDCPath(s.WSL2Engine, p.ddcMode, p.ddcPath, w)
+
+	opts := wsl.GameOptions{
+		EnginePath:   s.WSL2Engine.EnginePath,
+		ProjectPath:  p.cfg.Game.ProjectPath,
+		ProjectName:  projectName,
+		ServerTarget: p.cfg.Game.ResolvedServerTarget(),
+		Platform:     p.cfg.Game.Platform,
+		Arch:         p.arch,
+		ServerMap:    p.cfg.Game.ServerMap,
+		DDCMode:      p.ddcMode,
+		DDCPath:      wslDDCPath,
+	}
+
+	return wsl.BuildGame(ctx, w, opts)
+}
+
+// resolveWSL2GameDDCPath returns the DDC path to use inside WSL2 for a game build.
+// It prefers the path recorded in engine state (which reflects --wsl-native),
+// falling back to the virtiofs host path when DDC is enabled but no state path exists.
+func resolveWSL2GameDDCPath(engineState *state.WSL2EngineState, ddcMode, ddcPath string, w *wsl.WSL2) string {
+	if engineState.DDCPath != "" {
+		return engineState.DDCPath
+	}
+	if ddcMode == ddc.ModeLocal {
+		return w.ToWSLPath(ddcPath)
+	}
+	return ""
+}


### PR DESCRIPTION
## Summary

- Moves all WSL2-specific methods (`buildEngineWSL2`, `resolveWSL2EnginePaths`, `saveWSL2EngineState`, `buildGameWSL2`, `wsl2Fallback`) out of `stages.go` into a new `stages_wsl.go`
- Extracts four small helpers in `stages.go`: `dispatchClientBuild`, `saveClientState`, `buildImageURI`, `saveDeployState`
- Simplifies `resolveWSL2EnginePaths` signature — removes the redundant `sourcePath`/`version` parameters (reads from receiver directly)
- Extracts `resolveWSL2GameDDCPath` as a free function (was an inline `if` block in `buildGameWSL2`)
- Reduces `stages.go` complexity from 72 to ~55; WSL2 code is now self-contained in one file

## Test plan

- [ ] `go test ./cmd/pipeline/...` — 5 tests pass (existing 3 + new `TestBuildImageURI` and `TestResolveWSL2GameDDCPath`)
- [ ] Full `go test ./...` — all green
- [ ] `golangci-lint run ./...` — 0 issues