### PR TITLE
macOS Stabilization — Final Documentation Polish

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -142,6 +142,8 @@ game build --arch arm64
 Architecture mismatches are caught automatically — if you build arm64 but your fleet config
 says `c6i.large` (x86), Ludus switches to `c7g.large` (Graviton) and tells you.
 
+On macOS with container backends (`--backend docker`/`podman`), engine builds are forced to `linux/amd64` (QEMU user-mode emulation required; Epic only provides an x86_64 Linux toolchain). Game builds with `--arch arm64` (Graviton) cross-compile inside the emulated amd64 environment; the resulting engine image stays amd64 (even for later arm64 game containers). Pre-built amd64 engine images (from Linux/CI) are recommended to avoid emulation cost. The `--arch` flag and mismatch handling apply as above.
+
 ### Configuration Flow
 
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ludus init --verbose
 ludus run --verbose
 ```
 
-**Prerequisites at a glance**: UE5 source build, Docker, AWS CLI v2, Go 1.24+, 16 GB RAM, 300 GB disk. See [detailed prerequisites](#prerequisites) below.
+**Prerequisites at a glance**: UE5 source build, Docker/Podman, AWS CLI v2, Go 1.24+, 16 GB RAM, 300 GB disk. macOS (Apple Silicon/Intel) supported via container backends only. See [detailed prerequisites](#prerequisites) below.
 
 ## What it does
 
@@ -62,10 +62,13 @@ This single command orchestrates six stages:
 
 ### System requirements
 
-- **OS**: Windows 10/11 or Linux x86_64 (Ubuntu recommended)
+- **OS**: Windows 10/11, Linux x86_64 (Ubuntu recommended), or macOS (Apple Silicon/Intel via `--backend docker` or `--backend podman` only; see macOS subsection below)
 - **RAM**: 16 GB minimum (UE5 linking uses ~8 GB per job)
 - **Disk**: 300 GB free (a fully built UE5 engine occupies 280–320 GB)
 - **Go**: 1.24+
+
+### macOS (container backends)
+macOS requires a container backend (`--backend docker` or `--backend podman`; install Docker Desktop or Podman Desktop). Native engine builds target macOS, not Linux. Engine container builds always use `linux/amd64` (QEMU emulation; Epic ships only x86_64 Linux toolchain). Use pre-built engine image in `ludus.yaml` (`engine.dockerImage`) to skip QEMU. Run `ludus doctor` for checks. See [macOS Support](#macos-support) for examples and Graviton (`--arch arm64`) workflow.
 
 ### External tools
 


### PR DESCRIPTION
**macOS Stabilization — Final Documentation Polish**

Final focused docs-only PR per the task (after #250/#252/#253/#255/#256). Only README.md + ARCHITECTURE.md touched.

**Specific Items:**
1. Updated/expanded "Getting Started" flow (Quickstart + ## Prerequisites) with practical macOS instructions:
   - Updated "Prerequisites at a glance" + OS bullet (now explicitly lists macOS via container backends, with link to subsection).
   - Added tiny `### macOS (container backends)` subsection right after System requirements (practical: container backend req, engine linux/amd64 + QEMU cost on AS, pre-built image rec to skip, `ludus doctor`, link to detailed #macos-support for examples/Graviton workflow).
2. Updated ARCHITECTURE.md (### Cross-Architecture Support) with current reality: on macOS + container backends, engine builds forced to `linux/amd64` (QEMU; Epic x86_64-only toolchain); game `--arch arm64` (Graviton) cross-compiles inside the amd64 container; engine image stays amd64; pre-built images recommended; `--arch` + mismatch handling still apply.

**Strict rules followed:**
- Minimal & focused: 2 files only, +7/-2 lines net (tiny additions; no duplication of existing macOS Support section at 399+; no roadmap/other touches).
- Clear, friendly, professional language + practical instructions/examples (points to detailed section).
- No code/tests/warnings touched.
- Full validation before PR (see below); 0 Codacy issues (golangci clean + no hits on these files in codacy_issues.json).

**Validation (all clean):**
- `golangci-lint run ./...` → 0 issues
- `go test ./...` → all PASS (cached/docs-only)
- `go build -o ludus.exe .` → success
- `go vet ./...` → clean
- Pre-commit sim (build + lint + test) → passed
- Codacy: golangci + grep on codacy_issues.json for README/ARCHITECTURE → 0 new
- `git diff --stat` → 2 files, 7 insertions, 2 deletions (small)

Part of #243 (final docs polish). Follows merged #250/#252/#253/#255/#256. Pure documentation changes only.

---

Draft per workflow. Ready for review once CI green.