### PR TITLE
macOS Stabilization — Warnings + Doctor Improvements (Apple Silicon + container)

### DIFF
--- a/cmd/doctor/checks_env.go
+++ b/cmd/doctor/checks_env.go
@@ -156,6 +156,6 @@ func checkAppleSiliconContainer(cfg *config.Config) diagnostic {
 	}
 
 	d.status = "warn"
-	d.message = "container backend on Apple Silicon: engine + game builds use x86_64 QEMU emulation (Epic provides only x86_64 Linux toolchain). game.arch=arm64 still produces correct Graviton output via cross-compile. Emulation has a performance cost."
+	d.message = "container backend on Apple Silicon: engine + game builds use QEMU x86_64 emulation (due to Epic's toolchain). game.arch=arm64 still produces correct Graviton server output via cross-compilation. Emulation has a performance cost. Recommended: pre-build engine on x86_64 Linux + registry for speed."
 	return d
 }

--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -178,14 +178,12 @@ func TestCheckAppleSiliconContainer(t *testing.T) {
 				}
 				return "ok"
 			}(),
-			wantContains: []string{
-				func() string {
-					if isAS {
-						return "Apple Silicon"
-					}
-					return "not Apple Silicon"
-				}(),
-			},
+			wantContains: func() []string {
+				if isAS {
+					return []string{"Apple Silicon", "Recommended"}
+				}
+				return []string{"not Apple Silicon"}
+			}(),
 		},
 		{
 			name: "podman backend",
@@ -196,14 +194,12 @@ func TestCheckAppleSiliconContainer(t *testing.T) {
 				}
 				return "ok"
 			}(),
-			wantContains: []string{
-				func() string {
-					if isAS {
-						return "Apple Silicon"
-					}
-					return "not Apple Silicon"
-				}(),
-			},
+			wantContains: func() []string {
+				if isAS {
+					return []string{"Apple Silicon", "Recommended"}
+				}
+				return []string{"not Apple Silicon"}
+			}(),
 		},
 	}
 

--- a/internal/prereq/checker_apple_silicon_test.go
+++ b/internal/prereq/checker_apple_silicon_test.go
@@ -69,7 +69,7 @@ func TestCheckCrossArchEmulation_AppleSiliconWarningMessageShape(t *testing.T) {
 	}
 
 	// The actual warning message from checker_docker.go (updated minimal version):
-	msg := "Apple Silicon + container backend: engine + game container builds use QEMU x86_64 emulation (Epic provides only x86_64 Linux toolchain). game.arch=arm64 still produces correct Graviton output via cross-compile. Emulation has a performance cost."
+	msg := "Apple Silicon + container backend: engine + game container builds use QEMU x86_64 emulation (due to Epic's toolchain). game.arch=arm64 still produces correct Graviton (arm64) server output via cross-compilation. Emulation has a performance cost."
 
 	for _, phrase := range expectedPhrases {
 		if !strings.Contains(msg, phrase) {

--- a/internal/prereq/checker_docker.go
+++ b/internal/prereq/checker_docker.go
@@ -202,7 +202,7 @@ func (c *Checker) checkCrossArchEmulation() CheckResult {
 			Name:    name,
 			Passed:  true,
 			Warning: true,
-			Message: "Apple Silicon + container backend: engine + game container builds use x86_64 QEMU emulation (Epic provides only x86_64 Linux toolchain). game.arch=arm64 still produces correct Graviton output via cross-compile. Emulation has a performance cost.",
+			Message: "Apple Silicon + container backend: engine + game container builds use QEMU x86_64 emulation (due to Epic's toolchain). game.arch=arm64 still produces correct Graviton (arm64) server output via cross-compilation. Emulation has a performance cost.",
 		}
 	}
 


### PR DESCRIPTION
**macOS Stabilization — Warnings + `ludus doctor` Improvements**

Focused follow-up after #250 (engine force + game builder) and #252 (#249 dotnet fix). Implements the next piece per the explicit task: improve warnings/error messages and `ludus doctor` output specifically for macOS + container backends (Apple Silicon users).

**Specific Items delivered:**
1. Updated Apple Silicon / cross-arch warning in `internal/prereq/checker_docker.go`:
   - Clear and honest about QEMU emulation *cost* for engine + game container builds on Apple Silicon (due to Epic's toolchain).
   - Graviton (`arm64`) server output still supported via cross-compilation.
   - Helpful, not alarming tone. (Only the user-facing Message string was changed.)
2. Improved `ludus doctor` for macOS:
   - Better platform-aware output via `checkAppleSiliconContainer` (in `cmd/doctor/checks_env.go`) when container backend used on Apple Silicon.
   - Surfaces emulation cost + recommended workflow ("Recommended: pre-build engine on x86_64 Linux + registry for speed.").

**Strict scope followed:** Only warnings + doctor + relevant tests. No build logic, no docs, no Phase 2. 4 files touched.

**Files changed:**
- `internal/prereq/checker_docker.go` (warning message)
- `internal/prereq/checker_apple_silicon_test.go` (shape test literal sync)
- `cmd/doctor/checks_env.go` (doctor message + workflow)
- `cmd/doctor/doctor_test.go` (extend table test for "Recommended" phrase)

(`cmd/doctor/doctor.go` already had the append after `checkDockerDaemon()` in the right place; zero diff.)

**Exact messages:**

Prereq (Cross-Arch Emulation warning):
> Apple Silicon + container backend: engine + game container builds use QEMU x86_64 emulation (due to Epic's toolchain). game.arch=arm64 still produces correct Graviton (arm64) server output via cross-compilation. Emulation has a performance cost.

Doctor (Apple Silicon Container):
> container backend on Apple Silicon: engine + game builds use QEMU x86_64 emulation (due to Epic's toolchain). game.arch=arm64 still produces correct Graviton server output via cross-compilation. Emulation has a performance cost. Recommended: pre-build engine on x86_64 Linux + registry for speed.

**Validation performed (all clean before push):**
- `go test ./internal/prereq ./cmd/doctor -count=1` (and -v) → both packages PASS
- `golangci-lint run ./...` → 0 issues
- `go build -o ludus.exe -v .` → success
- `go vet ./...` → clean
- `gofmt -l` (edited files) → (no files listed)
- Manual: `go run . doctor` (this non-AS host) → "[OK]   Apple Silicon Container        not Apple Silicon"
- Pre-commit simulation (build + lint + test + fmt + vet) covered.

Codacy: relied on golangci-lint clean (0 issues) + go vet; GH Codacy check expected to report 0 new issues for these files. No complexity or lint problems introduced.

**Diff summary:** 4 files, small net change (string updates + minimal test extensions for coverage of the workflow phrase).

Part of #243 (warnings + doctor piece). Follows merged #250 and #252. Small, low-risk, focused.

---

Ready for review. (Draft per workflow; will mark ready after CI green.)