### PR TITLE
refactor(awsutil): add WrapTimeout, deduplicate poll error handling

### DIFF
--- a/internal/awsutil/poller.go
+++ b/internal/awsutil/poller.go
@@ -3,6 +3,7 @@ package awsutil
 import (
 	"context"
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -18,6 +19,16 @@ type PollOptions struct {
 // Poll calls fn until it returns done, an error, the context is canceled, or the timeout expires.
 func Poll(ctx context.Context, interval, timeout time.Duration, fn func() (bool, error)) error {
 	return PollWithOptions(ctx, PollOptions{Interval: interval, Timeout: timeout}, fn)
+}
+
+// WrapTimeout returns a formatted error if err is ErrPollTimeout, otherwise
+// returns err unchanged (including nil). Use after awsutil.Poll to convert
+// the generic timeout sentinel into a caller-specific message.
+func WrapTimeout(err error, operation string) error {
+	if errors.Is(err, ErrPollTimeout) {
+		return fmt.Errorf("timed out waiting for %s", operation)
+	}
+	return err
 }
 
 // PollWithOptions calls fn using the provided polling options.

--- a/internal/awsutil/poller_test.go
+++ b/internal/awsutil/poller_test.go
@@ -38,6 +38,51 @@ func TestPollWithOptionsTimeout(t *testing.T) {
 	}
 }
 
+func TestWrapTimeout(t *testing.T) {
+	tests := []struct {
+		name      string
+		err       error
+		operation string
+		wantMsg   string
+		wantNil   bool
+	}{
+		{
+			name:    "nil passes through",
+			err:     nil,
+			wantNil: true,
+		},
+		{
+			name:      "ErrPollTimeout becomes formatted message",
+			err:       ErrPollTimeout,
+			operation: "fleet to become ACTIVE",
+			wantMsg:   "timed out waiting for fleet to become ACTIVE",
+		},
+		{
+			name:    "other errors pass through unchanged",
+			err:     errors.New("some other error"),
+			wantMsg: "some other error",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := WrapTimeout(tt.err, tt.operation)
+			if tt.wantNil {
+				if got != nil {
+					t.Errorf("got %v, want nil", got)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatal("got nil, want error")
+			}
+			if got.Error() != tt.wantMsg {
+				t.Errorf("got %q, want %q", got.Error(), tt.wantMsg)
+			}
+		})
+	}
+}
+
 func TestPollWithOptionsContextCanceled(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()

--- a/internal/ec2fleet/deployer_fleet.go
+++ b/internal/ec2fleet/deployer_fleet.go
@@ -54,13 +54,7 @@ func (d *Deployer) waitForFleetActive(ctx context.Context, fleetID string, resul
 	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
 		return d.pollFleetActiveStatus(ctx, fleetID, result)
 	})
-	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
-		return err
-	}
-	if errors.Is(err, awsutil.ErrPollTimeout) {
-		return fmt.Errorf("timed out waiting for fleet to become ACTIVE")
-	}
-	return nil
+	return awsutil.WrapTimeout(err, "fleet to become ACTIVE")
 }
 
 func (d *Deployer) pollFleetActiveStatus(ctx context.Context, fleetID string, result *FleetStatus) (bool, error) {

--- a/internal/gamelift/deployer_container.go
+++ b/internal/gamelift/deployer_container.go
@@ -2,7 +2,6 @@ package gamelift
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -61,13 +60,7 @@ func (d *Deployer) waitForContainerGroupReady(ctx context.Context) error {
 		}
 		return false, nil
 	})
-	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
-		return err
-	}
-	if errors.Is(err, awsutil.ErrPollTimeout) {
-		return fmt.Errorf("timed out waiting for container group definition to become READY")
-	}
-	return nil
+	return awsutil.WrapTimeout(err, "container group definition to become READY")
 }
 
 func (d *Deployer) deleteContainerGroupDefinition(ctx context.Context) error {

--- a/internal/gamelift/deployer_fleet.go
+++ b/internal/gamelift/deployer_fleet.go
@@ -2,7 +2,6 @@ package gamelift
 
 import (
 	"context"
-	"errors"
 	"fmt"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -29,13 +28,7 @@ func (d *Deployer) waitForContainerFleetActive(ctx context.Context, fleetID stri
 		}
 		return false, nil
 	})
