### PR TITLE
refactor(ec2fleet): split deployer.go into focused domain files

### DIFF
--- a/internal/ec2fleet/deployer.go
+++ b/internal/ec2fleet/deployer.go
@@ -2,18 +2,14 @@ package ec2fleet
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
-	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
-	"github.com/devrecon/ludus/internal/awsutil"
 	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/glsession"
 	"github.com/devrecon/ludus/internal/runner"
@@ -80,117 +76,6 @@ func (d *Deployer) resourceTags() map[string]string {
 	})
 }
 
-// resolveBucket determines the S3 bucket name, creating it if needed.
-func (d *Deployer) resolveBucket(ctx context.Context) (string, error) {
-	bucket := d.opts.S3Bucket
-	if bucket != "" {
-		return bucket, nil
-	}
-
-	// Auto-derive bucket name from AWS account ID
-	identity, err := d.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if err != nil {
-		return "", fmt.Errorf("getting AWS account ID: %w", err)
-	}
-	accountID := aws.ToString(identity.Account)
-	bucket = fmt.Sprintf("ludus-builds-%s", accountID)
-
-	// Create bucket if it doesn't exist
-	_, err = d.s3Client.HeadBucket(ctx, &s3.HeadBucketInput{
-		Bucket: aws.String(bucket),
-	})
-	if err != nil {
-		fmt.Printf("Creating S3 bucket %s...\n", bucket)
-		createInput := &s3.CreateBucketInput{
-			Bucket: aws.String(bucket),
-		}
-		// us-east-1 doesn't use LocationConstraint
-		if d.opts.Region != "us-east-1" {
-			createInput.CreateBucketConfiguration = &s3types.CreateBucketConfiguration{
-				LocationConstraint: s3types.BucketLocationConstraint(d.opts.Region),
-			}
-		}
-		if _, err := d.s3Client.CreateBucket(ctx, createInput); err != nil {
-			return "", fmt.Errorf("creating S3 bucket: %w", err)
-		}
-
-		// Tag the bucket
-		tagSet := tags.ToS3Tags(d.resourceTags())
-		if len(tagSet) > 0 {
-			_, _ = d.s3Client.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
-				Bucket: aws.String(bucket),
-				Tagging: &s3types.Tagging{
-					TagSet: tagSet,
-				},
-			})
-		}
-	}
-
-	return bucket, nil
-}
-
-// ensureIAMRole creates the GameLift EC2 fleet IAM role if it doesn't exist.
-func (d *Deployer) ensureIAMRole(ctx context.Context) (string, error) {
-	getOut, err := d.iamClient.GetRole(ctx, &iam.GetRoleInput{
-		RoleName: aws.String(iamRoleName),
-	})
-	if err == nil {
-		return aws.ToString(getOut.Role.Arn), nil
-	}
-
-	assumeRolePolicy := `{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Principal": {"Service": "gamelift.amazonaws.com"},
-    "Action": "sts:AssumeRole"
-  }]
-}`
-
-	createOut, err := d.iamClient.CreateRole(ctx, &iam.CreateRoleInput{
-		RoleName:                 aws.String(iamRoleName),
-		AssumeRolePolicyDocument: aws.String(assumeRolePolicy),
-		Description:              aws.String("IAM role for Ludus GameLift EC2 fleet"),
-		Tags:                     tags.ToIAMTags(d.resourceTags()),
-	})
-	if err != nil {
-		return "", fmt.Errorf("creating IAM role: %w", err)
-	}
-
-	_, err = d.iamClient.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
-		RoleName:  aws.String(iamRoleName),
-		PolicyArn: aws.String(iamPolicyARN),
-	})
-	if err != nil {
-		return "", fmt.Errorf("attaching policy to role: %w", err)
-	}
-
-	// EC2 managed builds require S3 read access for GameLift to download
-	// the build archive. The GameLiftContainerFleetPolicy only covers
-	// container fleets, so we add an inline policy for S3.
-	s3Policy := `{
-  "Version": "2012-10-17",
-  "Statement": [{
-    "Effect": "Allow",
-    "Action": ["s3:GetObject", "s3:GetObjectVersion"],
-    "Resource": "arn:aws:s3:::ludus-builds-*/*"
-  }]
-}`
-	_, err = d.iamClient.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
-		RoleName:       aws.String(iamRoleName),
-		PolicyName:     aws.String("LudusS3BuildAccess"),
-		PolicyDocument: aws.String(s3Policy),
-	})
-	if err != nil {
-		return "", fmt.Errorf("adding S3 access policy: %w", err)
-	}
-
-	// Wait for IAM propagation
-	time.Sleep(10 * time.Second)
-
-	return aws.ToString(createOut.Role.Arn), nil
-}
-
 // CreateFleet creates a GameLift Managed EC2 fleet with the given build.
 func (d *Deployer) CreateFleet(ctx context.Context, buildID string) (*FleetStatus, error) {
 	roleARN, err := d.ensureIAMRole(ctx)
@@ -216,85 +101,6 @@ func (d *Deployer) CreateFleet(ctx context.Context, buildID string) (*FleetStatu
 	return result, nil
 }
 
-func (d *Deployer) createFleetInput(buildID, roleARN string) *gamelift.CreateFleetInput {
-	return &gamelift.CreateFleetInput{
-		Name:                 aws.String(d.opts.FleetName),
-		Description:          aws.String("Ludus dedicated server EC2 fleet"),
-		BuildId:              aws.String(buildID),
-		EC2InstanceType:      gltypes.EC2InstanceType(d.opts.InstanceType),
-		FleetType:            gltypes.FleetTypeOnDemand,
-		InstanceRoleArn:      aws.String(roleARN),
-		RuntimeConfiguration: d.runtimeConfiguration(),
-		EC2InboundPermissions: []gltypes.IpPermission{
-			{
-				FromPort: aws.Int32(int32(d.opts.ServerPort)),
-				ToPort:   aws.Int32(int32(d.opts.ServerPort)),
-				IpRange:  aws.String("0.0.0.0/0"),
-				Protocol: gltypes.IpProtocolUdp,
-			},
-		},
-		Tags: tags.ToGameLiftTags(d.resourceTags()),
-	}
-}
-
-func (d *Deployer) runtimeConfiguration() *gltypes.RuntimeConfiguration {
-	// The wrapper binary is at the root of the zip; game server details
-	// are configured in config.yaml. The wrapper accepts --port only.
-	launchPath := "/local/game/amazon-gamelift-servers-game-server-wrapper"
-	launchParams := fmt.Sprintf("--port %d", d.opts.ServerPort)
-
-	return &gltypes.RuntimeConfiguration{
-		ServerProcesses: []gltypes.ServerProcess{
-			{
-				LaunchPath:           aws.String(launchPath),
-				Parameters:           aws.String(launchParams),
-				ConcurrentExecutions: aws.Int32(1),
-			},
-		},
-	}
-}
-
-func (d *Deployer) waitForFleetActive(ctx context.Context, fleetID string, result *FleetStatus) error {
-	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
-		return d.pollFleetActiveStatus(ctx, fleetID, result)
-	})
-	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
-		return err
-	}
-	if errors.Is(err, awsutil.ErrPollTimeout) {
-		return fmt.Errorf("timed out waiting for fleet to become ACTIVE")
-	}
-	return nil
-}
-
-func (d *Deployer) pollFleetActiveStatus(ctx context.Context, fleetID string, result *FleetStatus) (bool, error) {
-	desc, err := d.glClient.DescribeFleetAttributes(ctx, &gamelift.DescribeFleetAttributesInput{
-		FleetIds: []string{fleetID},
-	})
-	if err != nil {
-		return false, fmt.Errorf("polling fleet status: %w", err)
-	}
-	if len(desc.FleetAttributes) == 0 {
-		return false, fmt.Errorf("fleet %s disappeared during polling", fleetID)
-	}
-
-	status := desc.FleetAttributes[0].Status
-	result.Status = string(status)
-	fmt.Printf("  Fleet status: %s\n", status)
-
-	return fleetActivePollResult(status)
-}
-
-func fleetActivePollResult(status gltypes.FleetStatus) (bool, error) {
-	if status == gltypes.FleetStatusActive {
-		return true, nil
-	}
-	if status == gltypes.FleetStatusError {
-		return false, fmt.Errorf("fleet entered ERROR state")
-	}
-	return false, nil
-}
-
 // CreateGameSession creates a game session on the EC2 fleet.
 func (d *Deployer) CreateGameSession(ctx context.Context, fleetID string, maxPlayers int) (*deploy.SessionInfo, error) {
 	return glsession.Create(ctx, d.glClient, fleetID, "", maxPlayers)
@@ -307,7 +113,6 @@ func (d *Deployer) DescribeGameSession(ctx context.Context, sessionID string) (s
 
 // GetFleetStatus looks up the fleet by name via ListFleets/DescribeFleetAttributes.
 func (d *Deployer) GetFleetStatus(ctx context.Context) (*FleetStatus, error) {
-	// List fleets with the build
 	listOut, err := d.glClient.ListFleets(ctx, &gamelift.ListFleetsInput{})
 	if err != nil {
 		return nil, fmt.Errorf("listing fleets: %w", err)
@@ -317,7 +122,6 @@ func (d *Deployer) GetFleetStatus(ctx context.Context) (*FleetStatus, error) {
 		return nil, fmt.Errorf("no fleets found")
 	}
 
-	// Describe to find our fleet by name
 	descOut, err := d.glClient.DescribeFleetAttributes(ctx, &gamelift.DescribeFleetAttributesInput{
 		FleetIds: listOut.FleetIds,
 	})
@@ -350,117 +154,5 @@ func (d *Deployer) Destroy(ctx context.Context, fleetID, buildID, s3Bucket, s3Ke
 		fmt.Printf("Warning: failed to delete IAM role: %v\n", err)
 	}
 
-	return nil
-}
-
-// deleteFleetResource deletes the fleet and polls until it is gone.
-func (d *Deployer) deleteFleetResource(ctx context.Context, fleetID string) error {
-	if fleetID == "" {
-		return nil
-	}
-
-	fmt.Println("Deleting fleet...")
-	_, err := d.glClient.DeleteFleet(ctx, &gamelift.DeleteFleetInput{
-		FleetId: aws.String(fleetID),
-	})
-	if err != nil && !awsutil.IsNotFound(err) {
-		return fmt.Errorf("deleting fleet: %w", err)
-	}
-
-	if err := d.waitForFleetDeletion(ctx, fleetID); err != nil {
-		return err
-	}
-	fmt.Println("Fleet deleted.")
-	return nil
-}
-
-// waitForFleetDeletion polls until the fleet no longer exists.
-func (d *Deployer) waitForFleetDeletion(ctx context.Context, fleetID string) error {
-	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
-		desc, err := d.glClient.DescribeFleetAttributes(ctx, &gamelift.DescribeFleetAttributesInput{
-			FleetIds: []string{fleetID},
-		})
-		if err != nil {
-			if awsutil.IsNotFound(err) {
-				return true, nil
-			}
-			return false, fmt.Errorf("polling fleet deletion: %w", err)
-		}
-		if len(desc.FleetAttributes) == 0 {
-			return true, nil
-		}
-		fmt.Println("  Waiting for fleet deletion...")
-		return false, nil
-	})
-	if errors.Is(err, awsutil.ErrPollTimeout) {
-		return nil
-	}
-	return err
-}
-
-// deleteBuildResource deletes the GameLift build, logging a warning on failure.
-func (d *Deployer) deleteBuildResource(ctx context.Context, buildID string) {
-	if buildID == "" {
-		return
-	}
-
-	fmt.Println("Deleting build...")
-	_, err := d.glClient.DeleteBuild(ctx, &gamelift.DeleteBuildInput{
-		BuildId: aws.String(buildID),
-	})
-	if err != nil && !awsutil.IsNotFound(err) {
-		fmt.Printf("Warning: failed to delete build: %v\n", err)
-		return
-	}
-	fmt.Println("Build deleted.")
-}
-
-// deleteS3Object removes the server build archive from S3.
-func (d *Deployer) deleteS3Object(ctx context.Context, bucket, key string) {
-	if bucket == "" || key == "" {
-		return
-	}
-
-	fmt.Printf("Deleting S3 object s3://%s/%s...\n", bucket, key)
-	_, err := d.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
-		Bucket: aws.String(bucket),
-		Key:    aws.String(key),
-	})
-	if err != nil {
-		fmt.Printf("Warning: failed to delete S3 object: %v\n", err)
-		return
-	}
-	fmt.Println("S3 object deleted.")
-}
-
-func (d *Deployer) deleteIAMRole(ctx context.Context) error {
-	fmt.Println("Deleting IAM role...")
-
-	_, err := d.iamClient.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{
-		RoleName:  aws.String(iamRoleName),
-		PolicyArn: aws.String(iamPolicyARN),
-	})
-	if err != nil && !awsutil.IsNotFound(err) {
-		return fmt.Errorf("detaching policy from role: %w", err)
-	}
-
-	// Remove S3 access inline policy
-	_, _ = d.iamClient.DeleteRolePolicy(ctx, &iam.DeleteRolePolicyInput{
-		RoleName:   aws.String(iamRoleName),
-		PolicyName: aws.String("LudusS3BuildAccess"),
-	})
-
-	_, err = d.iamClient.DeleteRole(ctx, &iam.DeleteRoleInput{
-		RoleName: aws.String(iamRoleName),
-	})
-	if err != nil {
-		if awsutil.IsNotFound(err) {
-			fmt.Println("IAM role not found, skipping.")
-			return nil
-		}
-		return fmt.Errorf("deleting IAM role: %w", err)
-	}
-
-	fmt.Println("IAM role deleted.")
 	return nil
 }

