### PR TITLE
refactor(stack): split deployer.go into focused domain files

### DIFF
--- a/internal/stack/deployer.go
+++ b/internal/stack/deployer.go
@@ -2,25 +2,16 @@ package stack
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
 	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
 
-	"github.com/devrecon/ludus/internal/awsutil"
 	"github.com/devrecon/ludus/internal/deploy"
 	"github.com/devrecon/ludus/internal/glsession"
 	"github.com/devrecon/ludus/internal/tags"
-)
-
-const (
-	pollInterval = 15 * time.Second
-	maxPollWait  = 30 * time.Minute
 )
 
 // StackOptions configures a CloudFormation stack deployment.
@@ -94,83 +85,12 @@ func (d *StackDeployer) Deploy(ctx context.Context) (*StackResult, error) {
 		{ParameterKey: aws.String("InstanceType"), ParameterValue: aws.String(d.opts.InstanceType)},
 	}
 
-	// Check if stack already exists
 	existing, err := d.describeStack(ctx)
 	if err == nil && existing != nil {
 		return d.updateStack(ctx, templateBody, params, stackTags)
 	}
 
 	return d.createStack(ctx, templateBody, params, stackTags)
-}
-
-func (d *StackDeployer) createStack(ctx context.Context, templateBody string, params []cftypes.Parameter, stackTags []cftypes.Tag) (*StackResult, error) {
-	fmt.Printf("Creating CloudFormation stack %q...\n", d.opts.StackName)
-
-	out, err := d.cfnClient.CreateStack(ctx, &cloudformation.CreateStackInput{
-		StackName:    aws.String(d.opts.StackName),
-		TemplateBody: aws.String(templateBody),
-		Parameters:   params,
-		Tags:         stackTags,
-		Capabilities: []cftypes.Capability{cftypes.CapabilityCapabilityNamedIam},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("creating stack: %w", err)
-	}
-
-	result := &StackResult{
-		StackName: d.opts.StackName,
-		StackID:   aws.ToString(out.StackId),
-	}
-
-	// Poll until complete
-	status, err := d.pollStack(ctx, "CREATE_COMPLETE", "CREATE_FAILED", "ROLLBACK_COMPLETE")
-	if err != nil {
-		result.Status = status
-		return result, err
-	}
-
-	result.Status = status
-	result.FleetID = d.readFleetIDFromOutputs(ctx)
-	return result, nil
-}
-
-func (d *StackDeployer) updateStack(ctx context.Context, templateBody string, params []cftypes.Parameter, stackTags []cftypes.Tag) (*StackResult, error) {
-	fmt.Printf("Updating CloudFormation stack %q...\n", d.opts.StackName)
-
-	_, err := d.cfnClient.UpdateStack(ctx, &cloudformation.UpdateStackInput{
-		StackName:    aws.String(d.opts.StackName),
-		TemplateBody: aws.String(templateBody),
-		Parameters:   params,
-		Tags:         stackTags,
-		Capabilities: []cftypes.Capability{cftypes.CapabilityCapabilityNamedIam},
-	})
-	if err != nil {
-		// "No updates are to be performed" is not an error
-		if strings.Contains(err.Error(), "No updates are to be performed") {
-			fmt.Println("Stack is already up to date.")
-			status := d.readStackStatus(ctx)
-			return &StackResult{
-				StackName: d.opts.StackName,
-				Status:    status,
-				FleetID:   d.readFleetIDFromOutputs(ctx),
-			}, nil
-		}
-		return nil, fmt.Errorf("updating stack: %w", err)
-	}
-
-	result := &StackResult{
-		StackName: d.opts.StackName,
-	}
-
-	status, err := d.pollStack(ctx, "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE", "UPDATE_FAILED")
-	if err != nil {
-		result.Status = status
-		return result, err
-	}
-
-	result.Status = status
-	result.FleetID = d.readFleetIDFromOutputs(ctx)
-	return result, nil
 }
 
 // Status returns the current status of the CloudFormation stack.
@@ -203,59 +123,6 @@ func (d *StackDeployer) Destroy(ctx context.Context) error {
 	return d.waitForStackDeletion(ctx)
 }
 
-func (d *StackDeployer) deleteStack(ctx context.Context) error {
-	_, err := d.cfnClient.DeleteStack(ctx, &cloudformation.DeleteStackInput{
-		StackName: aws.String(d.opts.StackName),
-	})
-	if err == nil {
-		return nil
-	}
-	if isStackNotFound(err) {
-		fmt.Println("Stack not found, skipping.")
-		return nil
-	}
-	return fmt.Errorf("deleting stack: %w", err)
-}
-
-func (d *StackDeployer) waitForStackDeletion(ctx context.Context) error {
-	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
-		return d.pollStackDeletion(ctx)
-	})
-	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
-		return err
-	}
-	if errors.Is(err, awsutil.ErrPollTimeout) {
-		return fmt.Errorf("timed out waiting for stack deletion")
-	}
-	return nil
-}
-
-func (d *StackDeployer) pollStackDeletion(ctx context.Context) (bool, error) {
-	stack, err := d.describeStack(ctx)
-	if err != nil {
-		if isStackNotFound(err) {
-			fmt.Println("Stack deleted.")
-			return true, nil
-		}
-		return false, fmt.Errorf("polling stack deletion: %w", err)
-	}
-
-	status := string(stack.StackStatus)
-	fmt.Printf("  Stack status: %s\n", status)
-	return stackDeletionPollResult(status, aws.ToString(stack.StackStatusReason))
-}
-
-func stackDeletionPollResult(status, reason string) (bool, error) {
-	if status == "DELETE_COMPLETE" {
-		fmt.Println("Stack deleted.")
-		return true, nil
-	}
-	if status == "DELETE_FAILED" {
-		return false, fmt.Errorf("stack deletion failed: %s", reason)
-	}
-	return false, nil
-}
-
 // GetFleetID reads the FleetId output from the stack.
 func (d *StackDeployer) GetFleetID(ctx context.Context) (string, error) {
 	status, err := d.Status(ctx)
@@ -283,82 +150,4 @@ func (d *StackDeployer) stackResourceTags() map[string]string {
 	return tags.Merge(d.opts.Tags, map[string]string{
 		"ludus:fleet-name": d.opts.FleetName,
 	})
-}
-
-func (d *StackDeployer) describeStack(ctx context.Context) (*cftypes.Stack, error) {
-	out, err := d.cfnClient.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
-		StackName: aws.String(d.opts.StackName),
-	})
-	if err != nil {
-		return nil, err
-	}
-	if len(out.Stacks) == 0 {
-		return nil, fmt.Errorf("stack %q not found", d.opts.StackName)
-	}
-	return &out.Stacks[0], nil
-}
-
-func (d *StackDeployer) pollStack(ctx context.Context, successStatus, failStatus, rollbackStatus string) (string, error) {
-	deadline := time.Now().Add(maxPollWait)
-	for time.Now().Before(deadline) {
-		status, err := d.pollStackStatus(ctx, successStatus, failStatus, rollbackStatus)
-		if err != nil {
-			return status, err
-		}
-		if status == successStatus {
-			return status, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-time.After(pollInterval):
-		}
-	}
-
-	return "", fmt.Errorf("timed out waiting for stack to reach %s", successStatus)
-}
-
-func (d *StackDeployer) pollStackStatus(ctx context.Context, successStatus, failStatus, rollbackStatus string) (string, error) {
-	stack, err := d.describeStack(ctx)
-	if err != nil {
-		return "", fmt.Errorf("polling stack status: %w", err)
-	}
-
-	status := string(stack.StackStatus)
-	fmt.Printf("  Stack status: %s\n", status)
-	if status == successStatus {
-		return status, nil
-	}
-	if status == failStatus || status == rollbackStatus {
-		reason := aws.ToString(stack.StackStatusReason)
-		return status, fmt.Errorf("stack operation failed (%s): %s", status, reason)
-	}
-	return status, nil
-}
-
-func (d *StackDeployer) readFleetIDFromOutputs(ctx context.Context) string {
-	status, err := d.Status(ctx)
-	if err != nil {
-		return ""
-	}
-	return status.FleetID
-}
-
-func (d *StackDeployer) readStackStatus(ctx context.Context) string {
-	stack, err := d.describeStack(ctx)
-	if err != nil {
-		return "UNKNOWN"
-	}
-	return string(stack.StackStatus)
-}
-
-func isStackNotFound(err error) bool {
-	if err == nil {
-		return false
-	}
-	msg := err.Error()
-	return strings.Contains(msg, "does not exist") ||
-		strings.Contains(msg, "NotFoundException") ||
-		strings.Contains(msg, "NotFound")
 }

