### PR TITLE
fix: install ca-certificates in macOS preflight so https wget succeeds (#269)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,6 +5,8 @@ See also [ARCHITECTURE.md](ARCHITECTURE.md) for the high-level design and module
 
 ## Build / Lint / Test
 
+Go `1.25.10` is required (see `go.mod`).
+
 ```bash
 # Build
 go build -o ludus -v .            # Linux/macOS
@@ -15,6 +17,7 @@ golangci-lint run ./...
 
 # Test
 go test ./...                          # All tests
+go test -race ./...                    # Race detector (Linux/macOS; requires CGO)
 go test -v ./internal/toolchain        # Single package
 go test -v -run TestParseBuildVersion ./internal/toolchain  # Single test
 
@@ -26,18 +29,42 @@ go mod tidy                       # Clean up module dependencies
 Pre-commit hooks (`.hooks/pre-commit`) run build, lint, and test.
 Activate with `git config core.hooksPath .hooks`.
 
+CI runs build and tests on Linux, Windows, and macOS, plus lint on Linux and
+Windows. Linux tests also collect coverage; Linux and macOS tests use `-race`.
+
 ## Project Structure
 
 - `main.go` — Entry point; calls `root.Execute()`.
 - `cmd/` — Cobra command packages. Each exports `var Cmd = &cobra.Command{...}`,
   registered in `cmd/root/root.go`. Handler functions are named `run<Command>`.
-  - `cmd/globals/` exports mutable global state (`Cfg`, `Verbose`, `JSONOutput`, `DryRun`, `Profile`)
-    and deployment target resolution (`resolve.go`). Not a `Cmd`. The `init` command lives in `cmd/root/init.go`.
+  - `cmd/globals/` exports mutable global state (`Cfg`, `Verbose`, `JSONOutput`,
+    `DryRun`, `Profile`, `DDCMode`) and deployment target resolution
+    (`resolve.go`). It is not a command package. The `init` command lives in
+    `cmd/root/init.go`.
   - `cmd/mcp/` — MCP server for AI agent orchestration (26 tools, stdio JSON-RPC).
+  - `cmd/resources/` — AWS resource inventory for resources managed by Ludus.
 - `internal/` — All business logic (unexported). One primary type per file.
   See [ARCHITECTURE.md](ARCHITECTURE.md) for the full package layout.
-- Config loaded via Viper from `ludus.yaml`.
+- Shared infrastructure includes `runner/` (subprocesses), `retry/` (network
+  retries), `awsutil/` (AWS config/errors/polling), `state/` and `cache/`
+  (persistent pipeline data), `inventory/` (AWS discovery), and `wsl/` (WSL2
+  detection, paths, commands, and source synchronization).
+- Config is loaded via Viper from `ludus.yaml`; `--profile <name>` prefers
+  `ludus-<name>.yaml` and isolates persisted state.
 - Platform-specific files use `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
+
+### Execution and External Services
+
+- Run external processes through `runner.Runner`; do not call `exec.Command`
+  directly. This preserves `--verbose`, `--dry-run`, environment overrides,
+  output routing, and consistent error handling.
+- Use `internal/retry` for retryable Docker/AWS operations. Use
+  `retry.Default()` unless the operation needs explicit timing or attempt limits.
+- Use `awsutil.Poll` / `PollWithOptions` for AWS wait loops and
+  `awsutil.IsNotFound` / `IsConflict` for idempotent AWS error handling.
+- Deploy backends implement `deploy.Target`; session-capable targets also
+  implement `deploy.SessionManager`. Wire new targets through
+  `cmd/globals/resolve.go` and expose them consistently in CLI, MCP, and status.
 
 ## Code Style
 
@@ -109,6 +136,7 @@ No logging library. All output via `fmt`:
   ```
 - **Assertions** via `if got != want` with `t.Errorf` / `t.Fatalf`.
 - **Temp dirs** via `t.TempDir()`, **env overrides** via `t.Setenv()`.
+- Use `t.Chdir()` for tests that depend on the working directory.
 - Test files co-located: `builder_test.go` alongside `builder.go`.
 
 ## Lint Configuration
@@ -125,3 +153,9 @@ proper nouns like `Setup.sh`.
 
 Ludus patches UE source files at init/build time. See [UE_SOURCE_PATCHES.md](UE_SOURCE_PATCHES.md)
 for full details on each patch and testing procedures.
+
+## Feature Work
+
+Approved feature designs live in `docs/superpowers/specs/`. Check relevant
+specs before implementing non-trivial features; associated implementation plans
+live in `docs/superpowers/plans/`.

--- a/internal/dockerbuild/deps.go
+++ b/internal/dockerbuild/deps.go
@@ -166,7 +166,7 @@ func PreflightDepsInstallScript() string {
 	dnfPkgs := strings.Join(dnfBuildPackages, " ")
 	return fmt.Sprintf(
 		`if command -v apt-get >/dev/null 2>&1; then `+
-			`DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y --no-install-recommends wget apt-transport-https && `+
+			`DEBIAN_FRONTEND=noninteractive apt-get update -qq && apt-get install -y --no-install-recommends ca-certificates wget apt-transport-https && `+
 			`wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb -O /tmp/packages-microsoft-prod.deb && `+
 			`dpkg -i /tmp/packages-microsoft-prod.deb && rm /tmp/packages-microsoft-prod.deb && `+
 			`apt-get update -qq && apt-get install -y --no-install-recommends %s && rm -rf /var/lib/apt/lists/*; `+

--- a/internal/dockerbuild/macos_preflight_test.go
+++ b/internal/dockerbuild/macos_preflight_test.go
@@ -125,6 +125,27 @@ func TestPreflightInstallCmd_ContainsBuildDeps(t *testing.T) {
 	}
 }
 
+// TestPreflightInstallCmd_InstallsCACertificates guards against #269: the
+// preflight uses --no-install-recommends, which suppresses the ca-certificates
+// that wget would otherwise pull in transitively. On a bare base image that
+// leaves no CA bundle, so the https wget to packages.microsoft.com fails the
+// TLS handshake (exit 5). ca-certificates must be installed explicitly, and
+// before the https wget that depends on it.
+func TestPreflightInstallCmd_InstallsCACertificates(t *testing.T) {
+	cmd := preflightInstallCmd("bash Setup.sh")
+
+	if !strings.Contains(cmd, "ca-certificates") {
+		t.Error("preflight must install ca-certificates so the https wget to packages.microsoft.com can verify TLS (#269)")
+	}
+
+	// ca-certificates must be installed no later than the https wget that needs it.
+	caIdx := strings.Index(cmd, "ca-certificates")
+	wgetIdx := strings.Index(cmd, "wget -q https://")
+	if wgetIdx >= 0 && (caIdx < 0 || caIdx > wgetIdx) {
+		t.Error("ca-certificates must be installed before the https wget that depends on it (#269)")
+	}
+}
+
 func TestPreflightInstallCmd_GenerateProjectFiles(t *testing.T) {
 	cmd := preflightInstallCmd("bash GenerateProjectFiles.sh -makefile")
 	if !strings.Contains(cmd, "bash GenerateProjectFiles.sh -makefile") {


### PR DESCRIPTION
## Summary

Fixes #269. `PreflightDepsInstallScript` installs `wget` with `--no-install-recommends`, which **suppresses** the `ca-certificates` package that `wget` would otherwise pull in as a *recommended* dependency. On a bare base image that leaves no CA bundle, so the very next line —

```
wget -q https://packages.microsoft.com/config/ubuntu/22.04/packages-microsoft-prod.deb ...
```

— fails the TLS handshake and the macOS preflight container exits **5** before any build deps are installed.

The engine Dockerfile path (`installDepsSnippet`) installs `wget` **without** `--no-install-recommends`, so it picks up `ca-certificates` transitively and is unaffected — which is exactly why this only bit the macOS preflight container, not the normal engine build.

## Fix

Install `ca-certificates` explicitly, ahead of the https `wget` that depends on it:

```diff
- apt-get install -y --no-install-recommends wget apt-transport-https && \
+ apt-get install -y --no-install-recommends ca-certificates wget apt-transport-https && \
```

## Contributor guidance

Also refreshes `AGENTS.md` with the repository's current Go/CI requirements, shared execution and AWS helper conventions, testing guidance, and feature-spec locations.

## Tests

- Added `TestPreflightInstallCmd_InstallsCACertificates`: asserts `ca-certificates` is present **and** ordered before the https `wget` that needs it.

## Validation

**Automated:**
- GitHub CI ✅
- Codacy: 0 new issues ✅
- `go build ./...` ✅
- `go test ./...` ✅
- `go test -v ./internal/dockerbuild` ✅

**End-to-end:**
Reproduced the failure and confirmed the fix in a bare `ubuntu:22.04` container, which exercises the same Linux-container apt path used by the macOS preflight:

```
Before: WGET_FAILED_EXIT=5
After:  PREFLIGHT_EXIT=0
```

After the fix, the HTTPS download from `packages.microsoft.com` succeeds and all preflight dependencies, including `dotnet-sdk-8.0`, install successfully.