### PR TITLE
fix(gamelift): write deploy state after fleet creation

### DIFF
--- a/cmd/deploy/deploy_fleet.go
+++ b/cmd/deploy/deploy_fleet.go
@@ -59,12 +59,24 @@ func runFleet(cmd *cobra.Command, args []string) error {
 		return diagnose.DeployError(err, "gamelift")
 	}
 
+	now := time.Now().UTC().Format(time.RFC3339)
+
 	if err := state.UpdateFleet(&state.FleetState{
 		FleetID:   fleetStatus.FleetID,
 		Status:    fleetStatus.Status,
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		CreatedAt: now,
 	}); err != nil {
-		fmt.Printf("Warning: failed to write state: %v\n", err)
+		fmt.Printf("Warning: failed to write fleet state: %v\n", err)
+	}
+
+	detail := fmt.Sprintf("fleet %s", fleetStatus.FleetID)
+	if err := state.UpdateDeploy(&state.DeployState{
+		TargetName: "gamelift",
+		Status:     fleetStatus.Status,
+		Detail:     detail,
+		DeployedAt: now,
+	}); err != nil {
+		fmt.Printf("Warning: failed to write deploy state: %v\n", err)
 	}
 
 	fmt.Printf("\nFleet deployed: %s (status: %s)\n", fleetStatus.FleetID, fleetStatus.Status)

--- a/internal/gamelift/adapter.go
+++ b/internal/gamelift/adapter.go
@@ -51,18 +51,30 @@ func (a *TargetAdapter) Deploy(ctx context.Context, input deploy.DeployInput) (*
 		return nil, err
 	}
 
+	now := time.Now().UTC().Format(time.RFC3339)
+
 	if err := state.UpdateFleet(&state.FleetState{
 		FleetID:   fleetStatus.FleetID,
 		Status:    fleetStatus.Status,
-		CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		CreatedAt: now,
 	}); err != nil {
-		fmt.Printf("Warning: failed to write state: %v\n", err)
+		fmt.Printf("Warning: failed to write fleet state: %v\n", err)
+	}
+
+	detail := fmt.Sprintf("fleet %s", fleetStatus.FleetID)
+	if err := state.UpdateDeploy(&state.DeployState{
+		TargetName: "gamelift",
+		Status:     fleetStatus.Status,
+		Detail:     detail,
+		DeployedAt: now,
+	}); err != nil {
+		fmt.Printf("Warning: failed to write deploy state: %v\n", err)
 	}
 
 	return &deploy.DeployResult{
 		TargetName: "gamelift",
 		Status:     fleetStatus.Status,
-		Detail:     fmt.Sprintf("fleet %s", fleetStatus.FleetID),
+		Detail:     detail,
 	}, nil
 }
 

--- a/internal/gamelift/deployer_test.go
+++ b/internal/gamelift/deployer_test.go
@@ -2,7 +2,52 @@ package gamelift
 
 import (
 	"testing"
+	"time"
+
+	"github.com/devrecon/ludus/internal/state"
 )
+
+// TestDeployWritesDeployState verifies that the state written after a gamelift
+// deploy sets targetName to "gamelift" (regression: adapter was only writing
+// UpdateFleet, leaving deploy.targetName stale from a previous deployment).
+func TestDeployWritesDeployState(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	fleetID := "fleet-abc123"
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	if err := state.UpdateFleet(&state.FleetState{
+		FleetID:   fleetID,
+		Status:    "ACTIVE",
+		CreatedAt: now,
+	}); err != nil {
+		t.Fatalf("UpdateFleet: %v", err)
+	}
+
+	detail := "fleet " + fleetID
+	if err := state.UpdateDeploy(&state.DeployState{
+		TargetName: "gamelift",
+		Status:     "ACTIVE",
+		Detail:     detail,
+		DeployedAt: now,
+	}); err != nil {
+		t.Fatalf("UpdateDeploy: %v", err)
+	}
+
+	s, err := state.Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if s.Deploy == nil {
+		t.Fatal("deploy state not written")
+	}
+	if s.Deploy.TargetName != "gamelift" {
+		t.Errorf("deploy.targetName = %q, want %q", s.Deploy.TargetName, "gamelift")
+	}
+	if s.Fleet == nil || s.Fleet.FleetID != fleetID {
+		t.Error("fleet state not written alongside deploy state")
+	}
+}
 
 func TestBuildCreateFleetInput_OmitsPortConfig(t *testing.T) {
 	opts := DeployOptions{


### PR DESCRIPTION
## Summary

- `TargetAdapter.Deploy()` was calling `state.UpdateFleet()` but not `state.UpdateDeploy()`, leaving `deploy.targetName` stale from a previous deployment
- This caused `deploy session` to fail with "target does not support game sessions" unless `--target gamelift` was passed explicitly
- Now writes both fleet state and deploy state (`targetName: "gamelift"`) following the same pattern as the `ec2fleet`, `stack`, and `anywhere` adapters

## Test plan

- [ ] `go test ./internal/gamelift/ ./internal/state/` passes
- [ ] `golangci-lint run ./internal/gamelift/ ./internal/state/` clean
- [ ] E2E: `ludus deploy fleet` followed by `ludus deploy session` (no `--target` flag) succeeds