### PR TITLE
fix(test): add explicit return after t.Fatal in helpers_build and toolchain tests

### DIFF
--- a/cmd/mcp/helpers_build_test.go
+++ b/cmd/mcp/helpers_build_test.go
@@ -29,6 +29,7 @@ func TestNewToolRunner(t *testing.T) {
 			r := newToolRunner(tt.inputDry)
 			if r == nil {
 				t.Fatal("expected non-nil runner")
+				return
 			}
 			if !r.Verbose {
 				t.Error("expected Verbose = true for MCP runner")

--- a/internal/toolchain/version_test.go
+++ b/internal/toolchain/version_test.go
@@ -138,6 +138,7 @@ func TestLookupToolchain(t *testing.T) {
 			}
 			if spec == nil {
 				t.Fatalf("expected spec for version %q, got nil", tt.version)
+				return
 			}
 			if spec.ClangMajor != tt.clang {
 				t.Errorf("got ClangMajor %d, want %d", spec.ClangMajor, tt.clang)


### PR DESCRIPTION
## Summary

- After #211 fixed `tools_async_test.go`, a fresh-cache `Lint (Windows)` run on PR #203 exposed SA5011 in two more files
- Same root cause: staticcheck doesn't treat `t.Fatal` as control-flow-terminating in all cache states; nil guards followed by field dereferences get flagged
- Two sites fixed with the same bare `return` pattern from v0.1.9 (b0abb62):
  - `cmd/mcp/helpers_build_test.go:31` — guards `r.Verbose`/`r.DryRun` derefs
  - `internal/toolchain/version_test.go:140` — guards `spec.ClangMajor` deref

## Test plan

- [x] `golangci-lint run ./cmd/mcp/... ./internal/toolchain/...` — 0 issues
- [x] `golangci-lint run ./...` — 0 issues  
- [x] `go test ./cmd/mcp/... ./internal/toolchain/...` — all pass
- [x] pre-commit hook — build + lint + tests pass
- [ ] PR CI: `Lint (Windows)` must pass
- [ ] After merge: rebase PR #203 onto new main and confirm `Lint (Windows)` passes there