--- a/internal/stack/deployer_helpers.go
+++ b/internal/stack/deployer_helpers.go
@@ -1,0 +1,67 @@
+package stack
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+)
+
+const (
+	pollInterval = 15 * time.Second
+	maxPollWait  = 30 * time.Minute
+)
+
+func (d *StackDeployer) describeStack(ctx context.Context) (*cftypes.Stack, error) {
+	out, err := d.cfnClient.DescribeStacks(ctx, &cloudformation.DescribeStacksInput{
+		StackName: aws.String(d.opts.StackName),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if len(out.Stacks) == 0 {
+		return nil, fmt.Errorf("stack %q not found", d.opts.StackName)
+	}
+	return &out.Stacks[0], nil
+}
+
+func (d *StackDeployer) readFleetIDFromOutputs(ctx context.Context) string {
+	status, err := d.Status(ctx)
+	if err != nil {
+		return ""
+	}
+	return status.FleetID
+}
+
+func (d *StackDeployer) readStackStatus(ctx context.Context) string {
+	stack, err := d.describeStack(ctx)
+	if err != nil {
+		return "UNKNOWN"
+	}
+	return string(stack.StackStatus)
+}
+
+func isStackNotFound(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "NotFoundException") ||
+		strings.Contains(msg, "NotFound")
+}
+
+func stackDeletionPollResult(status, reason string) (bool, error) {
+	if status == "DELETE_COMPLETE" {
+		fmt.Println("Stack deleted.")
+		return true, nil
+	}
+	if status == "DELETE_FAILED" {
+		return false, fmt.Errorf("stack deletion failed: %s", reason)
+	}
+	return false, nil
+}

--- a/internal/stack/deployer_lifecycle.go
+++ b/internal/stack/deployer_lifecycle.go
@@ -1,0 +1,164 @@
+package stack
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
+	cftypes "github.com/aws/aws-sdk-go-v2/service/cloudformation/types"
+
+	"github.com/devrecon/ludus/internal/awsutil"
+)
+
+func (d *StackDeployer) createStack(ctx context.Context, templateBody string, params []cftypes.Parameter, stackTags []cftypes.Tag) (*StackResult, error) {
+	fmt.Printf("Creating CloudFormation stack %q...\n", d.opts.StackName)
+
+	out, err := d.cfnClient.CreateStack(ctx, &cloudformation.CreateStackInput{
+		StackName:    aws.String(d.opts.StackName),
+		TemplateBody: aws.String(templateBody),
+		Parameters:   params,
+		Tags:         stackTags,
+		Capabilities: []cftypes.Capability{cftypes.CapabilityCapabilityNamedIam},
+	})
+	if err != nil {
+		return nil, fmt.Errorf("creating stack: %w", err)
+	}
+
+	result := &StackResult{
+		StackName: d.opts.StackName,
+		StackID:   aws.ToString(out.StackId),
+	}
+
+	status, err := d.pollStack(ctx, "CREATE_COMPLETE", "CREATE_FAILED", "ROLLBACK_COMPLETE")
+	if err != nil {
+		result.Status = status
+		return result, err
+	}
+
+	result.Status = status
+	result.FleetID = d.readFleetIDFromOutputs(ctx)
+	return result, nil
+}
+
+func (d *StackDeployer) updateStack(ctx context.Context, templateBody string, params []cftypes.Parameter, stackTags []cftypes.Tag) (*StackResult, error) {
+	fmt.Printf("Updating CloudFormation stack %q...\n", d.opts.StackName)
+
+	_, err := d.cfnClient.UpdateStack(ctx, &cloudformation.UpdateStackInput{
+		StackName:    aws.String(d.opts.StackName),
+		TemplateBody: aws.String(templateBody),
+		Parameters:   params,
+		Tags:         stackTags,
+		Capabilities: []cftypes.Capability{cftypes.CapabilityCapabilityNamedIam},
+	})
+	if err != nil {
+		if strings.Contains(err.Error(), "No updates are to be performed") {
+			fmt.Println("Stack is already up to date.")
+			status := d.readStackStatus(ctx)
+			return &StackResult{
+				StackName: d.opts.StackName,
+				Status:    status,
+				FleetID:   d.readFleetIDFromOutputs(ctx),
+			}, nil
+		}
+		return nil, fmt.Errorf("updating stack: %w", err)
+	}
+
+	result := &StackResult{
+		StackName: d.opts.StackName,
+	}
+
+	status, err := d.pollStack(ctx, "UPDATE_COMPLETE", "UPDATE_ROLLBACK_COMPLETE", "UPDATE_FAILED")
+	if err != nil {
+		result.Status = status
+		return result, err
+	}
+
+	result.Status = status
+	result.FleetID = d.readFleetIDFromOutputs(ctx)
+	return result, nil
+}
+
+func (d *StackDeployer) deleteStack(ctx context.Context) error {
+	_, err := d.cfnClient.DeleteStack(ctx, &cloudformation.DeleteStackInput{
+		StackName: aws.String(d.opts.StackName),
+	})
+	if err == nil {
+		return nil
+	}
+	if isStackNotFound(err) {
+		fmt.Println("Stack not found, skipping.")
+		return nil
+	}
+	return fmt.Errorf("deleting stack: %w", err)
+}
+
+func (d *StackDeployer) waitForStackDeletion(ctx context.Context) error {
+	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
+		return d.pollStackDeletion(ctx)
+	})
+	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
+		return err
+	}
+	if errors.Is(err, awsutil.ErrPollTimeout) {
+		return fmt.Errorf("timed out waiting for stack deletion")
+	}
+	return nil
+}
+
+func (d *StackDeployer) pollStackDeletion(ctx context.Context) (bool, error) {
+	stack, err := d.describeStack(ctx)
+	if err != nil {
+		if isStackNotFound(err) {
+			fmt.Println("Stack deleted.")
+			return true, nil
+		}
+		return false, fmt.Errorf("polling stack deletion: %w", err)
+	}
+
+	status := string(stack.StackStatus)
+	fmt.Printf("  Stack status: %s\n", status)
+	return stackDeletionPollResult(status, aws.ToString(stack.StackStatusReason))
+}
+
+func (d *StackDeployer) pollStack(ctx context.Context, successStatus, failStatus, rollbackStatus string) (string, error) {
+	deadline := time.Now().Add(maxPollWait)
+	for time.Now().Before(deadline) {
+		status, err := d.pollStackStatus(ctx, successStatus, failStatus, rollbackStatus)
+		if err != nil {
+			return status, err
+		}
+		if status == successStatus {
+			return status, nil
+		}
+
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+
+	return "", fmt.Errorf("timed out waiting for stack to reach %s", successStatus)
+}
+
+func (d *StackDeployer) pollStackStatus(ctx context.Context, successStatus, failStatus, rollbackStatus string) (string, error) {
+	stack, err := d.describeStack(ctx)
+	if err != nil {
+		return "", fmt.Errorf("polling stack status: %w", err)
+	}
+
+	status := string(stack.StackStatus)
+	fmt.Printf("  Stack status: %s\n", status)
+	if status == successStatus {
+		return status, nil
+	}
+	if status == failStatus || status == rollbackStatus {
+		reason := aws.ToString(stack.StackStatusReason)
+		return status, fmt.Errorf("stack operation failed (%s): %s", status, reason)
+	}
+	return status, nil
+}


### PR DESCRIPTION
## Summary

- `deployer.go` — public API only: `Deploy`, `Status`, `Destroy`, `GetFleetID`, `CreateGameSession`, `DescribeGameSession`, `stackResourceTags`, plus all type definitions and the constructor
- `deployer_lifecycle.go` — stack lifecycle operations: `createStack`, `updateStack`, `deleteStack`, `waitForStackDeletion`, and all polling functions (`pollStack`, `pollStackStatus`, `pollStackDeletion`)
- `deployer_helpers.go` — constants (`pollInterval`, `maxPollWait`), `describeStack`, `readFleetIDFromOutputs`, `readStackStatus`, `isStackNotFound`, `stackDeletionPollResult`

No public API or behavior changes. `template.go` and `adapter.go` untouched.

## Test plan

- [x] `go build ./internal/stack/...` — clean
- [x] `go test ./internal/stack/...` — pass
- [x] `golangci-lint run ./internal/stack/...` — 0 issues
- [x] `gocyclo -over 8 ./internal/stack/` — no violations
- [x] Pre-commit hook (full suite, 50 packages) — all pass