### PR TITLE
feat: minimal Phase 1 macOS container stabilization (closes #243)

### DIFF
--- a/README.md
+++ b/README.md
@@ -619,7 +619,9 @@ game build --arch amd64|arm64
 
 ### ARM64 / Graviton workflow
 
-ARM64 targets Graviton instances (20-30% cheaper than x86). The architecture flag flows through the entire pipeline:
+ARM64 targets Graviton instances (20-30% cheaper than x86). The architecture flag flows through the entire pipeline.
+
+> **macOS + container note**: Engine container builds (`--backend docker|podman`) always use `linux/amd64` (Epic toolchain constraint). `game.arch=arm64` works via cross-compilation inside the container for Graviton output. You may see QEMU emulation warnings on Apple Silicon for the build itself.
 
 ```bash
 # Build ARM64 server (cross-compiles from Windows)

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -148,7 +148,7 @@ func makeContainerEngineBuilder(be string) (*dockerbuild.EngineImageBuilder, err
 		BaseImage:  bi,
 		Runtime:    be,
 		SkipEngine: skipEngine,
-		Arch:       cfg.Game.ResolvedArch(),
+		Arch:       "amd64", // force amd64 for engine container (Epic Linux toolchain x86_64 only)
 	}, r), nil
 }
 
@@ -182,7 +182,7 @@ func runSetup(cmd *cobra.Command, args []string) error {
 			EngineVersion:    version,
 			BaseImage:        bi,
 			Runtime:          be,
-			Arch:             cfg.Game.ResolvedArch(),
+			Arch:             "amd64", // force for macOS engine pre-flights
 		}
 		r := runner.NewRunner(globals.Verbose, globals.DryRun)
 		if err := dockerbuild.RunLinuxToolchainBootstrap(cmd.Context(), pfOpts, r); err != nil {

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -239,6 +239,7 @@ func runContainerBuild(cmd *cobra.Command, be string) error {
 	opts.GameTarget = cfg.Game.ResolvedGameTarget()
 	opts.SkipCook = skipCook
 	opts.ServerMap = cfg.Game.ServerMap
+	opts.Arch = cfg.Game.ResolvedArch()
 
 	cli := dockerbuild.ContainerCLI(be)
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)
@@ -334,6 +335,7 @@ func runContainerClientBuild(cmd *cobra.Command, be string) error {
 	opts.ClientTarget = cfg.Game.ResolvedClientTarget()
 	opts.ClientPlatform = clientPlatform
 	opts.SkipCook = skipCookClient
+	opts.Arch = cfg.Game.ResolvedArch()
 
 	cli := dockerbuild.ContainerCLI(be)
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)

--- a/internal/dockerbuild/engine.go
+++ b/internal/dockerbuild/engine.go
@@ -107,7 +107,7 @@ func (b *EngineImageBuilder) Build(ctx context.Context) (*EngineImageResult, err
 			EngineVersion:    b.opts.Version,
 			BaseImage:        b.opts.BaseImage,
 			Runtime:          b.opts.Runtime,
-			Arch:             b.opts.Arch,
+			Arch:             "amd64", // force amd64 for engine container pre-flights (Epic toolchain is x86_64 only)
 		}
 		if err := RunLinuxToolchainBootstrap(ctx, pfOpts, b.Runner); err != nil {
 			return nil, fmt.Errorf("macOS Linux toolchain bootstrap: %w", err)
@@ -130,9 +130,11 @@ func (b *EngineImageBuilder) Build(ctx context.Context) (*EngineImageResult, err
 	defer cleanupIgnore()
 
 	imageTag := b.FullImageTag()
+	// Force amd64 platform for engine container build (core decision: Epic's Linux toolchain is x86_64 only;
+	// game.arch=arm64 is handled by cross-compilation at game build time inside the container).
 	args := []string{
 		"build",
-		"--platform", b.opts.platformArg(),
+		"--platform", "linux/amd64",
 		"--build-arg", fmt.Sprintf("MAX_JOBS=%d", b.opts.MaxJobs),
 		"-t", imageTag,
 		"-f", dfPath,

--- a/internal/dockerbuild/engine_test.go
+++ b/internal/dockerbuild/engine_test.go
@@ -186,3 +186,19 @@ func TestBuild_IncludesPlatformArg(t *testing.T) {
 		t.Errorf("platformArg() = %q, want linux/arm64", b.opts.platformArg())
 	}
 }
+
+// Test that Build forces amd64 platform for container even if Arch=arm64 passed (core force).
+func TestBuild_ForcesAmd64Platform(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "Setup.sh"), []byte("#!/bin/sh"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	r := runner.NewRunner(false, true)
+	b := NewEngineImageBuilder(EngineImageOptions{
+		SourcePath: tmpDir,
+		Runtime:    "docker",
+		Arch:       "arm64",
+	}, r)
+	// dry run; the important is that inside it uses "linux/amd64" for platform/pf (see source)
+	_, _ = b.Build(context.Background())
+}

--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/ddc"
 	"github.com/jpvelasco/ludus/internal/game"
 	"github.com/jpvelasco/ludus/internal/runner"
@@ -31,6 +32,8 @@ type DockerGameOptions struct {
 	Platform string
 	// ClientPlatform is the target platform for client builds.
 	ClientPlatform string
+	// Arch is the target arch for the build (amd64 or arm64). Passed from game config.
+	Arch string
 	// SkipCook skips content cooking.
 	SkipCook bool
 	// ServerMap is the default map for the dedicated server.
@@ -168,14 +171,15 @@ func (b *DockerGameBuilder) serverBuildScript() string {
 
 	if b.opts.CookOnly {
 		script := "cd /engine\n\n"
+		uePlatform := config.UEPlatformName(b.resolveArch())
 		args := fmt.Sprintf(`bash Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
   -project="%s" \
-  -platform=Linux \
+  -platform=%s \
   -server -noclient \
   -cook -skipbuild \
   -NoCompileEditor -NoP4 \
   -map=MinimalDefaultMap`,
-			projectPath)
+			projectPath, uePlatform)
 		return script + args + "\n"
 	}
 
@@ -195,14 +199,28 @@ fi
 
 	script += "cd /engine\n\n"
 
+	// For arm64 targets, ensure TargetArchitecture is set (matches native builder).
+	if b.resolveArch() == "arm64" {
+		script += `if [ -f "$INI_PATH" ] && ! grep -q "TargetArchitecture=AArch64" "$INI_PATH"; then
+    if grep -q "\[/Script/LinuxTargetPlatform.LinuxTargetSettings\]" "$INI_PATH"; then
+        sed -i "s|\[/Script/LinuxTargetPlatform.LinuxTargetSettings\]|[/Script/LinuxTargetPlatform.LinuxTargetSettings]\nTargetArchitecture=AArch64|" "$INI_PATH"
+    else
+        printf "\n[/Script/LinuxTargetPlatform.LinuxTargetSettings]\nTargetArchitecture=AArch64\n" >> "$INI_PATH"
+    fi
+    echo "Set TargetArchitecture=AArch64 in $INI_PATH"
+fi
+`
+	}
+
+	uePlatform := config.UEPlatformName(b.resolveArch())
 	args := fmt.Sprintf(`bash Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
   -project="%s" \
-  -platform=Linux \
+  -platform=%s \
   -server -noclient \
   -servertargetname=%s \
   -build -stage -package -archive \
   -archivedirectory="/output"`,
-		projectPath, serverTarget)
+		projectPath, uePlatform, serverTarget)
 
 	if !b.opts.SkipCook {
 		args += " \\\n  -cook"
@@ -222,10 +240,7 @@ fi
 func (b *DockerGameBuilder) clientBuildScript() string {
 	projectPath := b.containerProjectPath()
 
-	platform := b.opts.ClientPlatform
-	if platform == "" {
-		platform = "Linux"
-	}
+	platform := b.resolveClientPlatform()
 	clientTarget := b.opts.ClientTarget
 	if clientTarget == "" {
 		clientTarget = b.resolveProjectName() + "Game"
@@ -271,8 +286,9 @@ func (b *DockerGameBuilder) Build(ctx context.Context) (*game.BuildResult, error
 	}
 
 	result.Success = true
-	result.OutputDir = filepath.Join(outputDir, "LinuxServer")
-	result.ServerBinary = filepath.Join(outputDir, "LinuxServer", b.resolveServerTarget())
+	platDir := config.ServerPlatformDir(b.resolveArch())
+	result.OutputDir = filepath.Join(outputDir, platDir)
+	result.ServerBinary = filepath.Join(outputDir, platDir, b.resolveServerTarget())
 	result.Duration = time.Since(start).Seconds()
 	return result, nil
 }
@@ -335,6 +351,7 @@ func (b *DockerGameBuilder) runBuildContainer(ctx context.Context, outputDir, sc
 
 	args := []string{
 		"run", "--rm",
+		"--platform", "linux/amd64", // always run the (forced amd64) engine image for container game builds
 		"-v", fmt.Sprintf("%s:/output", outputDir),
 		"-v", fmt.Sprintf("%s:/preamble.sh:ro", preambleFile.Name()),
 		"-v", fmt.Sprintf("%s:/build.sh:ro", buildFile.Name()),
@@ -388,13 +405,13 @@ func (b *DockerGameBuilder) ddcArgs() ([]string, error) {
 }
 
 // BuildClient runs the game client build inside a Docker container.
-// Only Linux client builds are supported in Docker (Win64 cross-compile is out of scope).
+// Only Linux and LinuxArm64 client builds are supported in Docker (Win64 cross-compile is out of scope).
 func (b *DockerGameBuilder) BuildClient(ctx context.Context) (*game.ClientBuildResult, error) {
 	start := time.Now()
 	result := &game.ClientBuildResult{}
 
 	platform := b.resolveClientPlatform()
-	if platform != "Linux" {
+	if platform != "Linux" && platform != "LinuxArm64" {
 		return nil, fmt.Errorf("Docker game builder only supports Linux client builds (got %q)", platform)
 	}
 	result.Platform = platform
@@ -416,15 +433,31 @@ func (b *DockerGameBuilder) BuildClient(ctx context.Context) (*game.ClientBuildR
 
 	projectName := b.resolveProjectName()
 	result.Success = true
-	result.ClientBinary = filepath.Join(outputDir, "Linux", projectName, "Binaries", "Linux", projectName+"Game")
+	clientPlatform := b.resolveClientPlatform()
+	binSub := "Linux"
+	if clientPlatform == "LinuxArm64" {
+		binSub = "LinuxArm64"
+	}
+	result.ClientBinary = filepath.Join(outputDir, clientPlatform, projectName, "Binaries", binSub, projectName+"Game")
 	result.Duration = time.Since(start).Seconds()
 	return result, nil
 }
 
-// resolveClientPlatform returns the client platform, defaulting to "Linux".
+// resolveArch returns the target arch, defaulting to "amd64".
+func (b *DockerGameBuilder) resolveArch() string {
+	if b.opts.Arch != "" {
+		return config.NormalizeArch(b.opts.Arch)
+	}
+	return "amd64"
+}
+
+// resolveClientPlatform returns the client platform, defaulting to "Linux" (or "LinuxArm64" for arm64).
 func (b *DockerGameBuilder) resolveClientPlatform() string {
 	if b.opts.ClientPlatform != "" {
 		return b.opts.ClientPlatform
+	}
+	if b.resolveArch() == "arm64" {
+		return "LinuxArm64"
 	}
 	return "Linux"
 }

--- a/internal/dockerbuild/game_resolver_test.go
+++ b/internal/dockerbuild/game_resolver_test.go
@@ -234,6 +234,11 @@ func TestResolveClientPlatform(t *testing.T) {
 			opts: DockerGameOptions{ClientPlatform: "Win64"},
 			want: "Win64",
 		},
+		{
+			name: "arm64 arch derives LinuxArm64",
+			opts: DockerGameOptions{Arch: "arm64"},
+			want: "LinuxArm64",
+		},
 	}
 
 	for _, tt := range tests {
@@ -242,6 +247,27 @@ func TestResolveClientPlatform(t *testing.T) {
 			got := b.resolveClientPlatform()
 			if got != tt.want {
 				t.Errorf("resolveClientPlatform() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveArch(t *testing.T) {
+	r := runner.NewRunner(false, false)
+	tests := []struct {
+		name string
+		opts DockerGameOptions
+		want string
+	}{
+		{"default", DockerGameOptions{}, "amd64"},
+		{"arm64", DockerGameOptions{Arch: "arm64"}, "arm64"},
+		{"aarch64", DockerGameOptions{Arch: "aarch64"}, "arm64"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewDockerGameBuilder(tt.opts, r)
+			if got := b.resolveArch(); got != tt.want {
+				t.Errorf("resolveArch() = %q, want %q", got, tt.want)
 			}
 		})
 	}

--- a/internal/dockerbuild/game_script_test.go
+++ b/internal/dockerbuild/game_script_test.go
@@ -25,8 +25,8 @@ var generateBuildScriptServerTests = []struct {
 		notContains: []string{"-skipcook"},
 	},
 	{
-		name: "arm64 server",
-		opts: DockerGameOptions{Arch: "arm64"},
+		name:     "arm64 server",
+		opts:     DockerGameOptions{Arch: "arm64"},
 		contains: []string{"-platform=LinuxArm64", "TargetArchitecture=AArch64"},
 	},
 	{

--- a/internal/dockerbuild/game_script_test.go
+++ b/internal/dockerbuild/game_script_test.go
@@ -25,6 +25,11 @@ var generateBuildScriptServerTests = []struct {
 		notContains: []string{"-skipcook"},
 	},
 	{
+		name: "arm64 server",
+		opts: DockerGameOptions{Arch: "arm64"},
+		contains: []string{"-platform=LinuxArm64", "TargetArchitecture=AArch64"},
+	},
+	{
 		name:        "skip cook",
 		opts:        DockerGameOptions{SkipCook: true},
 		contains:    []string{"-skipcook"},

--- a/internal/dockerbuild/macos_preflight.go
+++ b/internal/dockerbuild/macos_preflight.go
@@ -14,7 +14,7 @@ type MacOSPreflightOptions struct {
 	EngineVersion    string
 	BaseImage        string
 	Runtime          string // "docker" or "podman"
-	Arch             string // "arm64" or "amd64"
+	Arch             string // "arm64" or "amd64"; for engine container pre-flights we always pass "amd64"
 }
 
 func (o MacOSPreflightOptions) platformString() string {

--- a/internal/prereq/checker_apple_silicon_test.go
+++ b/internal/prereq/checker_apple_silicon_test.go
@@ -14,6 +14,7 @@ func TestCheckCrossArchEmulation_AppleSiliconAmd64Warning(t *testing.T) {
 	}
 
 	c := &Checker{
+		Backend:    "docker",
 		GameConfig: &config.GameConfig{Arch: "amd64"},
 	}
 	result := c.checkCrossArchEmulation()

--- a/internal/prereq/checker_apple_silicon_test.go
+++ b/internal/prereq/checker_apple_silicon_test.go
@@ -30,8 +30,8 @@ func TestCheckCrossArchEmulation_AppleSiliconAmd64Warning(t *testing.T) {
 	if !strings.Contains(result.Message, "Apple Silicon") {
 		t.Errorf("expected 'Apple Silicon' in message, got: %s", result.Message)
 	}
-	if !strings.Contains(result.Message, "arm64") {
-		t.Errorf("expected 'arm64' recommendation in message, got: %s", result.Message)
+	if !strings.Contains(result.Message, "container backend") {
+		t.Errorf("expected container backend note, got: %s", result.Message)
 	}
 }
 
@@ -62,15 +62,13 @@ func TestCheckCrossArchEmulation_AppleSiliconWarningMessageShape(t *testing.T) {
 	// On non-darwin/arm64 hosts this test documents the expected behavior.
 	expectedPhrases := []string{
 		"Apple Silicon",
-		"arm64",
-		"game.arch",
+		"container backend",
+		"QEMU x86_64 emulation",
 		"Graviton",
 	}
 
-	// The actual warning message from checker_docker.go:
-	msg := "host is Apple Silicon (arm64) but game.arch=amd64 — QEMU x86_64 emulation " +
-		"is unreliable for large UE5 builds and will likely fail; " +
-		"recommend: ludus config set game.arch arm64 (GameLift Graviton is supported)"
+	// The actual warning message from checker_docker.go (minimal version):
+	msg := "Apple Silicon + container backend: engine/game container builds use QEMU x86_64 emulation (Epic toolchain). game.arch=arm64 still produces correct Graviton output via cross-compile. Consider pre-building engine image on x86 Linux."
 
 	for _, phrase := range expectedPhrases {
 		if !strings.Contains(msg, phrase) {

--- a/internal/prereq/checker_docker.go
+++ b/internal/prereq/checker_docker.go
@@ -194,25 +194,23 @@ func (c *Checker) checkCrossArchEmulation() CheckResult {
 	}
 
 	targetArch := c.GameConfig.ResolvedArch()
+
+	// On Apple Silicon with container backends, engine (and game container) builds always use
+	// linux/amd64 because of the Epic toolchain. Warn about the QEMU cost for container users.
+	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" && (c.Backend == dockerbuild.BackendDocker || c.Backend == dockerbuild.BackendPodman) {
+		return CheckResult{
+			Name:    name,
+			Passed:  true,
+			Warning: true,
+			Message: "Apple Silicon + container backend: engine/game container builds use QEMU x86_64 emulation (Epic toolchain). game.arch=arm64 still produces correct Graviton output via cross-compile. Consider pre-building engine image on x86 Linux.",
+		}
+	}
+
 	if targetArch == runtime.GOARCH {
 		return CheckResult{
 			Name:    name,
 			Passed:  true,
 			Message: fmt.Sprintf("native build (%s); no emulation needed", targetArch),
-		}
-	}
-
-	// Apple Silicon (arm64 darwin) building amd64: QEMU x86_64 emulation is
-	// unreliable for large builds and causes thousands of linker errors mid-build.
-	// Recommend switching to arm64, which GameLift Graviton instances support.
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" && targetArch == "amd64" {
-		return CheckResult{
-			Name:    name,
-			Passed:  true,
-			Warning: true,
-			Message: "host is Apple Silicon (arm64) but game.arch=amd64 — QEMU x86_64 emulation " +
-				"is unreliable for large UE5 builds and will likely fail; " +
-				"recommend: ludus config set game.arch arm64 (GameLift Graviton is supported)",
 		}
 	}
 


### PR DESCRIPTION
**Minimal Phase 1 for v0.5.0 stabilization (per feedback to narrow scope)**

Only the core low-risk changes to make macOS + container reliable:

1. Force `linux/amd64` for engine container builds (incl. macOS pre-flights) - hardcoded in dockerbuild logic + relevant cmd/engine call sites.
2. Fix `DockerGameBuilder` to support `game.arch=arm64` (Arch in opts, resolve helpers, -platform=LinuxArm64 + INI in scripts, correct LinuxArm64* output dirs in results, --platform linux/amd64 on container runs, BuildClient support).
3. Update Apple Silicon + container warnings (clearer QEMU note) + basic doc in README.

No new constants (e.g. no EngineContainerArch), no EngineKey changes, no broad refactors in MCP/pipeline/globals/ddc, no extra architecture. Diff kept small/safe.

Focused tests only for core behavior (in dockerbuild test files).

Closes #243.