### PR TITLE
chore: move community files to .github/ and add repo settings reference

### DIFF
--- a/.github/CODE_OF_CONDUCT.md
+++ b/.github/CODE_OF_CONDUCT.md
@@ -6,8 +6,8 @@ We as members, contributors, and leaders pledge to make participation in our
 community a harassment-free experience for everyone, regardless of age, body
 size, visible or invisible disability, ethnicity, sex characteristics, gender
 identity and expression, level of experience, education, socio-economic status,
-nationality, personal appearance, race, religion, or sexual identity
-and orientation.
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
 
 We pledge to act and interact in ways that contribute to an open, welcoming,
 diverse, inclusive, and healthy community.
@@ -67,10 +67,64 @@ All complaints will be reviewed and investigated promptly and fairly.
 All community leaders are obligated to respect the privacy and security of the
 reporter of any incident.
 
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within
+the community.
+
 ## Attribution
 
 This Code of Conduct is adapted from the [Contributor Covenant][homepage],
-version 2.0, available at
-<https://www.contributor-covenant.org/version/2/0/code_of_conduct.html>.
+version 2.1, available at
+<https://www.contributor-covenant.org/version/2/1/code_of_conduct.html>.
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+<https://www.contributor-covenant.org/faq>. Translations are available at
+<https://www.contributor-covenant.org/translations>.
 
 [homepage]: https://www.contributor-covenant.org
+[Mozilla CoC]: https://github.com/mozilla/diversity

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -12,7 +12,7 @@ Thanks for your interest in contributing! Ludus is open source under the MIT lic
    git checkout -b feat/your-feature
    ```
 3. Install dependencies:
-   - Go 1.24+
+   - Go 1.25+
    - golangci-lint v2 (`go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@latest`)
 4. Activate pre-commit hooks:
    ```bash
@@ -42,7 +42,7 @@ The pre-commit hook runs build, lint, and tests automatically. All three must pa
 
 ## Code Style
 
-- Follow existing patterns — see [AGENTS.md](AGENTS.md) for detailed conventions
+- Follow existing patterns — see [AGENTS.md](../AGENTS.md) for detailed conventions
 - Use `runner.Runner` for shell execution (never raw `exec.Command`)
 - Two import groups: stdlib, then everything else
 - Table-driven tests with stdlib only (no testify)

