### PR TITLE
macOS Stabilization — Test Coverage (Phase 4)

### DIFF
--- a/internal/dockerbuild/engine_test.go
+++ b/internal/dockerbuild/engine_test.go
@@ -1,6 +1,7 @@
 package dockerbuild
 
 import (
+	"bytes"
 	"context"
 	"os"
 	"path/filepath"
@@ -187,13 +188,54 @@ func TestBuild_IncludesPlatformArg(t *testing.T) {
 	}
 }
 
-// TestBuild_ForcesAmd64Platform: even with Arch=arm64 in opts, Build forces amd64 (for preflights + image).
+// TestBuild_ForcesAmd64Platform tests that engine container builds (used on macOS
+// + docker/podman backends) always force --platform linux/amd64 in the runner
+// command (Epic x86_64-only toolchain; arm64 output via cross at game layer).
+// Table covers arm64 input (the new behavior) + amd64 (no regression).
+// macOS preflight amd64 force (darwin branch + hardcoded "amd64" in engine.go:110)
+// is exercised on mac CI + preflight tests; here we cover the always-on container
+// build force (engine.go:136).
 func TestBuild_ForcesAmd64Platform(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmpDir, "Setup.sh"), []byte("#!/bin/sh"), 0755); err != nil {
 		t.Fatal(err)
 	}
-	r := runner.NewRunner(false, true)
-	b := NewEngineImageBuilder(EngineImageOptions{SourcePath: tmpDir, Runtime: "docker", Arch: "arm64"}, r)
-	_, _ = b.Build(context.Background()) // dry-run; forces inside (see engine.go + macos_preflight)
+
+	tests := []struct {
+		name    string
+		runtime string
+		arch    string
+	}{
+		{"docker arm64 input", "docker", "arm64"},
+		{"podman arm64 input", "podman", "arm64"},
+		{"docker amd64 input (regression)", "docker", "amd64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := runner.NewRunner(false, true)
+			var buf bytes.Buffer
+			r.Stdout = &buf
+
+			b := NewEngineImageBuilder(EngineImageOptions{
+				SourcePath: tmpDir,
+				Runtime:    tt.runtime,
+				Arch:       tt.arch,
+			}, r)
+
+			_, err := b.Build(context.Background())
+			if err != nil {
+				t.Fatalf("Build() err: %v", err)
+			}
+
+			out := buf.String()
+			if !strings.Contains(out, "--platform linux/amd64") {
+				t.Errorf("expected echoed command to contain --platform linux/amd64, got: %s", out)
+			}
+			// For container backends, must not emit arm64 platform even if Arch=arm64.
+			if strings.Contains(out, "--platform linux/arm64") {
+				t.Errorf("should not emit linux/arm64 platform for container engine build, got: %s", out)
+			}
+		})
+	}
 }

--- a/internal/dockerbuild/game_resolver_test.go
+++ b/internal/dockerbuild/game_resolver_test.go
@@ -1,6 +1,7 @@
 package dockerbuild
 
 import (
+	"bytes"
 	"context"
 	"strings"
 	"testing"
@@ -277,8 +278,6 @@ func TestResolveArch(t *testing.T) {
 
 // TestBuildResultForArm64 and amd64 (dry-run) to verify correct output dirs/binaries.
 func TestBuildResultForArm64(t *testing.T) {
-	r := runner.NewRunner(false, true)
-
 	tests := []struct {
 		name   string
 		arch   string
@@ -291,6 +290,14 @@ func TestBuildResultForArm64(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			opts := DockerGameOptions{EngineImage: "test:tag", ProjectName: "Lyra", Arch: tt.arch}
+
+			// Capture runner output to assert container platform force (always linux/amd64
+			// for game builds via container, even arm64; arm64 is cross inside via UAT).
+			// Covers "via container" + no regression on amd64.
+			r := runner.NewRunner(false, true)
+			var buf bytes.Buffer
+			r.Stdout = &buf
+
 			b := NewDockerGameBuilder(opts, r)
 			res, err := b.Build(context.Background())
 			if err != nil {
@@ -301,6 +308,11 @@ func TestBuildResultForArm64(t *testing.T) {
 			}
 			if !res.Success {
 				t.Error("expected Success")
+			}
+
+			out := buf.String()
+			if !strings.Contains(out, "--platform linux/amd64") {
+				t.Errorf("expected echoed docker run to contain --platform linux/amd64 (forced for container game builds), got: %s", out)
 			}
 		})
 	}


### PR DESCRIPTION
**macOS Stabilization — Test Coverage (Phase 4)**

Focused, tests-only PR per the task (after #250 engine force + arm64 game, #252, #253, #255 docs). Adds targeted table-driven tests (stdlib style) in `internal/dockerbuild/` only.

**Specific Items:**
1. `internal/dockerbuild/engine_test.go`: Enhanced `TestBuild_ForcesAmd64Platform` (now table-driven with runner stdout capture via `bytes.Buffer` + `r.Stdout`) to assert that engine builds for container backends (`docker`/`podman`, arm64 *and* amd64 inputs) always emit `+ docker build ... --platform linux/amd64`. Covers the force on macOS+container paths (pre-flight force noted as covered on mac CI + preflight tests). No regression on amd64.
2. `internal/dockerbuild/game_resolver_test.go`: Extended `TestBuildResultForArm64` (inside the table loop, same capture) to assert game `Build` (via container) always emits `+ docker run ... --platform linux/amd64` even for `arch=arm64` (while `LinuxArm64Server` results + success still hold). Directly tests "producing correct LinuxArm64Server output via container". Includes amd64 case for regression.

**Strict rules:**
- Only *_test.go edits (2 files, +60/-6 net; small/low-risk).
- Pure table-driven (tt ranges + t.Run, like all existing arm64/amd64 tables in these files).
- No code, docs, warnings touched.
- Validation run before PR (see below); no Codacy/complexity issues (lint clean, no mentions of these tests in codacy_issues.json).

**Validation (clean before PR):**
- `go test ./internal/dockerbuild -run 'ForcesAmd64Platform|BuildResultForArm64' -count=1 -v` → PASS (both new tables + subcases)
- `go test ./internal/dockerbuild -count=1` → PASS
- `golangci-lint run ./...` → 0 issues
- `go build -o ludus.exe .` → success
- `go vet ./internal/dockerbuild` → clean
- Pre-commit sim (build + lint + test steps) → passed
- Codacy proxy (golangci + grep codacy_issues.json for the test files) → no new issues
- `git diff --stat` → 2 files, 60 insertions, 6 deletions (small)

Part of #243. Follows merged #250/#252/#253/#255. Draft per workflow; CI (incl. mac runner for darwin preflight) will confirm.