### PR TITLE
refactor: extract helpers to reduce cyclomatic complexity

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -168,22 +168,17 @@ func runSession(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	target, err := resolveTarget(cmd)
+	var (
+		target deploy.Target
+		err    error
+	)
+	if targetFlag != "" {
+		target, err = resolveTarget(cmd)
+	} else {
+		target, err = globals.ResolveSessionTarget(cmd.Context(), globals.Cfg)
+	}
 	if err != nil {
 		return err
-	}
-
-	// Fall back to state.Deploy.TargetName when the config target (e.g. "binary")
-	// doesn't support sessions. This handles the common case where ludus.yaml has
-	// deploy.target: binary but the last deployment was gamelift/stack/ec2/anywhere.
-	if _, ok := target.(deploy.SessionManager); !ok && targetFlag == "" {
-		st, _ := state.Load()
-		if st.Deploy != nil && st.Deploy.TargetName != "" {
-			fallback, ferr := globals.ResolveTarget(cmd.Context(), globals.Cfg, st.Deploy.TargetName)
-			if ferr == nil {
-				target = fallback
-			}
-		}
 	}
 
 	sm, ok := target.(deploy.SessionManager)

--- a/cmd/deploy/deploy_fleet.go
+++ b/cmd/deploy/deploy_fleet.go
@@ -59,8 +59,18 @@ func runFleet(cmd *cobra.Command, args []string) error {
 		return diagnose.DeployError(err, "gamelift")
 	}
 
-	now := time.Now().UTC().Format(time.RFC3339)
+	recordFleetDeployState(fleetStatus)
 
+	fmt.Printf("\nFleet deployed: %s (status: %s)\n", fleetStatus.FleetID, fleetStatus.Status)
+	if err := maybeCreateSession(cmd.Context(), gamelift.NewTargetAdapter(deployer)); err != nil {
+		return err
+	}
+	printNextStep()
+	return nil
+}
+
+func recordFleetDeployState(fleetStatus *gamelift.FleetStatus) {
+	now := time.Now().UTC().Format(time.RFC3339)
 	if err := state.UpdateFleet(&state.FleetState{
 		FleetID:   fleetStatus.FleetID,
 		Status:    fleetStatus.Status,
@@ -68,7 +78,6 @@ func runFleet(cmd *cobra.Command, args []string) error {
 	}); err != nil {
 		fmt.Printf("Warning: failed to write fleet state: %v\n", err)
 	}
-
 	detail := fmt.Sprintf("fleet %s", fleetStatus.FleetID)
 	if err := state.UpdateDeploy(&state.DeployState{
 		TargetName: "gamelift",
@@ -78,11 +87,4 @@ func runFleet(cmd *cobra.Command, args []string) error {
 	}); err != nil {
 		fmt.Printf("Warning: failed to write deploy state: %v\n", err)
 	}
-
-	fmt.Printf("\nFleet deployed: %s (status: %s)\n", fleetStatus.FleetID, fleetStatus.Status)
-	if err := maybeCreateSession(cmd.Context(), gamelift.NewTargetAdapter(deployer)); err != nil {
-		return err
-	}
-	printNextStep()
-	return nil
 }

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -384,10 +384,6 @@ func runWSL2GameBuild(cmd *cobra.Command) error {
 	if err != nil {
 		return err
 	}
-	wslDDCPath := s.WSL2Engine.DDCPath
-	if ddcMode == ddc.ModeLocal && wslDDCPath == "" {
-		wslDDCPath = w.ToWSLPath(ddcPath)
-	}
 
 	opts := wsl.GameOptions{
 		EnginePath:   s.WSL2Engine.EnginePath,
@@ -400,7 +396,7 @@ func runWSL2GameBuild(cmd *cobra.Command) error {
 		ServerMap:    cfg.Game.ServerMap,
 		OutputDir:    config.ResolveServerBuildDir(cfg),
 		DDCMode:      ddcMode,
-		DDCPath:      wslDDCPath,
+		DDCPath:      resolveWSL2GameDDCPath(w, s.WSL2Engine.DDCPath, ddcMode, ddcPath),
 		ServerConfig: serverConfig,
 		MaxJobs:      maxJobs,
 	}
@@ -418,4 +414,11 @@ func runWSL2GameBuild(cmd *cobra.Command) error {
 	fmt.Printf("Output: %s\n", result.OutputDir)
 	fmt.Printf("\nNext: %s\n", nextAfterServerBuild())
 	return nil
+}
+
+func resolveWSL2GameDDCPath(w *wsl.WSL2, engineDDCPath, ddcMode, ddcPath string) string {
+	if ddcMode == ddc.ModeLocal && engineDDCPath == "" {
+		return w.ToWSLPath(ddcPath)
+	}
+	return engineDDCPath
 }

--- a/cmd/globals/resolve.go
+++ b/cmd/globals/resolve.go
@@ -14,6 +14,7 @@ import (
 	"github.com/jpvelasco/ludus/internal/pricing"
 	"github.com/jpvelasco/ludus/internal/runner"
 	"github.com/jpvelasco/ludus/internal/stack"
+	"github.com/jpvelasco/ludus/internal/state"
 	"github.com/jpvelasco/ludus/internal/tags"
 )
 
@@ -39,6 +40,28 @@ func ResolveTarget(ctx context.Context, cfg *config.Config, targetOverride strin
 	default:
 		return nil, fmt.Errorf("unknown deploy target %q (supported: gamelift, stack, binary, anywhere, ec2)", target)
 	}
+}
+
+// ResolveSessionTarget resolves a deploy target that supports sessions.
+// It first resolves the configured target; if that target doesn't implement
+// deploy.SessionManager it falls back to the target stored in deploy state.
+func ResolveSessionTarget(ctx context.Context, cfg *config.Config) (deploy.Target, error) {
+	target, err := ResolveTarget(ctx, cfg, "")
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := target.(deploy.SessionManager); ok {
+		return target, nil
+	}
+	st, _ := state.Load()
+	if st.Deploy == nil || st.Deploy.TargetName == "" {
+		return target, nil
+	}
+	fallback, ferr := ResolveTarget(ctx, cfg, st.Deploy.TargetName)
+	if ferr != nil {
+		return nil, fmt.Errorf("could not resolve deploy target from state (%q): %w", st.Deploy.TargetName, ferr)
+	}
+	return fallback, nil
 }
 
 func resolveGameLift(ctx context.Context, cfg *config.Config) (deploy.Target, error) {

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -376,23 +376,9 @@ func handleDeployEC2(ctx context.Context, _ *mcp.CallToolRequest, input deployEC
 func handleDeploySession(ctx context.Context, _ *mcp.CallToolRequest, input deploySessionInput) (*mcp.CallToolResult, any, error) {
 	cfg := globals.Cfg
 
-	// Resolve target from config; fall back to state.Deploy.TargetName when the
-	// config target (e.g. "binary") doesn't support sessions. This handles the
-	// common case where ludus.yaml has deploy.target: binary but the last real
-	// deployment was gamelift/stack/ec2/anywhere.
-	target, err := globals.ResolveTarget(ctx, cfg, "")
+	target, err := globals.ResolveSessionTarget(ctx, cfg)
 	if err != nil {
 		return toolError(fmt.Sprintf("could not resolve deploy target: %v", err))
-	}
-
-	if _, ok := target.(deploy.SessionManager); !ok {
-		st, _ := state.Load()
-		if st.Deploy != nil && st.Deploy.TargetName != "" {
-			target, err = globals.ResolveTarget(ctx, cfg, st.Deploy.TargetName)
-			if err != nil {
-				return toolError(fmt.Sprintf("could not resolve deploy target from state (%q): %v", st.Deploy.TargetName, err))
-			}
-		}
 	}
 
 	sm, ok := target.(deploy.SessionManager)


### PR DESCRIPTION
## Summary

Codacy flagged 4 functions exceeding the cyclomatic-complexity threshold. Extracting focused helpers brings each below the limit with zero behavior change.

- **`ResolveSessionTarget`** (`cmd/globals/resolve.go`) — new shared helper: resolves a deploy target that supports sessions, falling back to `state.Deploy.TargetName` when the configured target (e.g. `binary`) isn't a `SessionManager`. Eliminates the nested fallback block duplicated in two callers.
- **`handleDeploySession`** (`cmd/mcp/tools_deploy.go`) — use `ResolveSessionTarget`. CC 7 → 3.
- **`runSession`** (`cmd/deploy/deploy.go`) — use `ResolveSessionTarget` when no `--target` flag set. CC 5 → 3.
- **`recordFleetDeployState`** (`cmd/deploy/deploy_fleet.go`) — extracts the `UpdateFleet` + `UpdateDeploy` warning blocks. CC 8 → 5.
- **`resolveWSL2GameDDCPath`** (`cmd/game/game.go`) — extracts DDC path conditional. CC 7 → 5.

## Test plan

- [x] `go build` — clean
- [x] `golangci-lint run ./...` — 0 issues
- [x] `go test ./...` — all packages pass
- [x] pre-commit hook — all checks pass
- [ ] PR CI: all 13 checks pass
- [ ] Codacy: complexity violations resolved