--- a/.github/GITHUB_SETTINGS.md
+++ b/.github/GITHUB_SETTINGS.md
@@ -1,0 +1,144 @@
+# GitHub Repository Settings
+
+These settings are configured outside the repo (GitHub UI or API) and cannot
+be enforced by files in the codebase. Re-apply these when setting up a fork
+or new instance.
+
+---
+
+## Apply via `gh api` (replace `OWNER/REPO`)
+
+```bash
+# General settings
+gh api repos/OWNER/REPO \
+  --method PATCH \
+  --field delete_branch_on_merge=true \
+  --field default_branch=main
+
+# Dependabot alerts + security updates
+gh api repos/OWNER/REPO/vulnerability-alerts --method PUT
+gh api repos/OWNER/REPO/automated-security-fixes --method PUT
+
+# Secret scanning + push protection
+gh api repos/OWNER/REPO \
+  --method PATCH \
+  --header "Content-Type: application/json" \
+  --input - <<'EOF'
+{
+  "security_and_analysis": {
+    "secret_scanning": { "status": "enabled" },
+    "secret_scanning_push_protection": { "status": "enabled" }
+  }
+}
+EOF
+
+# CodeQL default setup
+gh api repos/OWNER/REPO/code-scanning/default-setup \
+  --method PATCH \
+  --input - <<'EOF'
+{ "state": "configured", "query_suite": "default" }
+EOF
+
+# Branch ruleset: Protect main
+gh api repos/OWNER/REPO/rulesets \
+  --method POST \
+  --header "Content-Type: application/json" \
+  --input - <<'EOF'
+{
+  "name": "Protect main",
+  "target": "branch",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["~DEFAULT_BRANCH"], "exclude": [] }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    {
+      "type": "pull_request",
+      "parameters": {
+        "required_approving_review_count": 0,
+        "dismiss_stale_reviews_on_push": false,
+        "require_code_owner_review": false,
+        "require_last_push_approval": false,
+        "required_review_thread_resolution": false,
+        "allowed_merge_methods": ["merge", "squash", "rebase"]
+      }
+    },
+    {
+      "type": "required_status_checks",
+      "parameters": {
+        "strict_required_status_checks_policy": true,
+        "do_not_enforce_on_create": false,
+        "required_status_checks": [
+          { "context": "Build (ubuntu-latest)" },
+          { "context": "Build (windows-latest)" },
+          { "context": "Lint" },
+          { "context": "Lint (Windows)" },
+          { "context": "Test (ubuntu-latest)" },
+          { "context": "Test (windows-latest)" }
+        ]
+      }
+    }
+  ]
+}
+EOF
+
+# Tag ruleset: Protect release tags
+gh api repos/OWNER/REPO/rulesets \
+  --method POST \
+  --header "Content-Type: application/json" \
+  --input - <<'EOF'
+{
+  "name": "Protect release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": { "include": ["refs/tags/v*"], "exclude": [] }
+  },
+  "rules": [
+    { "type": "deletion" },
+    { "type": "non_fast_forward" },
+    { "type": "update" }
+  ]
+}
+EOF
+```
+
+---
+
+## Current settings (jpvelasco/ludus)
+
+### General
+- Default branch: `main`
+- Auto-delete head branches: enabled
+
+### Branch ruleset: `Protect main`
+- Blocks deletion and force pushes
+- Requires PR before merging: yes
+- Required approvals: 0
+- Dismiss stale reviews on push: no
+- Require CODEOWNERS review: no
+- Require conversation resolution: no
+- Required status checks (all must pass):
+  - `Build (ubuntu-latest)`
+  - `Build (windows-latest)`
+  - `Lint`
+  - `Lint (Windows)`
+  - `Test (ubuntu-latest)`
+  - `Test (windows-latest)`
+- Require branch up to date: yes
+- Enforce on admins: yes
+
+### Tag ruleset: `Protect release tags`
+- Pattern: `v*`
+- Restrict deletions: yes
+- Restrict force pushes: yes
+- Restrict updates: yes
+
+### Security & Analysis
+- Secret scanning: enabled
+- Push protection: enabled
+- CodeQL (default setup): enabled — Go, JavaScript/TypeScript, Actions
+- Dependabot alerts: enabled
+- Dependabot security updates: enabled

--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -2,7 +2,6 @@
 description: Configuration for AI behavior when interacting with Codacy's MCP Server
 applyTo: '**'
 ---
----
 # Codacy Rules
 Configuration for AI behavior when interacting with Codacy's MCP Server
 

--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -1,6 +1,6 @@
 ---
-    description: Configuration for AI behavior when interacting with Codacy's MCP Server
-    applyTo: '**'
+description: Configuration for AI behavior when interacting with Codacy's MCP Server
+applyTo: '**'
 ---
 ---
 # Codacy Rules
@@ -76,4 +76,3 @@ Configuration for AI behavior when interacting with Codacy's MCP Server
 - If the user accepts, run the `codacy_setup_repository` tool
 - Do not ever try to run the `codacy_setup_repository` tool on your own
 - After setup, immediately retry the action that failed (only retry once)
----

