### PR TITLE
refactor(runner): split runner.go into focused domain files

### DIFF
--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,12 +1,9 @@
 package runner
 
 import (
-	"context"
 	"fmt"
 	"io"
 	"os"
-	"os/exec"
-	"strings"
 )
 
 // Runner executes shell commands with output streaming and error handling.
@@ -35,47 +32,6 @@ func NewRunner(verbose, dryRun bool) *Runner {
 	}
 }
 
-// environ returns the merged environment for child processes. If Env is empty,
-// it returns nil so exec.Cmd inherits the parent environment unchanged.
-// When Env is set, parent variables are included and any matching keys are
-// overridden by the Env values.
-func (r *Runner) environ() []string {
-	if len(r.Env) == 0 {
-		return nil
-	}
-
-	// Build a set of override keys for quick lookup.
-	overrides := make(map[string]string, len(r.Env))
-	for _, kv := range r.Env {
-		if k, _, ok := strings.Cut(kv, "="); ok {
-			overrides[k] = kv
-		}
-	}
-
-	// Start with parent env, replacing any keys present in overrides.
-	parent := os.Environ()
-	merged := make([]string, 0, len(parent)+len(r.Env))
-	seen := make(map[string]bool, len(overrides))
-	for _, kv := range parent {
-		k, _, _ := strings.Cut(kv, "=")
-		if override, ok := overrides[k]; ok {
-			merged = append(merged, override)
-			seen[k] = true
-		} else {
-			merged = append(merged, kv)
-		}
-	}
-
-	// Append any override keys that weren't in the parent env.
-	for k, kv := range overrides {
-		if !seen[k] {
-			merged = append(merged, kv)
-		}
-	}
-
-	return merged
-}
-
 // echo prints the command line if verbose or dry-run and returns true if dry-run.
 // Callers should return early when echo returns true.
 func (r *Runner) echo(prefix string, args []string) bool {
@@ -87,86 +43,4 @@ func (r *Runner) echo(prefix string, args []string) bool {
 		fmt.Fprintln(r.Stdout)
 	}
 	return r.DryRun
-}
-
-// Run executes a command and streams its output.
-func (r *Runner) Run(ctx context.Context, name string, args ...string) error {
-	if r.echo(name, args) {
-		return nil
-	}
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = r.environ()
-	cmd.Stdout = r.Stdout
-	cmd.Stderr = r.Stderr
-	return cmd.Run()
-}
-
-// RunQuiet executes a command, suppressing stdout unless Verbose is set.
-// Stderr is always shown. Use this for commands whose stdout contains
-// sensitive data (e.g. AWS account IDs, tokens) that should not be
-// printed in normal mode.
-func (r *Runner) RunQuiet(ctx context.Context, name string, args ...string) error {
-	if r.echo(name, args) {
-		return nil
-	}
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = r.environ()
-	if r.Verbose {
-		cmd.Stdout = r.Stdout
-	}
-	cmd.Stderr = r.Stderr
-	return cmd.Run()
-}
-
-// RunQuietWithStdin executes a command with the given reader piped to stdin,
-// suppressing stdout unless Verbose is set. Stderr is always shown.
-func (r *Runner) RunQuietWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) error {
-	if r.echo(name, args) {
-		return nil
-	}
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = r.environ()
-	cmd.Stdin = stdin
-	if r.Verbose {
-		cmd.Stdout = r.Stdout
-	}
-	cmd.Stderr = r.Stderr
-	return cmd.Run()
-}
-
-// RunOutput executes a command and returns its stdout as bytes instead of streaming.
-func (r *Runner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
-	if r.echo(name, args) {
-		return []byte("(dry-run)"), nil
-	}
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = r.environ()
-	cmd.Stderr = r.Stderr
-	return cmd.Output()
-}
-
-// RunWithStdin executes a command with the given reader piped to stdin.
-func (r *Runner) RunWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) error {
-	if r.echo(name, args) {
-		return nil
-	}
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Env = r.environ()
-	cmd.Stdin = stdin
-	cmd.Stdout = r.Stdout
-	cmd.Stderr = r.Stderr
-	return cmd.Run()
-}
-
-// RunInDir executes a command in a specific directory.
-func (r *Runner) RunInDir(ctx context.Context, dir, name string, args ...string) error {
-	if r.echo(fmt.Sprintf("cd %s && %s", dir, name), args) {
-		return nil
-	}
-	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = dir
-	cmd.Env = r.environ()
-	cmd.Stdout = r.Stdout
-	cmd.Stderr = r.Stderr
-	return cmd.Run()
 }

