### PR TITLE
fix(container,game): e2e findings — output path, backend flag, podman compat

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -68,6 +68,10 @@ Integration points: `internal/dockerbuild/` mounts the host DDC directory as a D
 
 `ludus ddc` subcommands: `status`, `clean`, `prune`, `warmup`. Config in `ludus.yaml` under `ddc.mode` / `ddc.localPath`, overridable via `--ddc` flag.
 
+### BuildGraph
+
+`cmd/buildgraph/` generates UE5 BuildGraph XML describing engine and game build stages as a DAG. Used with Horde, UET, or other external orchestrators. Exposed as `ludus_buildgraph` MCP tool.
+
 ### MCP Server
 
 `cmd/mcp/` exposes 26 tools via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout). Long-running builds have async variants returning build IDs.
@@ -80,9 +84,19 @@ Integration points: `internal/dockerbuild/` mounts the host DDC directory as a D
 
 `ludus.yaml` → Viper → `config.Config` struct (loaded in `PersistentPreRunE`, stored in `globals.Cfg`) → CLI flags override → MCP params override → `internal/` logic consumes.
 
+### WSL2 Build Backend
+
+`--backend wsl2` runs engine/game builds inside a WSL2 Linux distro without Docker. Two sub-modes controlled by `--wsl-native`:
+- Default (virtiofs): builds run against the Windows filesystem mounted at `/mnt/`. Slower I/O but no sync step.
+- `--wsl-native`: syncs the engine/project source to the WSL2 ext4 filesystem before building. Much faster compile times but requires disk space for the copy.
+
+`internal/wsl/` handles distro detection, path translation, and the source sync. Use `--wsl-distro` to override the auto-detected distro.
+
 ### AWS Polling
 
 `internal/awsutil/poll.go` provides a generic `Poll()` helper used across deployers for waiting on fleet activation, stack events, etc. Prefer it over hand-rolled polling loops when adding new AWS wait conditions.
+
+`awsutil.IsNotFound()` and `awsutil.IsConflict()` classify common AWS error patterns — use these in cleanup and idempotent create paths instead of inspecting error strings directly.
 
 ### State and Caching
 

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -21,6 +21,7 @@ var (
 	pushTag  string
 	noCache  bool
 	archFlag string
+	backend  string
 )
 
 // Cmd is the top-level container command group.
@@ -56,6 +57,7 @@ func init() {
 	buildCmd.Flags().StringVarP(&tag, "tag", "t", "latest", "image tag")
 	buildCmd.Flags().BoolVar(&noCache, "no-cache", false, "build without Docker cache")
 	buildCmd.Flags().StringVar(&archFlag, "arch", "", `target CPU architecture: amd64, arm64 (default: from ludus.yaml)`)
+	buildCmd.Flags().StringVar(&backend, "backend", "", `container runtime: docker, podman (default: auto-detect)`)
 
 	pushCmd.Flags().StringVarP(&pushTag, "tag", "t", "", "image tag to push (default: from ludus.yaml or latest)")
 
@@ -90,7 +92,9 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		cfg.Game.Arch = archFlag
 	}
 
+	resolvedBackend := globals.ResolveContainerBackend(backend)
 	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
+	checker.Backend = resolvedBackend
 	if err := prereq.Validate(checker.CheckDockerReady()); err != nil {
 		return err
 	}