--- a/internal/ec2fleet/deployer_fleet.go
+++ b/internal/ec2fleet/deployer_fleet.go
@@ -1,0 +1,154 @@
+package ec2fleet
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/gamelift"
+	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+	"github.com/devrecon/ludus/internal/awsutil"
+	"github.com/devrecon/ludus/internal/tags"
+)
+
+func (d *Deployer) createFleetInput(buildID, roleARN string) *gamelift.CreateFleetInput {
+	return &gamelift.CreateFleetInput{
+		Name:                 aws.String(d.opts.FleetName),
+		Description:          aws.String("Ludus dedicated server EC2 fleet"),
+		BuildId:              aws.String(buildID),
+		EC2InstanceType:      gltypes.EC2InstanceType(d.opts.InstanceType),
+		FleetType:            gltypes.FleetTypeOnDemand,
+		InstanceRoleArn:      aws.String(roleARN),
+		RuntimeConfiguration: d.runtimeConfiguration(),
+		EC2InboundPermissions: []gltypes.IpPermission{
+			{
+				FromPort: aws.Int32(int32(d.opts.ServerPort)),
+				ToPort:   aws.Int32(int32(d.opts.ServerPort)),
+				IpRange:  aws.String("0.0.0.0/0"),
+				Protocol: gltypes.IpProtocolUdp,
+			},
+		},
+		Tags: tags.ToGameLiftTags(d.resourceTags()),
+	}
+}
+
+func (d *Deployer) runtimeConfiguration() *gltypes.RuntimeConfiguration {
+	// The wrapper binary is at the root of the zip; game server details
+	// are configured in config.yaml. The wrapper accepts --port only.
+	launchPath := "/local/game/amazon-gamelift-servers-game-server-wrapper"
+	launchParams := fmt.Sprintf("--port %d", d.opts.ServerPort)
+
+	return &gltypes.RuntimeConfiguration{
+		ServerProcesses: []gltypes.ServerProcess{
+			{
+				LaunchPath:           aws.String(launchPath),
+				Parameters:           aws.String(launchParams),
+				ConcurrentExecutions: aws.Int32(1),
+			},
+		},
+	}
+}
+
+func (d *Deployer) waitForFleetActive(ctx context.Context, fleetID string, result *FleetStatus) error {
+	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
+		return d.pollFleetActiveStatus(ctx, fleetID, result)
+	})
+	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
+		return err
+	}
+	if errors.Is(err, awsutil.ErrPollTimeout) {
+		return fmt.Errorf("timed out waiting for fleet to become ACTIVE")
+	}
+	return nil
+}
+
+func (d *Deployer) pollFleetActiveStatus(ctx context.Context, fleetID string, result *FleetStatus) (bool, error) {
+	desc, err := d.glClient.DescribeFleetAttributes(ctx, &gamelift.DescribeFleetAttributesInput{
+		FleetIds: []string{fleetID},
+	})
+	if err != nil {
+		return false, fmt.Errorf("polling fleet status: %w", err)
+	}
+	if len(desc.FleetAttributes) == 0 {
+		return false, fmt.Errorf("fleet %s disappeared during polling", fleetID)
+	}
+
+	status := desc.FleetAttributes[0].Status
+	result.Status = string(status)
+	fmt.Printf("  Fleet status: %s\n", status)
+
+	return fleetActivePollResult(status)
+}
+
+func fleetActivePollResult(status gltypes.FleetStatus) (bool, error) {
+	if status == gltypes.FleetStatusActive {
+		return true, nil
+	}
+	if status == gltypes.FleetStatusError {
+		return false, fmt.Errorf("fleet entered ERROR state")
+	}
+	return false, nil
+}
+
+// deleteFleetResource deletes the fleet and polls until it is gone.
+func (d *Deployer) deleteFleetResource(ctx context.Context, fleetID string) error {
+	if fleetID == "" {
+		return nil
+	}
+
+	fmt.Println("Deleting fleet...")
+	_, err := d.glClient.DeleteFleet(ctx, &gamelift.DeleteFleetInput{
+		FleetId: aws.String(fleetID),
+	})
+	if err != nil && !awsutil.IsNotFound(err) {
+		return fmt.Errorf("deleting fleet: %w", err)
+	}
+
+	if err := d.waitForFleetDeletion(ctx, fleetID); err != nil {
+		return err
+	}
+	fmt.Println("Fleet deleted.")
+	return nil
+}
+
+// waitForFleetDeletion polls until the fleet no longer exists.
+func (d *Deployer) waitForFleetDeletion(ctx context.Context, fleetID string) error {
+	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
+		desc, err := d.glClient.DescribeFleetAttributes(ctx, &gamelift.DescribeFleetAttributesInput{
+			FleetIds: []string{fleetID},
+		})
+		if err != nil {
+			if awsutil.IsNotFound(err) {
+				return true, nil
+			}
+			return false, fmt.Errorf("polling fleet deletion: %w", err)
+		}
+		if len(desc.FleetAttributes) == 0 {
+			return true, nil
+		}
+		fmt.Println("  Waiting for fleet deletion...")
+		return false, nil
+	})
+	if errors.Is(err, awsutil.ErrPollTimeout) {
+		return nil
+	}
+	return err
+}
+
+// deleteBuildResource deletes the GameLift build, logging a warning on failure.
+func (d *Deployer) deleteBuildResource(ctx context.Context, buildID string) {
+	if buildID == "" {
+		return
+	}
+
+	fmt.Println("Deleting build...")
+	_, err := d.glClient.DeleteBuild(ctx, &gamelift.DeleteBuildInput{
+		BuildId: aws.String(buildID),
+	})
+	if err != nil && !awsutil.IsNotFound(err) {
+		fmt.Printf("Warning: failed to delete build: %v\n", err)
+		return
+	}
+	fmt.Println("Build deleted.")
+}

