### PR TITLE
refactor(cache): split cache.go into focused domain files

### DIFF
--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -5,19 +5,11 @@
 package cache
 
 import (
-	"crypto/sha256"
-	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"runtime"
-	"sort"
-	"strings"
 	"time"
-
-	"github.com/devrecon/ludus/internal/config"
 )
 
 const (
@@ -135,114 +127,4 @@ func RecordBuild(stage StageKey, hash string) {
 	}
 	c.Set(stage, hash, time.Now().UTC().Format(time.RFC3339))
 	_ = Save(c)
-}
-
-// hash computes a SHA-256 hex digest from a list of key-value strings.
-func hash(parts ...string) string {
-	h := sha256.New()
-	for _, p := range parts {
-		h.Write([]byte(p))
-		h.Write([]byte{0}) // separator
-	}
-	return hex.EncodeToString(h.Sum(nil))
-}
-
-// gitHEAD returns the git HEAD commit hash for the given directory.
-// Returns empty string if git is not available or the directory is not a repo.
-func gitHEAD(dir string) string {
-	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
-	out, err := cmd.Output()
-	if err != nil {
-		return ""
-	}
-	return strings.TrimSpace(string(out))
-}
-
-// fileKey returns "mtime:size" for a file, or empty string if stat fails.
-func fileKey(path string) string {
-	info, err := os.Stat(path)
-	if err != nil {
-		return ""
-	}
-	return fmt.Sprintf("%d:%d", info.ModTime().UnixNano(), info.Size())
-}
-
-// EngineKey computes the cache key for the engine build stage.
-func EngineKey(cfg *config.Config) string {
-	return hash(
-		gitHEAD(cfg.Engine.SourcePath),
-		cfg.Engine.Version,
-		fmt.Sprintf("%d", cfg.Engine.MaxJobs),
-		runtime.GOOS,
-		cfg.Engine.Backend,
-		cfg.Engine.DockerBaseImage,
-	)
-}
-
-// GameServerKey computes the cache key for the game server build stage.
-func GameServerKey(cfg *config.Config, engineHash string) string {
-	projectPath := cfg.Game.ProjectPath
-	if projectPath == "" && cfg.Game.ProjectName == "Lyra" {
-		projectPath = filepath.Join(cfg.Engine.SourcePath,
-			"Samples", "Games", "Lyra", "Lyra.uproject")
-	}
-
-	return hash(
-		engineHash,
-		fileKey(projectPath),
-		cfg.Game.ResolvedServerTarget(),
-		cfg.Game.ResolvedGameTarget(),
-		cfg.Game.ServerMap,
-		fmt.Sprintf("%v", cfg.Game.SkipCook),
-		cfg.Engine.Version,
-		cfg.Game.ResolvedArch(),
-	)
-}
-
-// GameClientKey computes the cache key for the game client build stage.
-func GameClientKey(cfg *config.Config, engineHash string, platform string) string {
-	projectPath := cfg.Game.ProjectPath
-	if projectPath == "" && cfg.Game.ProjectName == "Lyra" {
-		projectPath = filepath.Join(cfg.Engine.SourcePath,
-			"Samples", "Games", "Lyra", "Lyra.uproject")
-	}
-
-	return hash(
-		engineHash,
-		fileKey(projectPath),
-		cfg.Game.ResolvedClientTarget(),
-		platform,
-		fmt.Sprintf("%v", cfg.Game.SkipCook),
-		cfg.Engine.Version,
-		cfg.Game.ResolvedArch(),
-	)
-}
-
-// ContainerKey computes the cache key for the container build stage.
-// It hashes a manifest of filenames and sizes in the server build directory.
-func ContainerKey(cfg *config.Config, serverBuildDir string) string {
-	manifest := dirManifest(serverBuildDir)
-	return hash(
-		manifest,
-		cfg.Game.ProjectName,
-		cfg.Game.ResolvedServerTarget(),
-		fmt.Sprintf("%d", cfg.Container.ServerPort),
-		cfg.Container.Tag,
-	)
-}
-
-// dirManifest returns a deterministic string of "name:size" entries
-// for all files in a directory tree, sorted by path.
-func dirManifest(dir string) string {
-	var entries []string
-	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
-		if err != nil || info.IsDir() {
-			return nil
-		}
-		rel, _ := filepath.Rel(dir, path)
-		entries = append(entries, fmt.Sprintf("%s:%d", rel, info.Size()))
-		return nil
-	})
-	sort.Strings(entries)
-	return strings.Join(entries, "\n")
 }

