### PR TITLE
fix: arm64 cook -platform=Linux instead of LinuxArm64

### DIFF
--- a/internal/buildgraph/generator_test.go
+++ b/internal/buildgraph/generator_test.go
@@ -57,13 +57,13 @@ func TestGenerate_ARM64(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	assertOption(t, bg, "Platform", "LinuxArm64")
+	assertOption(t, bg, "Platform", "Linux")
 	assertOption(t, bg, "Arch", "arm64")
 
 	gameAgent := requireAgent(t, bg, "Game")
 	serverNode := requireNode(t, gameAgent, "BuildServer")
-	if !strings.Contains(serverNode.Steps[0].Arguments, "-platform=LinuxArm64") {
-		t.Errorf("BuildServer args should contain -platform=LinuxArm64, got %q", serverNode.Steps[0].Arguments)
+	if !strings.Contains(serverNode.Steps[0].Arguments, "-platform=Linux") {
+		t.Errorf("BuildServer args should contain -platform=Linux, got %q", serverNode.Steps[0].Arguments)
 	}
 }
 

--- a/internal/config/config_arch.go
+++ b/internal/config/config_arch.go
@@ -34,10 +34,7 @@ func BinariesPlatformDir(arch string) string {
 }
 
 // UEPlatformName returns the UE platform name used in RunUAT -platform= flag.
-// amd64 → "Linux", arm64 → "LinuxArm64".
+// amd64 → "Linux", arm64 → "Linux" (arm64 targeting is done via TargetArchitecture INI).
 func UEPlatformName(arch string) string {
-	if NormalizeArch(arch) == "arm64" {
-		return "LinuxArm64"
-	}
 	return "Linux"
 }

--- a/internal/config/config_arch_test.go
+++ b/internal/config/config_arch_test.go
@@ -78,7 +78,7 @@ func TestUEPlatformName(t *testing.T) {
 	}{
 		{"amd64", "Linux"},
 		{"", "Linux"},
-		{"arm64", "LinuxArm64"},
+		{"arm64", "Linux"},
 	}
 
 	for _, tt := range tests {

--- a/internal/dockerbuild/game_script_test.go
+++ b/internal/dockerbuild/game_script_test.go
@@ -27,7 +27,7 @@ var generateBuildScriptServerTests = []struct {
 	{
 		name:     "arm64 server",
 		opts:     DockerGameOptions{Arch: "arm64"},
-		contains: []string{"-platform=LinuxArm64", "TargetArchitecture=AArch64"},
+		contains: []string{"-platform=Linux", "TargetArchitecture=AArch64"},
 	},
 	{
 		name:        "skip cook",


### PR DESCRIPTION
UE's UAT doesn't recognize LinuxArm64 as a valid platform name; arm64 targeting is done via TargetArchitecture=AArch64 INI which is already applied separately. Return Linux for all architectures from UEPlatformName().

Closes #272