--- a/internal/ec2fleet/deployer_iam.go
+++ b/internal/ec2fleet/deployer_iam.go
@@ -1,0 +1,106 @@
+package ec2fleet
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/devrecon/ludus/internal/awsutil"
+	"github.com/devrecon/ludus/internal/tags"
+)
+
+// ensureIAMRole creates the GameLift EC2 fleet IAM role if it doesn't exist.
+func (d *Deployer) ensureIAMRole(ctx context.Context) (string, error) {
+	getOut, err := d.iamClient.GetRole(ctx, &iam.GetRoleInput{
+		RoleName: aws.String(iamRoleName),
+	})
+	if err == nil {
+		return aws.ToString(getOut.Role.Arn), nil
+	}
+
+	assumeRolePolicy := `{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {"Service": "gamelift.amazonaws.com"},
+    "Action": "sts:AssumeRole"
+  }]
+}`
+
+	createOut, err := d.iamClient.CreateRole(ctx, &iam.CreateRoleInput{
+		RoleName:                 aws.String(iamRoleName),
+		AssumeRolePolicyDocument: aws.String(assumeRolePolicy),
+		Description:              aws.String("IAM role for Ludus GameLift EC2 fleet"),
+		Tags:                     tags.ToIAMTags(d.resourceTags()),
+	})
+	if err != nil {
+		return "", fmt.Errorf("creating IAM role: %w", err)
+	}
+
+	_, err = d.iamClient.AttachRolePolicy(ctx, &iam.AttachRolePolicyInput{
+		RoleName:  aws.String(iamRoleName),
+		PolicyArn: aws.String(iamPolicyARN),
+	})
+	if err != nil {
+		return "", fmt.Errorf("attaching policy to role: %w", err)
+	}
+
+	// EC2 managed builds require S3 read access for GameLift to download
+	// the build archive. The GameLiftContainerFleetPolicy only covers
+	// container fleets, so we add an inline policy for S3.
+	s3Policy := `{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Action": ["s3:GetObject", "s3:GetObjectVersion"],
+    "Resource": "arn:aws:s3:::ludus-builds-*/*"
+  }]
+}`
+	_, err = d.iamClient.PutRolePolicy(ctx, &iam.PutRolePolicyInput{
+		RoleName:       aws.String(iamRoleName),
+		PolicyName:     aws.String("LudusS3BuildAccess"),
+		PolicyDocument: aws.String(s3Policy),
+	})
+	if err != nil {
+		return "", fmt.Errorf("adding S3 access policy: %w", err)
+	}
+
+	// Wait for IAM propagation
+	time.Sleep(10 * time.Second)
+
+	return aws.ToString(createOut.Role.Arn), nil
+}
+
+func (d *Deployer) deleteIAMRole(ctx context.Context) error {
+	fmt.Println("Deleting IAM role...")
+
+	_, err := d.iamClient.DetachRolePolicy(ctx, &iam.DetachRolePolicyInput{
+		RoleName:  aws.String(iamRoleName),
+		PolicyArn: aws.String(iamPolicyARN),
+	})
+	if err != nil && !awsutil.IsNotFound(err) {
+		return fmt.Errorf("detaching policy from role: %w", err)
+	}
+
+	// Remove S3 access inline policy
+	_, _ = d.iamClient.DeleteRolePolicy(ctx, &iam.DeleteRolePolicyInput{
+		RoleName:   aws.String(iamRoleName),
+		PolicyName: aws.String("LudusS3BuildAccess"),
+	})
+
+	_, err = d.iamClient.DeleteRole(ctx, &iam.DeleteRoleInput{
+		RoleName: aws.String(iamRoleName),
+	})
+	if err != nil {
+		if awsutil.IsNotFound(err) {
+			fmt.Println("IAM role not found, skipping.")
+			return nil
+		}
+		return fmt.Errorf("deleting IAM role: %w", err)
+	}
+
+	fmt.Println("IAM role deleted.")
+	return nil
+}

