### PR TITLE
fix(security): bump Go toolchain to 1.25.10

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jpvelasco/ludus
 
-go 1.25.9
+go 1.25.10
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.7


### PR DESCRIPTION
## Summary

- Upgrades Go toolchain from 1.25.9 → 1.25.10 in `go.mod`
- Fixes 5 CVEs flagged by Codacy/Trivy against `golang/stdlib@1.25.9`:
  - CVE-2026-39820 (HIGH): `net/mail` ParseAddress/ParseAddressList/Parse
  - CVE-2026-33814 (HIGH): HTTP/2 SETTINGS frame infinite loop in transport
  - CVE-2026-33811 (HIGH): `LookupCNAME` cgo DNS resolver long CNAME crash
  - CVE-2026-42499 (HIGH): `net/mail` consumePhrase DoS on pathological input
  - CVE-2026-39836 (HIGH): `net` Dial/LookupPort panic on NUL byte (Windows)

## Test plan

- [x] `go build` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] pre-commit hook — all checks pass
- [ ] PR CI: all 13 checks pass