### PR TITLE
fix: `container build --dry-run` errors after printing commands (#260)

### DIFF
--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -302,6 +302,9 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 // function that removes the generated files.
 func (b *Builder) generateAndWriteDockerfile(ctx context.Context) (func(), error) {
 	noop := func() {}
+	if b.Runner != nil && b.Runner.DryRun {
+		return noop, nil
+	}
 
 	// Build/fetch the GameLift Game Server Wrapper binary
 	wrapperBin, err := b.ensureWrapper(ctx)

--- a/internal/container/builder_test.go
+++ b/internal/container/builder_test.go
@@ -226,3 +226,42 @@ func TestRunDockerBuild_ProvenanceFlag(t *testing.T) {
 		})
 	}
 }
+
+// TestBuild_DryRun verifies that container build under --dry-run succeeds cleanly
+// (no attempt to ensure wrapper / read template / stage files into ServerBuildDir).
+// It is the first test to exercise full Builder.Build() with a dry-run runner.
+// Previously this path would fail with "reading config template" on cache miss
+// (Windows cross-compile path, or any host without pre-cached wrapper).
+func TestBuild_DryRun(t *testing.T) {
+	var stdout strings.Builder
+	r := runner.NewRunner(false, true) // dry-run: prints args, doesn't exec
+	r.Stdout = &stdout
+
+	b := NewBuilder(BuildOptions{
+		ServerBuildDir: t.TempDir(),
+		ImageName:      "test-image",
+		Tag:            "latest",
+		ServerPort:     7777,
+		Arch:           runtime.GOARCH, // match host arch to skip cross-arch check
+	}, r)
+
+	ctx := context.Background()
+	res, err := b.Build(ctx)
+	if err != nil {
+		t.Fatalf("Build() under dry-run should succeed cleanly, got: %v", err)
+	}
+	if res == nil {
+		t.Fatal("Build() returned nil result under dry-run")
+	}
+	if !res.Success {
+		t.Error("expected res.Success == true under dry-run")
+	}
+
+	output := stdout.String()
+	if !strings.Contains(output, "+ docker build") {
+		t.Errorf("expected echoed docker build cmd in dry-run output, got: %s", output)
+	}
+	if strings.Contains(output, "reading config template") || strings.Contains(output, "game server wrapper") {
+		t.Errorf("dry-run should not attempt wrapper/template load, got in output: %s", output)
+	}
+}


### PR DESCRIPTION
**Fix #260: `container build --dry-run` errors after printing commands**

**Problem (from issue):** When running `ludus container build --dry-run`, it prints the commands correctly but then fails when trying to read the wrapper template (which should be skipped in dry-run mode).

**Root cause:** `Builder.Build` unconditionally calls `generateAndWriteDockerfile` (which does `ensureWrapper` → `wrapper.EnsureBinary` → on cross/non-native: `buildWrapperBinary` → `os.ReadFile` of `template-managed-containers-config.yaml` after the dry-run `go build` that didn't populate the clone). The wrapper prep + FS staging (copy + 3x WriteFile) happens *before* `runDockerBuild` (the only step using `runner.Run` that benefits from dry-run echo/early-return). Direct `os.*` + post-runner reads are not guarded.

**Solution (minimal, per plan):** 3-line nil-safe `if b.Runner != nil && b.Runner.DryRun { return noop, nil }` right after `noop := func() {}` inside `generateAndWriteDockerfile`. This skips the entire load/stage path for dry-run but still reaches `runDockerBuild` (prints `+ docker build ...` or podman) so Build succeeds cleanly. No change to real builds, no touch to `wrapper/`, `cmd/container/`, or pure `Generate*` methods (still called post-Build in cmd for lint even on dry/cache-hit).

**Files changed (strictly 2, small/low-risk):**
- `internal/container/builder.go` (the guard)
- `internal/container/builder_test.go` (new `TestBuild_DryRun`)

**Test added (required):** `TestBuild_DryRun` — first test calling full `Build()` under dry-run runner (capture via `strings.Builder` like sibling `TestRunDockerBuild_ProvenanceFlag`). Asserts: err==nil, res.Success, `+ docker build` echoed, *no* "reading config template" or wrapper strings in output. Covers the Windows cross path that always hit the template read.

**Why this exact spot/approach (1 sentence):** Guard at the single choke point `generateAndWriteDockerfile` (the container build logic) is the smallest change that stops the load without broadening scope or duplicating dry-run checks.

**Validation (all green before PR, per strict rules):**

```
$ go test ./internal/container -run 'TestBuild_DryRun|TestRunDockerBuild_ProvenanceFlag' -count=1 -v
=== RUN   TestBuild_DryRun
--- PASS: TestBuild_DryRun (0.00s)
PASS

$ go test ./internal/dockerbuild
ok  	github.com/jpvelasco/ludus/internal/dockerbuild	0.940s

$ golangci-lint run ./...
0 issues.

$ go build -o ludus.exe -v .
# ok

$ go vet ./...
# ok

$ # pre-commit sim (full, with win GOTMPDIR)
go build ./...
golangci-lint run ./...
go test ./...
# (all pkgs green, including internal/container + dockerbuild)

$ # codacy equiv (live + snapshot)
golangci-lint ... → 0
# (grep on codacy_issues.json for internal/container/builder* shows only pre-existing G306 on 0644 WriteFile lines that are *after* the guard + already excluded in .golangci.yml; no *new* issues from this PR)
gofmt -l -s → clean
gocyclo -over 8 on builder.go → (no funcs >8; guard added trivial branch)

git diff --stat
 internal/container/builder.go      |  3 +++
 internal/container/builder_test.go | 39 ++++++++++++++++++++++++++++++++++++++
 2 files changed, 42 insertions(+)
```

**Diff (for review):**
```diff
--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -303,6 +303,9 @@ func (b *Builder) generateAndWriteDockerfile(ctx context.Context) (func(), error) {
 	noop := func() {}
+	if b.Runner != nil && b.Runner.DryRun {
+		return noop, nil
+	}
 
 	// Build/fetch the GameLift Game Server Wrapper binary
 	wrapperBin, err := b.ensureWrapper(ctx)
```
(The +39 lines are the required test case.)

**PR scope discipline (matches query + prior mac series PRs):**
- Only dry-run bug.
- Includes the test case verifying clean `--dry-run` success.
- Ran *exact* `go test ./internal/dockerbuild`, `golangci-lint run ./...`, pre-commit hook + full hygiene + Codacy equiv.
- No other changes. Small + low-risk. Conventional branch + commit.
- Part of macOS stabilization (container backend is the path for Apple Silicon users).

Closes #260.

(Plan was written in plan mode + presented via exit_plan_mode; this PR implements the approved plan exactly. See attached session plan.md for full exploration notes, alternatives considered, and verification checklist.)