--- a/internal/ec2fleet/deployer_s3.go
+++ b/internal/ec2fleet/deployer_s3.go
@@ -1,0 +1,79 @@
+package ec2fleet
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/devrecon/ludus/internal/tags"
+)
+
+// resolveBucket determines the S3 bucket name, creating it if needed.
+func (d *Deployer) resolveBucket(ctx context.Context) (string, error) {
+	bucket := d.opts.S3Bucket
+	if bucket != "" {
+		return bucket, nil
+	}
+
+	// Auto-derive bucket name from AWS account ID
+	identity, err := d.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", fmt.Errorf("getting AWS account ID: %w", err)
+	}
+	accountID := aws.ToString(identity.Account)
+	bucket = fmt.Sprintf("ludus-builds-%s", accountID)
+
+	// Create bucket if it doesn't exist
+	_, err = d.s3Client.HeadBucket(ctx, &s3.HeadBucketInput{
+		Bucket: aws.String(bucket),
+	})
+	if err != nil {
+		fmt.Printf("Creating S3 bucket %s...\n", bucket)
+		createInput := &s3.CreateBucketInput{
+			Bucket: aws.String(bucket),
+		}
+		// us-east-1 doesn't use LocationConstraint
+		if d.opts.Region != "us-east-1" {
+			createInput.CreateBucketConfiguration = &s3types.CreateBucketConfiguration{
+				LocationConstraint: s3types.BucketLocationConstraint(d.opts.Region),
+			}
+		}
+		if _, err := d.s3Client.CreateBucket(ctx, createInput); err != nil {
+			return "", fmt.Errorf("creating S3 bucket: %w", err)
+		}
+
+		// Tag the bucket
+		tagSet := tags.ToS3Tags(d.resourceTags())
+		if len(tagSet) > 0 {
+			_, _ = d.s3Client.PutBucketTagging(ctx, &s3.PutBucketTaggingInput{
+				Bucket: aws.String(bucket),
+				Tagging: &s3types.Tagging{
+					TagSet: tagSet,
+				},
+			})
+		}
+	}
+
+	return bucket, nil
+}
+
+// deleteS3Object removes the server build archive from S3.
+func (d *Deployer) deleteS3Object(ctx context.Context, bucket, key string) {
+	if bucket == "" || key == "" {
+		return
+	}
+
+	fmt.Printf("Deleting S3 object s3://%s/%s...\n", bucket, key)
+	_, err := d.s3Client.DeleteObject(ctx, &s3.DeleteObjectInput{
+		Bucket: aws.String(bucket),
+		Key:    aws.String(key),
+	})
+	if err != nil {
+		fmt.Printf("Warning: failed to delete S3 object: %v\n", err)
+		return
+	}
+	fmt.Println("S3 object deleted.")
+}


### PR DESCRIPTION
## Summary

- Splits `internal/ec2fleet/deployer.go` (~467 lines) into four focused files, mirroring the `internal/gamelift` split pattern
- No public API or behavior changes; `build.go` and `adapter.go` are untouched

| File | Responsibility |
|------|---------------|
| `deployer.go` | Struct, constructor, constants, `resourceTags`, orchestration (`CreateFleet`, `Destroy`, `GetFleetStatus`, sessions) |
| `deployer_fleet.go` | Fleet lifecycle: `createFleetInput`, `runtimeConfiguration`, `waitForFleetActive`, poll helpers, `deleteFleetResource`, `deleteBuildResource` |
| `deployer_iam.go` | `ensureIAMRole`, `deleteIAMRole` |
| `deployer_s3.go` | `resolveBucket`, `deleteS3Object` |

## Test plan

- [ ] `go build ./internal/ec2fleet/...` — clean
- [ ] `golangci-lint run ./internal/ec2fleet/...` — 0 issues
- [ ] `go test ./...` — all pass
- [ ] Pre-commit hook — all checks passed