--- a/internal/runner/runner_env.go
+++ b/internal/runner/runner_env.go
@@ -1,0 +1,47 @@
+package runner
+
+import (
+	"os"
+	"strings"
+)
+
+// environ returns the merged environment for child processes. If Env is empty,
+// it returns nil so exec.Cmd inherits the parent environment unchanged.
+// When Env is set, parent variables are included and any matching keys are
+// overridden by the Env values.
+func (r *Runner) environ() []string {
+	if len(r.Env) == 0 {
+		return nil
+	}
+
+	// Build a set of override keys for quick lookup.
+	overrides := make(map[string]string, len(r.Env))
+	for _, kv := range r.Env {
+		if k, _, ok := strings.Cut(kv, "="); ok {
+			overrides[k] = kv
+		}
+	}
+
+	// Start with parent env, replacing any keys present in overrides.
+	parent := os.Environ()
+	merged := make([]string, 0, len(parent)+len(r.Env))
+	seen := make(map[string]bool, len(overrides))
+	for _, kv := range parent {
+		k, _, _ := strings.Cut(kv, "=")
+		if override, ok := overrides[k]; ok {
+			merged = append(merged, override)
+			seen[k] = true
+		} else {
+			merged = append(merged, kv)
+		}
+	}
+
+	// Append any override keys that weren't in the parent env.
+	for k, kv := range overrides {
+		if !seen[k] {
+			merged = append(merged, kv)
+		}
+	}
+
+	return merged
+}

--- a/internal/runner/runner_exec.go
+++ b/internal/runner/runner_exec.go
@@ -1,0 +1,46 @@
+package runner
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os/exec"
+)
+
+// Run executes a command and streams its output.
+func (r *Runner) Run(ctx context.Context, name string, args ...string) error {
+	if r.echo(name, args) {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.environ()
+	cmd.Stdout = r.Stdout
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}
+
+// RunWithStdin executes a command with the given reader piped to stdin.
+func (r *Runner) RunWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) error {
+	if r.echo(name, args) {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.environ()
+	cmd.Stdin = stdin
+	cmd.Stdout = r.Stdout
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}
+
+// RunInDir executes a command in a specific directory.
+func (r *Runner) RunInDir(ctx context.Context, dir, name string, args ...string) error {
+	if r.echo(fmt.Sprintf("cd %s && %s", dir, name), args) {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = dir
+	cmd.Env = r.environ()
+	cmd.Stdout = r.Stdout
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}

--- a/internal/runner/runner_output.go
+++ b/internal/runner/runner_output.go
@@ -1,0 +1,51 @@
+package runner
+
+import (
+	"context"
+	"io"
+	"os/exec"
+)
+
+// RunOutput executes a command and returns its stdout as bytes instead of streaming.
+func (r *Runner) RunOutput(ctx context.Context, name string, args ...string) ([]byte, error) {
+	if r.echo(name, args) {
+		return []byte("(dry-run)"), nil
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.environ()
+	cmd.Stderr = r.Stderr
+	return cmd.Output()
+}
+
+// RunQuiet executes a command, suppressing stdout unless Verbose is set.
+// Stderr is always shown. Use this for commands whose stdout contains
+// sensitive data (e.g. AWS account IDs, tokens) that should not be
+// printed in normal mode.
+func (r *Runner) RunQuiet(ctx context.Context, name string, args ...string) error {
+	if r.echo(name, args) {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.environ()
+	if r.Verbose {
+		cmd.Stdout = r.Stdout
+	}
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}
+
+// RunQuietWithStdin executes a command with the given reader piped to stdin,
+// suppressing stdout unless Verbose is set. Stderr is always shown.
+func (r *Runner) RunQuietWithStdin(ctx context.Context, stdin io.Reader, name string, args ...string) error {
+	if r.echo(name, args) {
+		return nil
+	}
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Env = r.environ()
+	cmd.Stdin = stdin
+	if r.Verbose {
+		cmd.Stdout = r.Stdout
+	}
+	cmd.Stderr = r.Stderr
+	return cmd.Run()
+}


### PR DESCRIPTION
## Summary

- `runner.go` — `Runner` struct, `NewRunner`, `echo` (shared core)
- `runner_env.go` — `environ()` (env var merging logic)
- `runner_exec.go` — `Run`, `RunWithStdin`, `RunInDir` (streaming exec variants)
- `runner_output.go` — `RunOutput`, `RunQuiet`, `RunQuietWithStdin` (capture/suppress variants)

Mirrors the pre-existing test file split (`_env_test.go`, `_exec_test.go`, `_output_test.go`). No behavior or public API changes.

## Test plan

- [ ] `go build ./internal/runner/...` — clean
- [ ] `go test ./internal/runner/...` — all pass
- [ ] `golangci-lint run ./internal/runner/...` — 0 issues
- [ ] Pre-commit hook — all checks pass