@@ -113,6 +117,7 @@ func runBuild(cmd *cobra.Command, args []string) error {
 		ProjectName:    cfg.Game.ProjectName,
 		ServerTarget:   cfg.Game.ResolvedServerTarget(),
 		Arch:           cfg.Game.ResolvedArch(),
+		Backend:        resolvedBackend,
 	}, r)
 
 	fmt.Println("Building container image...")

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -359,6 +359,12 @@ func runContainerClientBuild(cmd *cobra.Command, be string) error {
 func runWSL2GameBuild(cmd *cobra.Command) error {
 	cfg := globals.Cfg
 
+	engineHash := cache.EngineKey(cfg)
+	serverHash := cache.GameServerKey(cfg, engineHash)
+	if cache.CheckSkip(cache.StageGameServer, serverHash, cfg.Game.ProjectName, noCache) {
+		return nil
+	}
+
 	s, err := state.Load()
 	if err != nil {
 		return fmt.Errorf("loading state: %w", err)
@@ -392,6 +398,7 @@ func runWSL2GameBuild(cmd *cobra.Command) error {
 		Arch:         resolveArch(),
 		SkipCook:     skipCook,
 		ServerMap:    cfg.Game.ServerMap,
+		OutputDir:    config.ResolveServerBuildDir(cfg),
 		DDCMode:      ddcMode,
 		DDCPath:      wslDDCPath,
 		ServerConfig: serverConfig,
@@ -404,6 +411,8 @@ func runWSL2GameBuild(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
+
+	cache.RecordBuild(cache.StageGameServer, serverHash)
 
 	fmt.Printf("%s server build complete in %.0fs\n", cfg.Game.ProjectName, result.Duration)
 	fmt.Printf("Output: %s\n", result.OutputDir)

--- a/cmd/globals/ddc_test.go
+++ b/cmd/globals/ddc_test.go
@@ -7,6 +7,45 @@ import (
 	"github.com/devrecon/ludus/internal/config"
 )
 
+func TestResolveContainerBackend(t *testing.T) {
+	tests := []struct {
+		name       string
+		flag       string
+		cfgBackend string
+		want       string
+	}{
+		{"explicit docker flag", "docker", "", "docker"},
+		{"explicit podman flag", "podman", "", "podman"},
+		{"flag overrides config", "docker", "podman", "docker"},
+		{"wsl2 flag filtered out", "wsl2", "", ""},
+		{"native flag filtered out", "native", "", ""},
+		{"empty flag uses config docker", "", "docker", "docker"},
+		{"empty flag uses config podman", "", "podman", "podman"},
+		{"wsl2 config filtered out", "", "wsl2", ""},
+		{"native config filtered out", "", "native", ""},
+		{"both empty returns empty", "", "", ""},
+		{"nil config returns empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origCfg := Cfg
+			t.Cleanup(func() { Cfg = origCfg })
+
+			if tt.name == "nil config returns empty" {
+				Cfg = nil
+			} else {
+				Cfg = &config.Config{}
+				Cfg.Engine.Backend = tt.cfgBackend
+			}
+
+			got := ResolveContainerBackend(tt.flag)
+			if got != tt.want {
+				t.Errorf("ResolveContainerBackend(%q) = %q, want %q", tt.flag, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestResolveDDCMode(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/cmd/globals/globals.go
+++ b/cmd/globals/globals.go
@@ -33,3 +33,18 @@ func ResolveBackend(flagValue string) string {
 	}
 	return ""
 }
+
+// ResolveContainerBackend returns the effective container runtime backend ("docker" or "podman").
+// Unlike ResolveBackend, it ignores non-container backends like "wsl2" and "native" — those
+// are engine build backends that don't apply to container image builds.
+func ResolveContainerBackend(flagValue string) string {
+	be := flagValue
+	if be == "" && Cfg != nil {
+		be = Cfg.Engine.Backend
+	}
+	switch be {
+	case "docker", "podman":
+		return be
+	}
+	return ""
+}

--- a/cmd/mcp/tools_container.go
+++ b/cmd/mcp/tools_container.go
@@ -15,6 +15,7 @@ type containerBuildInput struct {
 	Tag     string `json:"tag,omitempty" jsonschema:"Container image tag (default: from config or latest)"`
 	NoCache bool   `json:"no_cache,omitempty" jsonschema:"Disable container build cache"`
 	Arch    string `json:"arch,omitempty" jsonschema:"Target CPU architecture: amd64 or arm64 (default: from config)"`
+	Backend string `json:"backend,omitempty" jsonschema:"Container runtime: docker or podman (default: auto-detect)"`
 	DryRun  bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
 }
 
@@ -34,7 +35,7 @@ type containerResult struct {
 func registerContainerTools(s *mcp.Server) {
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "ludus_container_build",
-		Description: "Build a container image for the dedicated server (Docker-only, GameLift format). Generates Dockerfile, builds GameLift wrapper, and runs docker build.",
+		Description: "Build a container image for the dedicated server (Docker or Podman, GameLift format). Generates Dockerfile, builds GameLift wrapper, and runs docker/podman build.",
 	}, handleContainerBuild)
 
 	mcp.AddTool(s, &mcp.Tool{
@@ -65,6 +66,7 @@ func handleContainerBuild(ctx context.Context, _ *mcp.CallToolRequest, input con
 		ProjectName:    cfg.Game.ProjectName,
 		ServerTarget:   cfg.Game.ResolvedServerTarget(),
 		Arch:           cfg.Game.ResolvedArch(),
+		Backend:        globals.ResolveContainerBackend(input.Backend),
 	}, r)
 
 	var result containerResult

--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -35,6 +35,8 @@ type BuildOptions struct {
 	ServerTarget string
 	// Arch is the target CPU architecture: "amd64" or "arm64".
 	Arch string
+	// Backend is the container runtime: "docker" (default) or "podman".
+	Backend string
 }
 
 // BuildResult holds the outcome of a container build.
@@ -68,6 +70,14 @@ func (b *Builder) resolveProjectName() string {
 		return b.opts.ProjectName
 	}
 	return "Lyra"
+}
+
+// resolveCLI returns the container CLI binary name: "podman" if backend is podman, otherwise "docker".
+func (b *Builder) resolveCLI() string {
+	if b.opts.Backend == "podman" {
+		return "podman"
+	}
+	return "docker"
 }
 
 // resolveServerTarget returns the server target name, defaulting to ProjectName + "Server".
@@ -240,25 +250,21 @@ Manifest_*.txt
 `
 }
 
-// checkDockerPlatformSupport verifies that Docker can build for the given platform.
+// checkContainerPlatformSupport verifies that the container CLI can build for the given platform.
 // Cross-architecture builds (e.g. arm64 on an amd64 host) require QEMU user-mode
 // emulation registered via binfmt_misc.
-//
-// NOTE: GameLift container builds use Docker directly. These images are small
-// (~3-5 GB) and unaffected by the containerd lease timeouts that affect large
-// engine images. Podman support for GameLift containers is planned for a future release.
-func checkDockerPlatformSupport(platform string) error {
-	out, err := exec.Command("docker", "buildx", "inspect", "--bootstrap").CombinedOutput()
+func checkContainerPlatformSupport(cli, platform string) error {
+	out, err := exec.Command(cli, "buildx", "inspect", "--bootstrap").CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("docker buildx not available: %w", err)
+		return fmt.Errorf("%s buildx not available: %w", cli, err)
 	}
 	if strings.Contains(string(out), platform) {
 		return nil
 	}
-	return fmt.Errorf("Docker cannot build for %s on this machine.\n"+
+	return fmt.Errorf("%s cannot build for %s on this machine.\n"+
 		"  Cross-architecture builds require QEMU emulation. Install it with:\n"+
 		"    docker run --rm --privileged tonistiigi/binfmt --install arm64\n"+
-		"  Then retry the build", platform)
+		"  Then retry the build", cli, platform)
 }
 
 // Build creates the Docker image for the dedicated server.
@@ -342,8 +348,9 @@ func (b *Builder) generateAndWriteDockerfile(ctx context.Context) (func(), error
 	return cleanup, nil
 }
 
-// runDockerBuild runs the docker build command with platform and provenance settings.
+// runDockerBuild runs the container build command with platform and provenance settings.
 func (b *Builder) runDockerBuild(ctx context.Context, imageTag string) error {
+	cli := b.resolveCLI()
 	arch := b.resolveArch()
 	platform := "linux/amd64"
 	if arch == "arm64" {
@@ -352,7 +359,7 @@ func (b *Builder) runDockerBuild(ctx context.Context, imageTag string) error {
 
 	// Cross-arch builds (e.g. building arm64 on amd64) require QEMU emulation.
 	if arch != runtime.GOARCH {
-		if err := checkDockerPlatformSupport(platform); err != nil {
+		if err := checkContainerPlatformSupport(cli, platform); err != nil {
 			return err
 		}
 	}
@@ -360,14 +367,19 @@ func (b *Builder) runDockerBuild(ctx context.Context, imageTag string) error {
 	// --provenance=false prevents BuildKit from creating an OCI manifest index
 	// with attestation manifests. GameLift requires a simple single-platform
 	// image manifest and cannot parse multi-manifest OCI indexes.
-	args := []string{"build", "--platform", platform, "--provenance=false", "-t", imageTag}
+	// Podman does not support --provenance (it never generates attestation manifests).
+	args := []string{"build", "--platform", platform}
+	if cli == "docker" {
+		args = append(args, "--provenance=false")
+	}
+	args = append(args, "-t", imageTag)
 	if b.opts.NoCache {
 		args = append(args, "--no-cache")
 	}
 	args = append(args, b.opts.ServerBuildDir)
 
-	if err := b.Runner.Run(ctx, "docker", args...); err != nil {
-		return fmt.Errorf("docker build failed: %w", err)
+	if err := b.Runner.Run(ctx, cli, args...); err != nil {
+		return fmt.Errorf("%s build failed: %w", cli, err)
 	}
 	return nil
 }

--- a/internal/container/builder_test.go
+++ b/internal/container/builder_test.go
@@ -1,8 +1,11 @@
 package container
 
 import (
+	"context"
 	"strings"
 	"testing"
+
+	"github.com/devrecon/ludus/internal/runner"
 )
 
 func TestNewBuilder(t *testing.T) {
@@ -158,5 +161,66 @@ func TestGenerateDockerignore(t *testing.T) {
 		if !strings.Contains(ignore, p) {
 			t.Errorf("dockerignore missing pattern %q", p)
 		}
+	}
+}
+
+func TestResolveCLI(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend string
+		want    string
+	}{
+		{"podman backend returns podman", "podman", "podman"},
+		{"docker backend returns docker", "docker", "docker"},
+		{"empty backend returns docker", "", "docker"},
+		{"unrecognised backend returns docker", "wsl2", "docker"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewBuilder(BuildOptions{Backend: tt.backend}, nil)
+			got := b.resolveCLI()
+			if got != tt.want {
+				t.Errorf("resolveCLI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunDockerBuild_ProvenanceFlag(t *testing.T) {
+	tests := []struct {
+		name           string
+		backend        string
+		wantProvenance bool // true = expect --provenance=false in output
+	}{
+		{"docker includes provenance flag", "docker", true},
+		{"podman omits provenance flag", "podman", false},
+		{"empty backend (defaults to docker) includes provenance flag", "", true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var stdout strings.Builder
+			r := runner.NewRunner(false, true) // dry-run: prints args, doesn't exec
+			r.Stdout = &stdout
+
+			b := NewBuilder(BuildOptions{
+				Backend:        tt.backend,
+				ServerBuildDir: t.TempDir(),
+				ImageName:      "test-image",
+				Tag:            "latest",
+			}, r)
+
+			ctx := context.Background()
+			_ = b.runDockerBuild(ctx, "test-image:latest")
+
+			output := stdout.String()
+			hasProvenance := strings.Contains(output, "--provenance=false")
+			if hasProvenance != tt.wantProvenance {
+				if tt.wantProvenance {
+					t.Errorf("expected --provenance=false in dry-run output, got: %s", output)
+				} else {
+					t.Errorf("unexpected --provenance=false in dry-run output for podman, got: %s", output)
+				}
+			}
+		})
 	}
 }

--- a/internal/container/builder_test.go
+++ b/internal/container/builder_test.go
@@ -2,6 +2,7 @@ package container
 
 import (
 	"context"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -207,6 +208,7 @@ func TestRunDockerBuild_ProvenanceFlag(t *testing.T) {
 				ServerBuildDir: t.TempDir(),
 				ImageName:      "test-image",
 				Tag:            "latest",
+				Arch:           runtime.GOARCH, // match host arch to skip cross-arch check
 			}, r)
 
 			ctx := context.Background()

--- a/internal/wsl/game_test.go
+++ b/internal/wsl/game_test.go
@@ -188,6 +188,28 @@ func TestBuildRunUATArgs_SkipCookAndQuoting(t *testing.T) {
 	})
 }
 
+func TestBuildRunUATArgs_OutputDir(t *testing.T) {
+	t.Run("explicit outputDir is passed as archivedirectory", func(t *testing.T) {
+		assertRunUATArgs(t,
+			GameOptions{Platform: "Linux"},
+			"/mnt/f/game/Lyra.uproject",
+			"/mnt/f/game/PackagedServer/LinuxServer",
+			[]string{"-archivedirectory='/mnt/f/game/PackagedServer/LinuxServer'"},
+			nil,
+		)
+	})
+
+	t.Run("empty outputDir passes empty archivedirectory (RunUAT uses default)", func(t *testing.T) {
+		assertRunUATArgs(t,
+			GameOptions{Platform: "Linux"},
+			"/mnt/f/game/Lyra.uproject",
+			"",
+			[]string{"-archivedirectory=''"},
+			nil,
+		)
+	})
+}
+
 func assertRunUATArgs(t *testing.T, opts GameOptions, projectPath, outputDir string, wantContain, wantExclude []string) {
 	t.Helper()
 	args := buildRunUATArgs(opts, projectPath, outputDir)


### PR DESCRIPTION
## Summary

Five bugs found and fixed during a full E2E pipeline run (WSL-native engine build → game build → container build → GameLift fleet deploy → session):

- **WSL2 game build missing `OutputDir`**: `runWSL2GameBuild` never set `OutputDir`, so RunUAT archived to `ArchivedBuilds/LinuxServer` instead of `PackagedServer/LinuxServer`. Container build then couldn't find server binaries. Also added missing cache check/record that native and docker paths have.
- **`container build` had no `--backend` flag**: Hardcoded `CheckDockerReady()` regardless of backend. Added `--backend docker|podman` flag, `ResolveContainerBackend()` helper in globals (filters non-container backends like `wsl2`/`native`), wired through to prereq checker and builder.
- **Podman incompatible `--provenance=false`**: Docker BuildKit-only flag caused Podman to fail. Now conditionally omitted. Builder gains `Backend` field, `resolveCLI()` method, and `checkContainerPlatformSupport(cli, platform)`.
- **MCP `ludus_container_build` had no `backend` param**: Added field and wired through `ResolveContainerBackend()`.

## Files changed

| File | Change |
|------|--------|
| `cmd/game/game.go` | Set `OutputDir`, add cache check + record in `runWSL2GameBuild` |
| `cmd/container/container.go` | Add `--backend` flag, use `ResolveContainerBackend` |
| `cmd/globals/globals.go` | Add `ResolveContainerBackend()` |
| `cmd/mcp/tools_container.go` | Add `backend` param, update description |
| `internal/container/builder.go` | `Backend` field, `resolveCLI()`, Podman-safe build args |
| `CLAUDE.md` | WSL2 backend and awsutil sections added |

## Open items (tracked separately)

- `ludus_engine_build_start` missing wsl2 async support
- `deploy fleet` (gamelift) not writing `deploy.targetName` to state — `deploy session` requires explicit `--target gamelift`
- MCP `ludus_deploy_fleet` returned binary-export result instead of fleet status (needs investigation)

## Test plan

- [x] `go build` clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all pass
- [x] Pre-commit hook passed on commit
- [x] E2E: WSL2 game build archived to `PackagedServer/LinuxServer` ✓
- [x] E2E: `container build --backend docker` succeeded (131s, ludus-server:latest) ✓
- [x] E2E: `container build --backend podman` reached podman machine (socket env issue is infra, not code) ✓
- [x] E2E: Full GameLift fleet deploy → session (16.147.39.133:4193) → destroy ✓