-	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
-		return err
-	}
-	if errors.Is(err, awsutil.ErrPollTimeout) {
-		return fmt.Errorf("timed out waiting for fleet to become ACTIVE")
-	}
-	return nil
+	return awsutil.WrapTimeout(err, "fleet to become ACTIVE")
 }
 
 // GetFleetStatus returns the current status of the deployed fleet.
@@ -105,11 +98,5 @@ func (d *Deployer) waitForContainerFleetDeletion(ctx context.Context, fleetID st
 		fmt.Println("  Waiting for fleet deletion...")
 		return false, nil
 	})
-	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
-		return err
-	}
-	if errors.Is(err, awsutil.ErrPollTimeout) {
-		return fmt.Errorf("timed out waiting for fleet deletion")
-	}
-	return nil
+	return awsutil.WrapTimeout(err, "fleet deletion")
 }

--- a/internal/stack/deployer_lifecycle.go
+++ b/internal/stack/deployer_lifecycle.go
@@ -2,10 +2,8 @@ package stack
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudformation"
@@ -100,13 +98,7 @@ func (d *StackDeployer) waitForStackDeletion(ctx context.Context) error {
 	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
 		return d.pollStackDeletion(ctx)
 	})
-	if err != nil && !errors.Is(err, awsutil.ErrPollTimeout) {
-		return err
-	}
-	if errors.Is(err, awsutil.ErrPollTimeout) {
-		return fmt.Errorf("timed out waiting for stack deletion")
-	}
-	return nil
+	return awsutil.WrapTimeout(err, "stack deletion")
 }
 
 func (d *StackDeployer) pollStackDeletion(ctx context.Context) (bool, error) {
@@ -125,24 +117,16 @@ func (d *StackDeployer) pollStackDeletion(ctx context.Context) (bool, error) {
 }
 
 func (d *StackDeployer) pollStack(ctx context.Context, successStatus, failStatus, rollbackStatus string) (string, error) {
-	deadline := time.Now().Add(maxPollWait)
-	for time.Now().Before(deadline) {
+	var lastStatus string
+	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
 		status, err := d.pollStackStatus(ctx, successStatus, failStatus, rollbackStatus)
+		lastStatus = status
 		if err != nil {
-			return status, err
+			return false, err
 		}
-		if status == successStatus {
-			return status, nil
-		}
-
-		select {
-		case <-ctx.Done():
-			return "", ctx.Err()
-		case <-time.After(pollInterval):
-		}
-	}
-
-	return "", fmt.Errorf("timed out waiting for stack to reach %s", successStatus)
+		return status == successStatus, nil
+	})
+	return lastStatus, awsutil.WrapTimeout(err, "stack to reach "+successStatus)
 }
 
 func (d *StackDeployer) pollStackStatus(ctx context.Context, successStatus, failStatus, rollbackStatus string) (string, error) {


### PR DESCRIPTION
## Summary

- Add `awsutil.WrapTimeout(err, operation)` to `internal/awsutil/poller.go` — converts `ErrPollTimeout` into a caller-specific message, passes all other errors (including nil) through unchanged
- Replace 5 duplicated two-liner `ErrPollTimeout` patterns across `gamelift`, `ec2fleet`, and `stack` deployers with single-line `WrapTimeout` calls
- Migrate `stack.pollStack` from a hand-rolled `time.After` deadline loop to `awsutil.Poll`, making it consistent with all other deployers; captures last status in closure to preserve the `(string, error)` return

Note: `ec2fleet.waitForFleetDeletion` intentionally treats `ErrPollTimeout` as success (timeout = fleet is gone) — left unchanged.

Note: `ec2fleet/build.go:createBuildZip` has a pre-existing `gocyclo` violation (complexity 9) outside the scope of this PR.

## Test plan

- [x] `go test ./internal/awsutil/... ./internal/gamelift/... ./internal/ec2fleet/... ./internal/stack/...` — pass
- [x] `golangci-lint run ./internal/...` — 0 issues
- [x] `gocyclo -over 8` — no new violations in changed files
- [x] Pre-commit hook (full suite, 50 packages) — all pass