### PR TITLE
test: final pre-release regression check + CI/Lint(Windows) stability

### DIFF
--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -151,66 +151,38 @@ func TestFormatDiagnosticSummary(t *testing.T) {
 func TestCheckAppleSiliconContainer(t *testing.T) {
 	isAS := runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
 	tests := []struct {
-		name         string
-		be           string
-		wantStatus   string
-		wantContains []string
+		name string
+		be   string
 	}{
-		{
-			name:       "native backend",
-			be:         "native",
-			wantStatus: "ok",
-			wantContains: []string{
-				func() string {
-					if isAS {
-						return "native backend (no container emulation)"
-					}
-					return "not Apple Silicon"
-				}(),
-			},
-		},
-		{
-			name: "docker backend",
-			be:   "docker",
-			wantStatus: func() string {
-				if isAS {
-					return "warn"
-				}
-				return "ok"
-			}(),
-			wantContains: func() []string {
-				if isAS {
-					return []string{"Apple Silicon", "Recommended"}
-				}
-				return []string{"not Apple Silicon"}
-			}(),
-		},
-		{
-			name: "podman backend",
-			be:   "podman",
-			wantStatus: func() string {
-				if isAS {
-					return "warn"
-				}
-				return "ok"
-			}(),
-			wantContains: func() []string {
-				if isAS {
-					return []string{"Apple Silicon", "Recommended"}
-				}
-				return []string{"not Apple Silicon"}
-			}(),
-		},
+		{"native backend", "native"},
+		{"docker backend", "docker"},
+		{"podman backend", "podman"},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cfg := &config.Config{Engine: config.EngineConfig{Backend: tt.be}}
 			d := checkAppleSiliconContainer(cfg)
-			if d.status != tt.wantStatus {
-				t.Errorf("status=%s want=%s", d.status, tt.wantStatus)
+
+			var wantStatus string
+			var wantContains []string
+			if isAS {
+				if tt.be == "native" {
+					wantStatus = "ok"
+					wantContains = []string{"native backend (no container emulation)"}
+				} else {
+					wantStatus = "warn"
+					wantContains = []string{"Apple Silicon", "Recommended"}
+				}
+			} else {
+				wantStatus = "ok"
+				wantContains = []string{"not Apple Silicon"}
 			}
-			for _, sub := range tt.wantContains {
+
+			if d.status != wantStatus {
+				t.Errorf("status=%s want=%s", d.status, wantStatus)
+			}
+			for _, sub := range wantContains {
 				if !strings.Contains(d.message, sub) {
 					t.Errorf("message %q missing %q", d.message, sub)
 				}


### PR DESCRIPTION
**Final Pre-Release Validation PR: Regression Check + CI Stability (v0.5.0)**

**Task:** Verify no regressions on Windows/WSL2/Linux after macOS changes; ensure Lint(Windows) + CI stable; clean new Codacy/complexity/lint.

**Specific checks performed (all green):**
- WSL2 engine+game (units + dry): `go test -count=1 -v ./internal/wsl` (PASS, all Test*Build/Sync/Install/Detect etc).
- Windows native: prereq (MSVC/os/memory/wsl2), toolchain, doctor checks (PASS).
- Linux container: `go test -count=1 -v ./internal/dockerbuild` (incl ForcesAmd64, arm64 results, dotnet preflight, scripts; PASS); container builder tests (PASS).
- doctor/setup/status/deploy fallback: `go test ./cmd/doctor ./internal/status` + temp config CLI `go run . doctor/status/setup --help` (all PASS, AS check correctly "not Apple Silicon" on win).
- Full: `go test -count=1 ./...` (all pkgs PASS).
- Lint(Windows): `gh run list` (recent main/branch runs success for Lint(Windows)); local `go run .../golangci-lint/v2/cmd/golangci-lint@v2.10.1 run ./...` + current (0 issues both).
- Pre-commit sim (build + lint + GOTMPDIR go test): PASS.
- gocyclo / Codacy: only pre-fix cyclo 11 in TestCheckAppleSiliconContainer (mac-touched from #253); post-fix 0 report; no new in codacy_issues.json for doctor; golangci 0.

**Fix (minimal, 1 file):** Refactored `TestCheckAppleSiliconContainer` (cmd/doctor/doctor_test.go) to drop cyclo 11→≤8 (moved inline `func(){if isAS}` branches out of table literals into linear if/else inside t.Run; modeled on prior checker_os_test refactor; preserves *exact* 3 cases + AS/non-AS expects + runtime-driven coverage for mac CI).

**Before/after (gocyclo -over 8 -test cmd/doctor/doctor_test.go):**
Before:
11 doctor TestCheckAppleSiliconContainer cmd/doctor/doctor_test.go:151
After:
(no output; exit 0 = ≤8)

**Diff (24+ / 52- net, only this test):**
```diff
 cmd/doctor/doctor_test.go | 76 +++++++++++++++--------------------------------
 1 file changed, 24 insertions(+), 52 deletions(-)
```
(Full: table simplified to name+be only; expects computed inside loop.)

**Strict rules:**
- Minimal: only the cyclo fix (no regressions found, so no other source changes).
- Tests: the refactored test itself (still runs all cases/subtests + passes).
- Full val before open (listed above + `go test ./internal/dockerbuild`, golangci, pre-commit hook sim).
- Small/low-risk: 1 file; conventional branch/commit; draft PR.

Part of v0.5.0 prep. Follows approved plan (exploration showed 0 logic regressions in WSL/windows/container paths; mac gates + prior extracts kept things stable).

(Plan in session plan.md with full cmds, subagent notes, refactor sketch.)