### PR TITLE
fix: derive container uproject filename from path, not projectName (#271)

### DIFF
--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -100,7 +100,11 @@ func (b *DockerGameBuilder) isExternalProject() bool {
 // containerProjectPath returns the project path as seen from inside the container.
 func (b *DockerGameBuilder) containerProjectPath() string {
 	if b.isExternalProject() {
-		return fmt.Sprintf("/project/%s.uproject", b.resolveProjectName())
+		// The project directory is mounted at /project, so the .uproject lives at
+		// /project/<basename>. Derive the filename from the path the user gave —
+		// it can legitimately differ from projectName, which only governs target
+		// names (e.g. Epic ships LyraStarterGame.uproject with LyraServer targets).
+		return "/project/" + filepath.Base(b.opts.ProjectPath)
 	}
 	// Lyra or in-engine project
 	return fmt.Sprintf("/engine/Samples/Games/%s/%s.uproject",

--- a/internal/dockerbuild/game_resolver_test.go
+++ b/internal/dockerbuild/game_resolver_test.go
@@ -202,9 +202,12 @@ func TestContainerProjectPath(t *testing.T) {
 			want: "/project/MyGame.uproject",
 		},
 		{
-			name: "external project defaults name to Lyra",
-			opts: DockerGameOptions{ProjectPath: "/some/path"},
-			want: "/project/Lyra.uproject",
+			// #271: the container path follows the actual .uproject filename from the
+			// path even when projectName is unset; projectName only defaults (to Lyra)
+			// for target names, not for the on-disk uproject filename.
+			name: "external project derives filename from path basename",
+			opts: DockerGameOptions{ProjectPath: "/home/user/LyraStarterGame/LyraStarterGame.uproject"},
+			want: "/project/LyraStarterGame.uproject",
 		},
 	}
 

--- a/internal/dockerbuild/game_script_test.go
+++ b/internal/dockerbuild/game_script_test.go
@@ -139,6 +139,15 @@ var generateBuildScriptClientTests = []struct {
 		contains: []string{"/project/MyGame.uproject"},
 	},
 	{
+		name: "external project client with filename != projectName",
+		opts: DockerGameOptions{
+			ProjectPath: "/home/user/LyraStarterGame/LyraStarterGame.uproject",
+			ProjectName: "Lyra",
+		},
+		contains:    []string{"/project/LyraStarterGame.uproject"},
+		notContains: []string{"/project/Lyra.uproject"},
+	},
+	{
 		name:     "arm64 client",
 		opts:     DockerGameOptions{Arch: "arm64"},
 		contains: []string{"-platform=LinuxArm64"},

--- a/internal/dockerbuild/game_script_test.go
+++ b/internal/dockerbuild/game_script_test.go
@@ -57,6 +57,18 @@ var generateBuildScriptServerTests = []struct {
 		},
 		contains: []string{"/project/MyGame.uproject", "-servertargetname=MyGameServer"},
 	},
+	{
+		// #271: uproject filename differs from projectName. Epic ships the Lyra
+		// sample as LyraStarterGame.uproject but its targets are LyraServer/LyraGame,
+		// so projectName is set to "Lyra". The container path must follow the actual
+		// filename (mounted at /project), not <projectName>.uproject.
+		name: "external project with filename != projectName",
+		opts: DockerGameOptions{
+			ProjectPath: "/home/user/LyraStarterGame/LyraStarterGame.uproject", ProjectName: "Lyra", ServerTarget: "LyraServer",
+		},
+		contains:    []string{"/project/LyraStarterGame.uproject", "-servertargetname=LyraServer"},
+		notContains: []string{"/project/Lyra.uproject"},
+	},
 }
 
 func TestGenerateBuildScript_Server(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #271. `ludus` can build any standalone UE5 project by pointing `game.projectPath` at its `.uproject`, but `containerProjectPath()` built the in-container path as `/project/<projectName>.uproject`. Because `projectName` *also* prefixes the build targets (`<projectName>Server` / `<projectName>Game`), a project whose `.uproject` filename diverges from its target prefix failed the build:

```
Could not find a project file /project/Lyra.uproject.
AutomationTool exiting with ExitCode=1 (Error_Unknown)
```

This is the common case for Epic's **Lyra** sample: it ships as `LyraStarterGame.uproject` but its targets are `LyraServer` / `LyraGame`, so you set `projectName: Lyra` — and the build then looked for `/project/Lyra.uproject` and died.

## Fix

The project directory is already mounted at `/project` (see `runBuildContainer`, which mounts `filepath.Dir(ProjectPath)`), so the `.uproject` always lands at `/project/<basename>`. Derive the container path from the basename of the path the user actually gave:

```go
if b.isExternalProject() {
	return "/project/" + filepath.Base(b.opts.ProjectPath)
}
```

`projectName` now governs target names only — its more intuitive role. Server/game targets remain independently overridable via `game.serverTarget` / `game.gameTarget`. This fixes both the server and client build scripts (both go through `containerProjectPath()`).

## Tests

- Updated the one `TestContainerProjectPath` case that asserted the old `projectName`-derived filename (`/some/path` → `/project/Lyra.uproject`) — that case encoded the bug. It now asserts the path follows the actual basename.
- Added table-driven cases (resolver, server script, and client script) covering a `.uproject` filename that diverges from `projectName`, asserting `/project/LyraStarterGame.uproject` **and** that `/project/Lyra.uproject` is *not* emitted.

## Validation

Validated again after updating to current `main`:
- `go build ./...` ✅
- `go test ./...` ✅
- `go test -v ./internal/dockerbuild` ✅
- `gofmt` / `git diff --check` clean ✅

> Note: the docs half of #271 (a "Building your own UE5 game" README section) is intentionally left out of this code-fix PR to keep it focused; happy to follow up with a docs PR.