--- a/internal/cache/cache_helpers.go
+++ b/internal/cache/cache_helpers.go
@@ -1,0 +1,46 @@
+package cache
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// gitHEAD returns the git HEAD commit hash for the given directory.
+// Returns empty string if git is not available or the directory is not a repo.
+func gitHEAD(dir string) string {
+	cmd := exec.Command("git", "-C", dir, "rev-parse", "HEAD")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// fileKey returns "mtime:size" for a file, or empty string if stat fails.
+func fileKey(path string) string {
+	info, err := os.Stat(path)
+	if err != nil {
+		return ""
+	}
+	return fmt.Sprintf("%d:%d", info.ModTime().UnixNano(), info.Size())
+}
+
+// dirManifest returns a deterministic string of "name:size" entries
+// for all files in a directory tree, sorted by path.
+func dirManifest(dir string) string {
+	var entries []string
+	_ = filepath.Walk(dir, func(path string, info os.FileInfo, err error) error {
+		if err != nil || info.IsDir() {
+			return nil
+		}
+		rel, _ := filepath.Rel(dir, path)
+		entries = append(entries, fmt.Sprintf("%s:%d", rel, info.Size()))
+		return nil
+	})
+	sort.Strings(entries)
+	return strings.Join(entries, "\n")
+}

--- a/internal/cache/cache_keys.go
+++ b/internal/cache/cache_keys.go
@@ -1,0 +1,85 @@
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"path/filepath"
+	"runtime"
+
+	"github.com/devrecon/ludus/internal/config"
+)
+
+// hash computes a SHA-256 hex digest from a list of key-value strings.
+func hash(parts ...string) string {
+	h := sha256.New()
+	for _, p := range parts {
+		h.Write([]byte(p))
+		h.Write([]byte{0}) // separator
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// EngineKey computes the cache key for the engine build stage.
+func EngineKey(cfg *config.Config) string {
+	return hash(
+		gitHEAD(cfg.Engine.SourcePath),
+		cfg.Engine.Version,
+		fmt.Sprintf("%d", cfg.Engine.MaxJobs),
+		runtime.GOOS,
+		cfg.Engine.Backend,
+		cfg.Engine.DockerBaseImage,
+	)
+}
+
+// GameServerKey computes the cache key for the game server build stage.
+func GameServerKey(cfg *config.Config, engineHash string) string {
+	projectPath := cfg.Game.ProjectPath
+	if projectPath == "" && cfg.Game.ProjectName == "Lyra" {
+		projectPath = filepath.Join(cfg.Engine.SourcePath,
+			"Samples", "Games", "Lyra", "Lyra.uproject")
+	}
+
+	return hash(
+		engineHash,
+		fileKey(projectPath),
+		cfg.Game.ResolvedServerTarget(),
+		cfg.Game.ResolvedGameTarget(),
+		cfg.Game.ServerMap,
+		fmt.Sprintf("%v", cfg.Game.SkipCook),
+		cfg.Engine.Version,
+		cfg.Game.ResolvedArch(),
+	)
+}
+
+// GameClientKey computes the cache key for the game client build stage.
+func GameClientKey(cfg *config.Config, engineHash string, platform string) string {
+	projectPath := cfg.Game.ProjectPath
+	if projectPath == "" && cfg.Game.ProjectName == "Lyra" {
+		projectPath = filepath.Join(cfg.Engine.SourcePath,
+			"Samples", "Games", "Lyra", "Lyra.uproject")
+	}
+
+	return hash(
+		engineHash,
+		fileKey(projectPath),
+		cfg.Game.ResolvedClientTarget(),
+		platform,
+		fmt.Sprintf("%v", cfg.Game.SkipCook),
+		cfg.Engine.Version,
+		cfg.Game.ResolvedArch(),
+	)
+}
+
+// ContainerKey computes the cache key for the container build stage.
+// It hashes a manifest of filenames and sizes in the server build directory.
+func ContainerKey(cfg *config.Config, serverBuildDir string) string {
+	manifest := dirManifest(serverBuildDir)
+	return hash(
+		manifest,
+		cfg.Game.ProjectName,
+		cfg.Game.ResolvedServerTarget(),
+		fmt.Sprintf("%d", cfg.Container.ServerPort),
+		cfg.Container.Tag,
+	)
+}


### PR DESCRIPTION
## Summary

- `cache.go` — core types (`StageKey`, `Entry`, `Cache`), persistence (`Load`, `Save`, `cachePath`), and high-level pipeline functions (`IsHit`, `MissReason`, `Set`, `CheckSkip`, `RecordBuild`)
- `cache_keys.go` — key computation: `EngineKey`, `GameServerKey`, `GameClientKey`, `ContainerKey`, and the `hash` helper (only used by key functions)
- `cache_helpers.go` — filesystem and git helpers: `gitHEAD`, `fileKey`, `dirManifest`

No public API or behavior changes. All 5 existing test files pass unchanged.

Note: `cache_workflow_test.go:TestRecordBuild` has a pre-existing `gocyclo` violation (complexity 11) outside the scope of this PR.

## Test plan

- [x] `go test ./internal/cache/...` — pass
- [x] `golangci-lint run ./internal/cache/...` — 0 issues
- [x] `gocyclo -over 8 ./internal/cache/` — no new violations in changed files
- [x] Pre-commit hook (full suite, 50 packages) — all pass