### PR TITLE
fix(test): add explicit return after t.Fatal in tools_async_test

### DIFF
--- a/cmd/mcp/tools_async_test.go
+++ b/cmd/mcp/tools_async_test.go
@@ -15,19 +15,23 @@ func assertToolError(t *testing.T, result *mcpsdk.CallToolResult, err error, wan
 	t.Helper()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+		return
 	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 	if !result.IsError {
 		t.Error("expected IsError = true")
 	}
 	if len(result.Content) == 0 {
 		t.Fatal("expected at least one content item")
+		return
 	}
 	tc, ok := result.Content[0].(*mcpsdk.TextContent)
 	if !ok {
 		t.Fatalf("expected *mcpsdk.TextContent, got %T", result.Content[0])
+		return
 	}
 	if !strings.Contains(tc.Text, wantErr) {
 		t.Errorf("error message %q should contain %q", tc.Text, wantErr)
@@ -55,9 +59,11 @@ func TestAsyncWSL2Engine(t *testing.T) {
 	result, _, err := handleEngineBuildStart(context.Background(), nil, engineBuildStartInput{Backend: "wsl2"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+		return
 	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 
 	// A "not yet supported" rejection must not be returned.
@@ -72,6 +78,7 @@ func TestAsyncWSL2Engine(t *testing.T) {
 	// Success path: a build ID must be present.
 	if len(result.Content) == 0 {
 		t.Fatal("expected content in result")
+		return
 	}
 }
 
@@ -86,9 +93,11 @@ func TestAsyncWSL2Game(t *testing.T) {
 	result, _, err := handleGameBuildStart(context.Background(), nil, gameBuildStartInput{Backend: "wsl2"})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
+		return
 	}
 	if result == nil {
 		t.Fatal("expected non-nil result")
+		return
 	}
 
 	if result.IsError {
@@ -100,6 +109,7 @@ func TestAsyncWSL2Game(t *testing.T) {
 	}
 	if len(result.Content) == 0 {
 		t.Fatal("expected content in result")
+		return
 	}
 }
 


### PR DESCRIPTION
## Summary

- `Lint (Windows)` on PR #203 (dependabot S3 bump) failed with SA5011 (possible nil pointer dereference) in `cmd/mcp/tools_async_test.go`, even though #203 doesn't touch that file
- Root cause: staticcheck's flow analysis doesn't always treat `t.Fatal` as control-flow-terminating; cache-state dependent — the same file passed on PRs #207, #209, #210 with different cache keys
- Fix: bare `return` after each `t.Fatal*` call, identical to the v0.1.9 pattern from commit `b0abb62` (`buildgraph` and `toolchain` tests)

## Test plan

- [x] `golangci-lint run ./cmd/mcp/...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test -v -run "TestAsync" ./cmd/mcp/` — all 4 async tests pass
- [x] `go test ./...` — all packages pass
- [x] pre-commit hook — build + lint + tests pass
- [ ] PR CI: `Lint (Windows)` must pass (the check we're fixing)
- [ ] After merge: rebase PR #203 onto new main and confirm `Lint (Windows)` passes there too