### PR TITLE
fix: reduce cyclomatic complexity for Codacy (runSetup, checkOS test, checkCrossArchEmulation)

### DIFF
--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -1,6 +1,7 @@
 package engine
 
 import (
+	"context"
 	"fmt"
 	"path/filepath"
 	"runtime"
@@ -163,37 +164,50 @@ func runSetup(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// On macOS with a container backend, also run the Linux pre-flights so
-	// the engine tree is fully prepared for container builds.
-	be := resolveBackend()
-	if runtime.GOOS == "darwin" && dockerbuild.IsContainerBackend(be) {
-		cfg := globals.Cfg
-		sourcePath := uePath
-		if sourcePath == "" {
-			sourcePath = cfg.Engine.SourcePath
-		}
-		bi := baseImage
-		if bi == "" {
-			bi = cfg.Engine.DockerBaseImage
-		}
-		version, _ := toolchain.DetectEngineVersion(sourcePath, cfg.Engine.Version)
-		pfOpts := dockerbuild.MacOSPreflightOptions{
-			EngineSourcePath: sourcePath,
-			EngineVersion:    version,
-			BaseImage:        bi,
-			Runtime:          be,
-			Arch:             "amd64", // force amd64 for pre-flights (Epic toolchain)
-		}
-		r := runner.NewRunner(globals.Verbose, globals.DryRun)
-		if err := dockerbuild.RunLinuxToolchainBootstrap(cmd.Context(), pfOpts, r); err != nil {
-			return fmt.Errorf("Linux toolchain bootstrap: %w", err)
-		}
-		if err := dockerbuild.RunLinuxGenerateProjectFiles(cmd.Context(), pfOpts, r); err != nil {
-			return fmt.Errorf("Linux GenerateProjectFiles: %w", err)
-		}
+	if err := maybeRunMacOSPreflights(cmd.Context()); err != nil {
+		return err
 	}
 
 	fmt.Println("\nNext: ludus engine build")
+	return nil
+}
+
+// maybeRunMacOSPreflights runs the Linux toolchain bootstrap + GenerateProjectFiles
+// inside a throwaway container when on macOS + container backend. This ensures the
+// engine source tree has the Linux prerequisites even though the actual engine build
+// will happen in a linux/amd64 container later.
+func maybeRunMacOSPreflights(ctx context.Context) error {
+	be := resolveBackend()
+	if runtime.GOOS != "darwin" || !dockerbuild.IsContainerBackend(be) {
+		return nil
+	}
+
+	cfg := globals.Cfg
+	sourcePath := uePath
+	if sourcePath == "" {
+		sourcePath = cfg.Engine.SourcePath
+	}
+	bi := baseImage
+	if bi == "" {
+		bi = cfg.Engine.DockerBaseImage
+	}
+	version, _ := toolchain.DetectEngineVersion(sourcePath, cfg.Engine.Version)
+
+	pfOpts := dockerbuild.MacOSPreflightOptions{
+		EngineSourcePath: sourcePath,
+		EngineVersion:    version,
+		BaseImage:        bi,
+		Runtime:          be,
+		Arch:             "amd64", // force amd64 for pre-flights (Epic toolchain)
+	}
+
+	r := runner.NewRunner(globals.Verbose, globals.DryRun)
+	if err := dockerbuild.RunLinuxToolchainBootstrap(ctx, pfOpts, r); err != nil {
+		return fmt.Errorf("Linux toolchain bootstrap: %w", err)
+	}
+	if err := dockerbuild.RunLinuxGenerateProjectFiles(ctx, pfOpts, r); err != nil {
+		return fmt.Errorf("Linux GenerateProjectFiles: %w", err)
+	}
 	return nil
 }
 

--- a/internal/prereq/checker_docker.go
+++ b/internal/prereq/checker_docker.go
@@ -195,9 +195,10 @@ func (c *Checker) checkCrossArchEmulation() CheckResult {
 
 	targetArch := c.GameConfig.ResolvedArch()
 
-	// On Apple Silicon + container, engine+game builds use QEMU x86_64 emulation (Epic toolchain only).
-	// arm64/Graviton output still supported via cross-compile.
-	if runtime.GOOS == "darwin" && runtime.GOARCH == "arm64" && (c.Backend == dockerbuild.BackendDocker || c.Backend == dockerbuild.BackendPodman) {
+	// On Apple Silicon + container backend, engine+game container builds are always
+	// emulated (x86_64 QEMU) because Epic ships only an x86_64 Linux toolchain.
+	// arm64/Graviton server output is still produced via cross-compilation inside it.
+	if c.isAppleSiliconContainerBackend() {
 		return CheckResult{
 			Name:    name,
 			Passed:  true,
@@ -245,6 +246,15 @@ func (c *Checker) resolveEmulationCLI() (string, bool) {
 		return dockerbuild.BackendPodman, true
 	}
 	return "", false
+}
+
+// isAppleSiliconContainerBackend reports whether we are on darwin/arm64 using
+// a container backend. In this case engine (and game) container builds run
+// under QEMU x86_64 emulation due to Epic's Linux toolchain requirements.
+func (c *Checker) isAppleSiliconContainerBackend() bool {
+	return runtime.GOOS == "darwin" &&
+		runtime.GOARCH == "arm64" &&
+		(c.Backend == dockerbuild.BackendDocker || c.Backend == dockerbuild.BackendPodman)
 }
 
 // checkPodmanEmulation checks QEMU emulation availability via podman.

--- a/internal/prereq/checker_os_test.go
+++ b/internal/prereq/checker_os_test.go
@@ -14,32 +14,30 @@ func TestCheckOS_CurrentPlatform(t *testing.T) {
 		t.Errorf("expected name 'Operating System', got: %s", result.Name)
 	}
 
-	switch runtime.GOOS {
-	case "linux":
-		if !result.Passed {
-			t.Errorf("expected pass on linux, got: %s", result.Message)
+	// Table of expectations for the live checkOS() call on the current platform.
+	// This ensures the real implementation path is exercised on CI runners (linux, windows, darwin).
+	expects := map[string]struct {
+		passed  bool
+		contain string
+	}{
+		"linux":   {true, "Linux"},
+		"windows": {true, "Windows"},
+		"darwin":  {true, "macOS"},
+	}
+
+	if ex, ok := expects[runtime.GOOS]; ok {
+		if result.Passed != ex.passed {
+			t.Errorf("expected Passed=%v on %s, got: %s", ex.passed, runtime.GOOS, result.Message)
 		}
-		if !strings.Contains(result.Message, "Linux") {
-			t.Errorf("expected 'Linux' in message, got: %s", result.Message)
+		if !strings.Contains(result.Message, ex.contain) {
+			t.Errorf("expected %q in message, got: %s", ex.contain, result.Message)
 		}
-	case "windows":
-		if !result.Passed {
-			t.Errorf("expected pass on windows, got: %s", result.Message)
-		}
-		if !strings.Contains(result.Message, "Windows") {
-			t.Errorf("expected 'Windows' in message, got: %s", result.Message)
-		}
-	case "darwin":
-		if !result.Passed {
-			t.Errorf("expected pass on darwin, got: %s", result.Message)
-		}
-		if !strings.Contains(result.Message, "macOS") {
-			t.Errorf("expected 'macOS' in message, got: %s", result.Message)
-		}
-	default:
-		if result.Passed {
-			t.Errorf("expected fail on unsupported OS %s", runtime.GOOS)
-		}
+		return
+	}
+
+	// Unsupported platform (hit only if running on an exotic OS).
+	if result.Passed {
+		t.Errorf("expected fail on unsupported OS %s", runtime.GOOS)
 	}
 }
 


### PR DESCRIPTION
Addresses the three MEDIUM Code complexity issues reported by Codacy (Lizard):

1. `cmd/engine/engine.go:runSetup` (cyclomatic 9 → ≤ 8)
   - Extracted the macOS container preflight logic (the Linux bootstrap + GenerateProjectFiles calls) into a new helper `maybeRunMacOSPreflights`.
   - runSetup is now a small linear sequence of setup + conditional preflight + next hint.

2. `internal/prereq/checker_os_test.go:TestCheckOS_CurrentPlatform` (12 → ≤ 8)
   - Replaced the large switch over runtime.GOOS (with duplicated ifs in each arm) with a small expectations map + linear lookup + early return for the happy path.
   - Still exercises the *live* `checkOS()` on the current platform (important for CI runners) while the sibling table test covers fabricated messages for other OSes.

3. `internal/prereq/checker_docker.go:checkCrossArchEmulation` (9 → ≤ 8)
   - Extracted the compound Apple Silicon + container condition into a tiny predicate helper `isAppleSiliconContainerBackend()`.
   - Main function now has a simple `if c.isAppleSiliconContainerBackend() { return warning }`.
   - The helper + comment make the special case self-documenting. (Preserves the exact warning text from #253.)

**Validation (clean):**
- `go test ./cmd/engine ./internal/prereq -count=1` → PASS
- `golangci-lint run ./...` → 0 issues
- `go build -o ludus.exe .` → success
- `go vet ./...` → clean
- `gofmt -l` (edited files) → (none)

No behavior change. These were pure complexity-reduction refactors (smaller focused functions, simpler control flow in the test).

This cleans up findings surfaced after the recent macOS stabilization PRs (#250/#251/#252/#253).