### PR TITLE
feat: add Go toolchain version check for container builds (#274)

### DIFF
--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -63,6 +63,7 @@ func (c *Checker) RunAll() []CheckResult {
 	results = append(results, c.checkAWSCredentials())
 	results = append(results, c.checkCommand("git", "Git"))
 	results = append(results, c.checkCommand("go", "Go compiler"))
+	results = append(results, c.checkGoVersion())
 	results = append(results, c.platformChecks()...)
 	results = append(results, c.checkDiskSpace())
 	results = append(results, c.checkMemory())
@@ -102,7 +103,7 @@ func (c *Checker) CheckGameReady() []CheckResult {
 // (e.g. GameLift container fleet images). These are Docker-specific because
 // GameLift container fleets require Docker-format images.
 func (c *Checker) CheckDockerReady() []CheckResult {
-	return []CheckResult{c.checkDocker(), c.checkCrossArchEmulation()}
+	return []CheckResult{c.checkDocker(), c.checkCrossArchEmulation(), c.checkGoVersion()}
 }
 
 // CheckPushReady validates prerequisites for push commands (container/engine push).

--- a/internal/prereq/checker_go.go
+++ b/internal/prereq/checker_go.go
@@ -38,7 +38,15 @@ var (
 func (c *Checker) checkGoVersion() CheckResult {
 	const name = "Go compiler version"
 
-	if !dockerbuild.IsContainerBackend(c.Backend) {
+	// Treat default/empty backend as Docker. This ensures the check runs for the
+	// common case of `ludus container build` (no --backend, config backend often
+	// "native"/"wsl2") because ResolveContainerBackend returns "" but the actual
+	// build (ContainerCLI etc.) defaults to Docker. See review feedback on #279.
+	be := c.Backend
+	if be == "" {
+		be = dockerbuild.BackendDocker
+	}
+	if !dockerbuild.IsContainerBackend(be) {
 		return CheckResult{Name: name, Passed: true, Message: "skipped — only required for container builds"}
 	}
 

--- a/internal/prereq/checker_go.go
+++ b/internal/prereq/checker_go.go
@@ -1,0 +1,113 @@
+package prereq
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/jpvelasco/ludus/internal/dockerbuild"
+)
+
+// minGoMajor / minGoMinor is the minimum host Go toolchain version required to
+// build the Amazon GameLift server wrapper. The wrapper's Makefile invokes
+// `go build -C src` (and `go test -C src`); the `-C` flag was introduced in
+// Go 1.20, so an older toolchain fails mid-`container build` with
+// "flag provided but not defined: -C".
+const (
+	minGoMajor = 1
+	minGoMinor = 20
+)
+
+// errGoNotFound / errGoUnreadable distinguish "no go on PATH" (a hard failure
+// for container builds) from "go present but its version couldn't be read or
+// parsed" (a warning — we can't verify, but won't block).
+var (
+	errGoNotFound   = errors.New("go not found in PATH")
+	errGoUnreadable = errors.New("go version could not be determined")
+)
+
+// checkGoVersion verifies the host Go toolchain is new enough to build the
+// GameLift server wrapper. It is only relevant for the container backends
+// (docker/podman), where `ludus container build` shells out to `go build`.
+// For other backends it is a no-op pass, mirroring the other container-scoped
+// checks (e.g. checkMacOSContainerBuild).
+func (c *Checker) checkGoVersion() CheckResult {
+	const name = "Go compiler version"
+
+	if !dockerbuild.IsContainerBackend(c.Backend) {
+		return CheckResult{Name: name, Passed: true, Message: "skipped — only required for container builds"}
+	}
+
+	major, minor, err := detectHostGoVersion()
+	switch {
+	case errors.Is(err, errGoNotFound):
+		return CheckResult{Name: name, Passed: false,
+			Message: fmt.Sprintf("go not found in PATH; container builds need Go >= %d.%d to build the GameLift wrapper", minGoMajor, minGoMinor)}
+	case err != nil:
+		return CheckResult{Name: name, Passed: true, Warning: true,
+			Message: fmt.Sprintf("could not determine Go version; container builds need Go >= %d.%d for the GameLift wrapper", minGoMajor, minGoMinor)}
+	case goVersionTooOld(major, minor):
+		return CheckResult{Name: name, Passed: false,
+			Message: fmt.Sprintf("go%d.%d found; GameLift wrapper build requires Go >= %d.%d (uses 'go build -C')", major, minor, minGoMajor, minGoMinor)}
+	default:
+		return CheckResult{Name: name, Passed: true,
+			Message: fmt.Sprintf("go%d.%d found (>= %d.%d required for GameLift wrapper build)", major, minor, minGoMajor, minGoMinor)}
+	}
+}
+
+// detectHostGoVersion runs `go version` and returns the parsed major/minor.
+// It returns errGoNotFound if go is not on PATH, or errGoUnreadable if go ran
+// but its version output could not be obtained or parsed.
+func detectHostGoVersion() (major, minor int, err error) {
+	if _, lookErr := exec.LookPath("go"); lookErr != nil {
+		return 0, 0, errGoNotFound
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	out, runErr := exec.CommandContext(ctx, "go", "version").Output()
+	if runErr != nil {
+		return 0, 0, errGoUnreadable
+	}
+
+	major, minor, ok := parseGoMinorVersion(string(out))
+	if !ok {
+		return 0, 0, errGoUnreadable
+	}
+	return major, minor, nil
+}
+
+// goVersionTooOld reports whether (major, minor) is below the required minimum.
+func goVersionTooOld(major, minor int) bool {
+	if major != minGoMajor {
+		return major < minGoMajor
+	}
+	return minor < minGoMinor
+}
+
+// parseGoMinorVersion extracts the major and minor version from `go version`
+// output, e.g. "go version go1.25.10 linux/amd64" -> (1, 25, true). It returns
+// ok=false if no recognizable goX.Y token is present.
+func parseGoMinorVersion(versionOutput string) (major, minor int, ok bool) {
+	for _, field := range strings.Fields(versionOutput) {
+		num, found := strings.CutPrefix(field, "go")
+		if !found || num == "" {
+			continue
+		}
+		parts := strings.SplitN(num, ".", 3)
+		if len(parts) < 2 {
+			continue
+		}
+		maj, errMaj := strconv.Atoi(parts[0])
+		min, errMin := strconv.Atoi(parts[1])
+		if errMaj != nil || errMin != nil {
+			continue
+		}
+		return maj, min, true
+	}
+	return 0, 0, false
+}

--- a/internal/prereq/checker_go_test.go
+++ b/internal/prereq/checker_go_test.go
@@ -6,68 +6,41 @@ import (
 
 func TestParseGoMinorVersion(t *testing.T) {
 	tests := []struct {
-		name      string
-		input     string
-		wantMajor int
-		wantMinor int
-		wantOK    bool
+		name                 string
+		input                string
+		wantMajor, wantMinor int
+		wantOK               bool
 	}{
-		{
-			name:      "standard linux output",
-			input:     "go version go1.25.10 linux/amd64",
-			wantMajor: 1, wantMinor: 25, wantOK: true,
-		},
-		{
-			name:      "older 1.18",
-			input:     "go version go1.18 linux/amd64",
-			wantMajor: 1, wantMinor: 18, wantOK: true,
-		},
-		{
-			name:      "exactly 1.20",
-			input:     "go version go1.20.0 darwin/arm64",
-			wantMajor: 1, wantMinor: 20, wantOK: true,
-		},
-		{
-			name:      "two-component version",
-			input:     "go version go1.21 windows/amd64",
-			wantMajor: 1, wantMinor: 21, wantOK: true,
-		},
-		{
-			name:      "trailing newline",
-			input:     "go version go1.23.4 linux/arm64\n",
-			wantMajor: 1, wantMinor: 23, wantOK: true,
-		},
-		{
-			name:   "no go token",
-			input:  "some unexpected output",
-			wantOK: false,
-		},
-		{
-			name:   "empty",
-			input:  "",
-			wantOK: false,
-		},
-		{
-			name:   "goroutine is not a version token",
-			input:  "goroutine running",
-			wantOK: false,
-		},
+		{"standard linux output", "go version go1.25.10 linux/amd64", 1, 25, true},
+		{"older 1.18", "go version go1.18 linux/amd64", 1, 18, true},
+		{"exactly 1.20", "go version go1.20.0 darwin/arm64", 1, 20, true},
+		{"two-component version", "go version go1.21 windows/amd64", 1, 21, true},
+		{"trailing newline", "go version go1.23.4 linux/arm64\n", 1, 23, true},
+		{"no go token", "some unexpected output", 0, 0, false},
+		{"empty", "", 0, 0, false},
+		{"goroutine is not a version token", "goroutine running", 0, 0, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			major, minor, ok := parseGoMinorVersion(tt.input)
-			if ok != tt.wantOK {
-				t.Fatalf("parseGoMinorVersion(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
-			}
-			if !tt.wantOK {
-				return
-			}
-			if major != tt.wantMajor || minor != tt.wantMinor {
-				t.Errorf("parseGoMinorVersion(%q) = (%d, %d), want (%d, %d)",
-					tt.input, major, minor, tt.wantMajor, tt.wantMinor)
-			}
+			assertParseGoMinorVersion(t, tt.input, tt.wantMajor, tt.wantMinor, tt.wantOK)
 		})
+	}
+}
+
+// assertParseGoMinorVersion is a helper to keep TestParseGoMinorVersion short
+// and under the 50-LOC complexity limit while preserving full coverage.
+func assertParseGoMinorVersion(t *testing.T, input string, wantMajor, wantMinor int, wantOK bool) {
+	major, minor, ok := parseGoMinorVersion(input)
+	if ok != wantOK {
+		t.Fatalf("parseGoMinorVersion(%q) ok = %v, want %v", input, ok, wantOK)
+	}
+	if !wantOK {
+		return
+	}
+	if major != wantMajor || minor != wantMinor {
+		t.Errorf("parseGoMinorVersion(%q) = (%d, %d), want (%d, %d)",
+			input, major, minor, wantMajor, wantMinor)
 	}
 }
 

--- a/internal/prereq/checker_go_test.go
+++ b/internal/prereq/checker_go_test.go
@@ -1,0 +1,99 @@
+package prereq
+
+import (
+	"testing"
+)
+
+func TestParseGoMinorVersion(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantMajor int
+		wantMinor int
+		wantOK    bool
+	}{
+		{
+			name:      "standard linux output",
+			input:     "go version go1.25.10 linux/amd64",
+			wantMajor: 1, wantMinor: 25, wantOK: true,
+		},
+		{
+			name:      "older 1.18",
+			input:     "go version go1.18 linux/amd64",
+			wantMajor: 1, wantMinor: 18, wantOK: true,
+		},
+		{
+			name:      "exactly 1.20",
+			input:     "go version go1.20.0 darwin/arm64",
+			wantMajor: 1, wantMinor: 20, wantOK: true,
+		},
+		{
+			name:      "two-component version",
+			input:     "go version go1.21 windows/amd64",
+			wantMajor: 1, wantMinor: 21, wantOK: true,
+		},
+		{
+			name:      "trailing newline",
+			input:     "go version go1.23.4 linux/arm64\n",
+			wantMajor: 1, wantMinor: 23, wantOK: true,
+		},
+		{
+			name:   "no go token",
+			input:  "some unexpected output",
+			wantOK: false,
+		},
+		{
+			name:   "empty",
+			input:  "",
+			wantOK: false,
+		},
+		{
+			name:   "goroutine is not a version token",
+			input:  "goroutine running",
+			wantOK: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, ok := parseGoMinorVersion(tt.input)
+			if ok != tt.wantOK {
+				t.Fatalf("parseGoMinorVersion(%q) ok = %v, want %v", tt.input, ok, tt.wantOK)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if major != tt.wantMajor || minor != tt.wantMinor {
+				t.Errorf("parseGoMinorVersion(%q) = (%d, %d), want (%d, %d)",
+					tt.input, major, minor, tt.wantMajor, tt.wantMinor)
+			}
+		})
+	}
+}
+
+func TestCheckGoVersion_NonContainerBackendSkips(t *testing.T) {
+	for _, backend := range []string{"", "native", "wsl2"} {
+		c := &Checker{Backend: backend}
+		result := c.checkGoVersion()
+		if !result.Passed {
+			t.Errorf("backend %q: expected pass (skip), got fail: %s", backend, result.Message)
+		}
+		if result.Warning {
+			t.Errorf("backend %q: expected non-warning skip, got warning: %s", backend, result.Message)
+		}
+	}
+}
+
+func TestCheckGoVersion_ContainerBackendChecks(t *testing.T) {
+	// With a container backend the check actually probes the host `go`. On the
+	// CI/build host Go is current (the project requires 1.25+), so this must
+	// pass and report a version, never silently skip.
+	c := &Checker{Backend: "docker"}
+	result := c.checkGoVersion()
+	if result.Name != "Go compiler version" {
+		t.Errorf("unexpected check name: %q", result.Name)
+	}
+	if !result.Passed {
+		t.Errorf("expected Go version check to pass on this host, got fail: %s", result.Message)
+	}
+}

--- a/internal/prereq/checker_go_test.go
+++ b/internal/prereq/checker_go_test.go
@@ -72,7 +72,8 @@ func TestParseGoMinorVersion(t *testing.T) {
 }
 
 func TestCheckGoVersion_NonContainerBackendSkips(t *testing.T) {
-	for _, backend := range []string{"", "native", "wsl2"} {
+	// Explicit non-container backends skip the Go check (wrapper build not involved).
+	for _, backend := range []string{"native", "wsl2"} {
 		c := &Checker{Backend: backend}
 		result := c.checkGoVersion()
 		if !result.Passed {
@@ -85,15 +86,18 @@ func TestCheckGoVersion_NonContainerBackendSkips(t *testing.T) {
 }
 
 func TestCheckGoVersion_ContainerBackendChecks(t *testing.T) {
-	// With a container backend the check actually probes the host `go`. On the
-	// CI/build host Go is current (the project requires 1.25+), so this must
-	// pass and report a version, never silently skip.
-	c := &Checker{Backend: "docker"}
-	result := c.checkGoVersion()
-	if result.Name != "Go compiler version" {
-		t.Errorf("unexpected check name: %q", result.Name)
-	}
-	if !result.Passed {
-		t.Errorf("expected Go version check to pass on this host, got fail: %s", result.Message)
+	// With a container backend (or default "") the check probes host `go`.
+	// Default "" must *not* skip — this covers `ludus container build` with
+	// no --backend when config backend is native/wsl2 (Resolve returns "").
+	// Must pass on this host (Go 1.25+).
+	for _, be := range []string{"docker", "", "podman"} {
+		c := &Checker{Backend: be}
+		result := c.checkGoVersion()
+		if result.Name != "Go compiler version" {
+			t.Errorf("backend %q: unexpected check name: %q", be, result.Name)
+		}
+		if !result.Passed {
+			t.Errorf("backend %q: expected pass on this host, got fail: %s", be, result.Message)
+		}
 	}
 }

--- a/internal/prereq/checker_stages_test.go
+++ b/internal/prereq/checker_stages_test.go
@@ -31,8 +31,8 @@ func TestCheckGameReady(t *testing.T) {
 func TestCheckDockerReady(t *testing.T) {
 	c := &Checker{GameConfig: &config.GameConfig{}}
 	results := c.CheckDockerReady()
-	if len(results) != 2 {
-		t.Fatalf("expected 2 checks, got %d", len(results))
+	if len(results) != 3 {
+		t.Fatalf("expected 3 checks, got %d", len(results))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #274. `ludus container build` shells out to `go build` to compile the Amazon GameLift server wrapper. The wrapper's Makefile uses `go build -C src` (and `go test -C src`); the `-C` flag was introduced in **Go 1.20**, so an older host toolchain fails *partway through* `container build` rather than being caught up front:

```
go build -C src -trimpath -v ...
flag provided but not defined: -C
usage: go build [-o output] [build flags] [packages]
make: *** [Makefile:47: build] Error 2
Error: container build: game server wrapper: building game server wrapper: exit status 2
```

(Hit in practice on Ubuntu 22.04's `golang-go` = Go 1.18. Installing current Go fixed it immediately.)

## Fix

Add `checkGoVersion` to the prereq checks: it runs `go version`, parses the toolchain version, and **fails fast** when the host Go is `< 1.20`, with an actionable message. It's gated on the container backend (`docker`/`podman`) via the existing `dockerbuild.IsContainerBackend`, mirroring the other container-scoped checks (e.g. `checkMacOSContainerBuild`) — a no-op pass for `native`/`wsl2`, where the wrapper Go build never runs.

Wired into:
- `RunAll()` — the full `ludus init` diagnostics, and
- `CheckDockerReady()` — the `ludus container build` pre-flight that actually hit this failure.

Sample output:
```
[OK]   Go compiler version: go1.23 found (>= 1.20 required for GameLift wrapper build)
```
or, when too old:
```
[FAIL] Go compiler version: go1.18 found; GameLift wrapper build requires Go >= 1.20 (uses 'go build -C')
```

## Implementation notes

- Version parsing is a **pure** free function (`parseGoMinorVersion`) so it's exhaustively unit-testable without invoking the toolchain — table-driven coverage for standard output, two/three-component versions, trailing newline, and non-version junk (`go version go1.25.10 linux/amd64` → `(1, 25)`).
- Uses `exec.CommandContext` with a timeout, consistent with the existing checks in this package (which all use `os/exec` directly rather than `runner.Runner`). The version probes the **host** `go` binary, not `runtime.Version()` (which would report the version ludus itself was built with, not the user's build toolchain).
- The check lives in `internal/prereq` (where the failure actually bites — the `container build` pre-flight). `cmd/doctor` is a separate system; a parallel doctor diagnostic could be added in a follow-up if desired, but the prereq check is what provides the fail-fast the issue asks for.

## Validation

Linux x86_64, Go 1.25.4, golangci-lint v2.12.2 (the `.hooks/pre-commit` gate):
- `go build ./...` ✅ · `go vet ./...` ✅ · `gofmt -l` clean ✅
- `golangci-lint run ./...` → **0 issues** ✅
- `go test ./...` → **all packages pass** ✅ (incl. the updated `CheckDockerReady` count assertion)