--- a/.github/instructions/codacy.instructions.md
+++ b/.github/instructions/codacy.instructions.md
@@ -1,0 +1,79 @@
+---
+    description: Configuration for AI behavior when interacting with Codacy's MCP Server
+    applyTo: '**'
+---
+---
+# Codacy Rules
+Configuration for AI behavior when interacting with Codacy's MCP Server
+
+## using any tool that accepts the arguments: `provider`, `organization`, or `repository`
+- ALWAYS use:
+ - provider: gh
+ - organization: jpvelasco
+ - repository: ludus
+- Avoid calling `git remote -v` unless really necessary
+
+## CRITICAL: After ANY successful `edit_file` or `reapply` operation
+- YOU MUST IMMEDIATELY run the `codacy_cli_analyze` tool from Codacy's MCP Server for each file that was edited, with:
+ - `rootPath`: set to the workspace path
+ - `file`: set to the path of the edited file
+ - `tool`: leave empty or unset
+- If any issues are found in the new edits, propose and apply fixes for them.
+- > NOTE: Failure to follow this rule is considered a critical error.
+
+## When you tried to run the `codacy_cli_analyze` tool and the Codacy CLI is not installed
+- Ask the user 'Codacy CLI is not installed. Would you like me to install it now?'
+- If the user responds with "yes", run the `codacy_cli_install` tool and then continue with the original task
+- If the user responds with "no", instruct the user that they can disable automatic analysis in the extension settings
+- Wait for the user to respond before proceeding with any other actions
+
+## After every response
+- If you made any file edits in this conversation, verify you ran `codacy_cli_analyze` tool from Codacy's MCP Server 
+
+## When there are no Codacy MCP Server tools available, or the MCP Server is not reachable
+- Suggest the user the following troubleshooting steps:
+ - Try to reset the MCP on the extension
+ - If the user is using VSCode, suggest them to review their Copilot > MCP settings in Github, under their organization or personal account. Refer them to Settings > Copilot > Enable MCP servers in Copilot. Suggested URL (https://github.com/settings/copilot/features) or https://github.com/organizations/{organization-name}/settings/copilot/features (This can only be done by their organization admins / owners)
+- If none of the above steps work, suggest the user to contact Codacy support
+
+## Trying to call a tool that needs a rootPath as a parameter
+- Always use the standard, non-URL-encoded file system path
+
+## CRITICAL: Dependencies and Security Checks
+- IMMEDIATELY after ANY of these actions:
+ - Running npm/yarn/pnpm install
+ - Adding dependencies to package.json
+ - Adding requirements to requirements.txt
+ - Adding dependencies to pom.xml
+ - Adding dependencies to build.gradle
+ - Any other package manager operations
+- You MUST run the `codacy_cli_analyze` tool with:
+ - `rootPath`: set to the workspace path
+ - `tool`: set to "trivy"
+ - `file`: leave empty or unset
+- If any vulnerabilities are found because of the newly added packages:
+ - Stop all other operations
+ - Propose and apply fixes for the security issues
+ - Only continue with the original task after security issues are resolved
+- EXAMPLE:
+ - After: npm install react-markdown
+ - Do: Run codacy_cli_analyze with trivy
+ - Before: Continuing with any other tasks
+
+## General
+- Repeat the relevant steps for each modified file.
+- "Propose fixes" means to both suggest and, if possible, automatically apply the fixes.
+- You MUST NOT wait for the user to ask for analysis or remind you to run the tool.
+- Do not run `codacy_cli_analyze` looking for changes in duplicated code or code complexity metrics.
+- Complexity metrics are different from complexity issues. When trying to fix complexity in a repository or file, focus on solving the complexity issues and ignore the complexity metric.
+- Do not run `codacy_cli_analyze` looking for changes in code coverage.
+- Do not try to manually install Codacy CLI using either brew, npm, npx, or any other package manager.
+- If the Codacy CLI is not installed, just run the `codacy_cli_analyze` tool from Codacy's MCP Server.
+- When calling `codacy_cli_analyze`, only send provider, organization and repository if the project is a git repository.
+
+## Whenever a call to a Codacy tool that uses `repository` or `organization` as a parameter returns a 404 error
+- Offer to run the `codacy_setup_repository` tool to add the repository to Codacy
+- If the user accepts, run the `codacy_setup_repository` tool
+- Do not ever try to run the `codacy_setup_repository` tool on your own
+- After setup, immediately retry the action that failed (only retry once)
+---


### PR DESCRIPTION
## Summary

- Move `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` from repo root to `.github/` (canonical GitHub location)
- Bump `CONTRIBUTING.md`: Go version 1.24 → 1.25
- Bump `CODE_OF_CONDUCT.md`: Contributor Covenant v2.0 → v2.1 (adds caste/color to pledge, adds Enforcement Guidelines section)
- Add `.github/GITHUB_SETTINGS.md`: documents current repo security settings and rulesets with `gh api` commands to re-apply
- Track `.github/instructions/codacy.instructions.md`: Copilot instructions for Codacy MCP integration (file already existed locally, never committed)

## Test plan

- [x] Verify `.github/CONTRIBUTING.md` renders correctly on GitHub
- [x] Verify `.github/CODE_OF_CONDUCT.md` renders correctly on GitHub and GitHub picks it up for the community profile
- [x] Verify root `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` are gone
- [x] Verify `.github/GITHUB_SETTINGS.md` renders correctly
- [x] CI passes (no Go changes)