### PR TITLE
fix(dockerbuild): support dnf-based base images in macOS preflight containers

### DIFF
--- a/internal/cache/cache_keys.go
+++ b/internal/cache/cache_keys.go
@@ -29,6 +29,7 @@ func EngineKey(cfg *config.Config) string {
 		runtime.GOOS,
 		cfg.Engine.Backend,
 		cfg.Engine.DockerBaseImage,
+		cfg.Game.ResolvedArch(), // container builds are arch-specific
 	)
 }
 

--- a/internal/dockerbuild/deps.go
+++ b/internal/dockerbuild/deps.go
@@ -151,6 +151,23 @@ fi
 `, pkgs)
 }
 
+// PreflightDepsInstallScript returns a shell one-liner that installs UE5 build
+// prerequisites using the image's package manager (apt-get or dnf). Used in
+// macOS pre-flight containers that run against a bare base image before the
+// main engine Dockerfile build starts.
+func PreflightDepsInstallScript() string {
+	aptPkgs := strings.Join(aptBuildPackages, " ")
+	dnfPkgs := strings.Join(dnfBuildPackages, " ")
+	return fmt.Sprintf(
+		`if command -v apt-get >/dev/null 2>&1; then `+
+			`DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y --no-install-recommends %s && rm -rf /var/lib/apt/lists/*; `+
+			`elif command -v dnf >/dev/null 2>&1; then `+
+			`dnf install -y %s && dnf clean all; `+
+			`else echo "ERROR: no supported package manager (need apt-get or dnf)" >&2; exit 1; fi`,
+		aptPkgs, dnfPkgs,
+	)
+}
+
 // formatPackageList formats a slice of package names as indented continuation lines
 // for a shell command (backslash-continuation style).
 func formatPackageList(pkgs []string, indent int) string {

--- a/internal/dockerbuild/macos_preflight.go
+++ b/internal/dockerbuild/macos_preflight.go
@@ -3,7 +3,6 @@ package dockerbuild
 import (
 	"context"
 	"fmt"
-	"strings"
 
 	"github.com/jpvelasco/ludus/internal/runner"
 	"github.com/jpvelasco/ludus/internal/toolchain"
@@ -41,15 +40,11 @@ func LinuxToolchainPresent(engineSourcePath, version string) bool {
 }
 
 // preflightInstallCmd returns a shell command that installs build prerequisites
-// then runs the given script. This ensures preflight containers have the same
-// tools (git, cmake, python3, etc.) that Stage 1 of the engine Dockerfile
-// installs, so Setup.sh and GenerateProjectFiles.sh can run successfully.
+// using the image's package manager (apt-get or dnf), then runs the given
+// script. Supports both Debian/Ubuntu and Amazon Linux/RHEL base images,
+// mirroring the Dockerfile's package-manager detection in installDepsSnippet().
 func preflightInstallCmd(script string) string {
-	pkgs := strings.Join(aptBuildPackages, " ")
-	return fmt.Sprintf(
-		"apt-get update -qq && apt-get install -y --no-install-recommends %s && %s",
-		pkgs, script,
-	)
+	return fmt.Sprintf("%s && %s", PreflightDepsInstallScript(), script)
 }
 
 // RunLinuxToolchainBootstrap runs Setup.sh inside a throwaway Linux container

--- a/internal/dockerbuild/macos_preflight_test.go
+++ b/internal/dockerbuild/macos_preflight_test.go
@@ -108,8 +108,12 @@ func TestRunLinuxGenerateProjectFiles_DryRun(t *testing.T) {
 
 func TestPreflightInstallCmd_ContainsBuildDeps(t *testing.T) {
 	cmd := preflightInstallCmd("bash Setup.sh")
-	if !strings.Contains(cmd, "apt-get install") {
-		t.Error("expected apt-get install in preflight command")
+	// Must handle both apt-get and dnf based images
+	if !strings.Contains(cmd, "apt-get") {
+		t.Error("expected apt-get path in preflight command")
+	}
+	if !strings.Contains(cmd, "dnf") {
+		t.Error("expected dnf path in preflight command for Amazon Linux support")
 	}
 	if !strings.Contains(cmd, "bash Setup.sh") {
 		t.Error("expected script invocation in preflight command")


### PR DESCRIPTION
## Summary

`preflightInstallCmd` hardcoded `apt-get`, which would fail immediately for users whose `engine.dockerBaseImage` is set to `amazonlinux:2023` or another dnf-based image — with `apt-get: not found` before `Setup.sh` even runs.

Adds `PreflightDepsInstallScript()` to `deps.go` that mirrors the package-manager detection already used by `installDepsSnippet()` in the engine Dockerfile (auto-selects `apt-get` or `dnf`). `preflightInstallCmd` now delegates to this function.

## Test plan

- [x] `go test ./...` passes on Linux and Windows CI
- [x] `TestPreflightInstallCmd_ContainsBuildDeps` asserts both apt-get and dnf paths present
- [ ] macOS preflight with `engine.dockerBaseImage: ubuntu:22.04` — apt-get path executes
- [ ] macOS preflight with `engine.dockerBaseImage: amazonlinux:2023` — dnf path executes

Addresses Codex review feedback on PR #245