### PR TITLE
macOS Stabilization — Documentation Pass (macOS Support in README)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,6 +396,65 @@ engine:
   backend: "wsl2"
 ```
 
+### macOS Support
+
+Ludus fully supports macOS (Apple Silicon and Intel) using container backends (`--backend docker` or `--backend podman`). This is the primary supported path for producing Linux dedicated servers from a Mac.
+
+Native engine builds on macOS target macOS, not Linux. Container builds use Linux base images and the official Linux toolchain inside the container.
+
+#### Recommended workflow for Apple Silicon users targeting Graviton
+
+On Apple Silicon (`darwin/arm64`):
+
+- **Engine container builds** always target `linux/amd64`. This is required because Epic only ships an x86_64 Linux toolchain. The build runs under QEMU user-mode emulation, which works but has a performance cost (slower than native x86_64 Linux or WSL2).
+
+- **Game builds** with `--arch arm64` (for Graviton) cross-compile inside the emulated amd64 environment. The resulting `LinuxArm64Server` binaries are correct and deploy to Graviton instances.
+
+- The engine image itself stays amd64 even if you later build an arm64 game container image.
+
+To avoid the QEMU cost for engine builds on your Mac, build the engine image once on a native x86_64 Linux machine or CI runner, push to a registry, and point at the pre-built image:
+
+```yaml
+engine:
+  backend: "docker"
+  dockerImage: "123456789.dkr.ecr.us-east-1.amazonaws.com/ludus-engine:5.6.1"
+```
+
+Subsequent game builds and runs will skip the engine stage entirely.
+
+#### Common one-command examples
+
+```bash
+# Build engine inside container (QEMU on Apple Silicon)
+./ludus engine build --backend docker --verbose
+
+# Same with Podman
+./ludus engine build --backend podman --verbose
+
+# Build game server for Graviton (cross-compile inside the amd64 container)
+./ludus game build --arch arm64 --backend docker --verbose
+
+# Build the final container image for the packaged server
+./ludus container build --verbose
+./ludus container push --verbose
+
+# Full pipeline targeting arm64/Graviton
+./ludus run --backend docker --arch arm64 --verbose
+```
+
+Set sensible defaults in `ludus.yaml`:
+
+```yaml
+engine:
+  backend: "docker"
+game:
+  arch: "arm64"
+```
+
+See the [ARM64 / Graviton workflow](#arm64--graviton-workflow) for deployment commands (e.g. `ludus deploy fleet --with-session` automatically selects Graviton instance types).
+
+Run `ludus doctor` for macOS + container environment checks.
+
 ### DDC (Derived Data Cache)
 
 One of the biggest time sinks in UE5 dedicated server builds is a cold Derived Data Cache (DDC). Every container run previously started with a completely cold cache, forcing hours of shader compilation and asset derivation.
@@ -621,7 +680,7 @@ game build --arch amd64|arm64
 
 ARM64 targets Graviton instances (20-30% cheaper than x86). The architecture flag flows through the entire pipeline.
 
-> **macOS + container note**: Engine container builds (`--backend docker|podman`) always use `linux/amd64` (Epic toolchain constraint). `game.arch=arm64` works via cross-compilation inside the container for Graviton output. You may see QEMU emulation warnings on Apple Silicon for the build itself.
+> **macOS + container**: See the [macOS Support](#macos-support) section for the recommended Apple Silicon + Graviton workflow, QEMU emulation cost details, and copy-paste examples.
 
 ```bash
 # Build ARM64 server (cross-compiles from Windows)


### PR DESCRIPTION
**macOS Stabilization — Documentation Pass**

Focused docs-only PR per the task (PRs #250/#252/#253 merged). Updates only README.md.

**Specific Items delivered:**
1. Added dedicated `### macOS Support` section (under ## Usage, after WSL2 for logical grouping with backend docs, before DDC). Includes:
   - Clear explanation of macOS support via container backends.
   - Recommended workflow for Apple Silicon users targeting Graviton: `amd64` engine image + cross-compile for `arm64` servers.
   - Explicit mention of QEMU emulation cost for engine builds on Apple Silicon.
   - Clear one-command examples for engine build, game build with `--arch arm64`, and container build (docker + podman variants, full `run`).
   - Config example + links to related sections (`ludus doctor`, ARM64 deploy).
2. Expanded the old buried note in the ARM64/Graviton section to a short pointer to the new section (avoids duplication, minimal).

**Strict rules followed:**
- Minimal & focused: 1 file only (`README.md`), +60/-1 lines net.
- No code, tests, warnings, or other docs touched.
- Clear, friendly, professional language.
- Full validation run *before* PR (see below).

**Validation (all clean):**
- `golangci-lint run ./...` → 0 issues
- `go test ./...` → all packages PASS
- `go build -o ludus.exe .` → success
- `go vet ./...` → clean
- Pre-commit simulation (build + lint + test steps from `.hooks/pre-commit`) → passed
- Codacy: no new issues (existing `codacy_issues.json` unrelated to .md; golangci clean as proxy)
- `git diff --stat` → 1 file, 60 insertions, 1 deletion (small/clean)

**New section (excerpt):**

```markdown
### macOS Support

Ludus fully supports macOS (Apple Silicon and Intel) using container backends (`--backend docker` or `--backend podman`). This is the primary supported path for producing Linux dedicated servers from a Mac.

#### Recommended workflow for Apple Silicon users targeting Graviton

On Apple Silicon (`darwin/arm64`):

- **Engine container builds** always target `linux/amd64`. ... QEMU user-mode emulation, which works but has a performance cost ...

- **Game builds** with `--arch arm64` (for Graviton) cross-compile inside the emulated amd64 environment. ...

To avoid the QEMU cost ... use a pre-built `dockerImage` ...

#### Common one-command examples

```bash
# Build engine inside container (QEMU on Apple Silicon)
./ludus engine build --backend docker --verbose

# Build game server for Graviton (cross-compile inside the amd64 container)
./ludus game build --arch arm64 --backend docker --verbose

# Build the final container image for the packaged server
./ludus container build --verbose
./ludus container push --verbose

# Full pipeline targeting arm64/Graviton
./ludus run --backend docker --arch arm64 --verbose
```
...
```

**Pointer added in ARM64 section:**
> **macOS + container**: See the [macOS Support](#macos-support) section for the recommended Apple Silicon + Graviton workflow, QEMU emulation cost details, and copy-paste examples.

Part of #243 (macOS stabilization docs piece). Follows merged #250/#252/#253. Pure documentation change.

---

Draft per workflow. Ready for review once CI green (will be docs-only, no code impact).