### PR TITLE
fix: deploy destroy no longer deletes ludus-engine ECR

### DIFF
--- a/cmd/deploy/deploy_destroy.go
+++ b/cmd/deploy/deploy_destroy.go
@@ -134,16 +134,6 @@ func cleanupECRRepos(ctx context.Context, cleaner *cleanup.Cleaner, cfg *config.
 	if err := cleaner.DeleteECRRepository(ctx, ecrRepo); err != nil {
 		fmt.Printf("  ECR %s: %v (continuing)\n", ecrRepo, err)
 	}
-
-	engineRepo := cfg.Engine.DockerImageName
-	if engineRepo == "" {
-		engineRepo = "ludus-engine"
-	}
-	if engineRepo != ecrRepo {
-		if err := cleaner.DeleteECRRepository(ctx, engineRepo); err != nil {
-			fmt.Printf("  ECR %s: %v (continuing)\n", engineRepo, err)
-		}
-	}
 }
 
 func cleanupS3Bucket(ctx context.Context, cleaner *cleanup.Cleaner, awsCfg aws.Config, cfg *config.Config) {

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -500,16 +500,6 @@ func cleanupECRRepos(ctx context.Context, cleaner *cleanup.Cleaner, cfg *config.
 	if err := cleaner.DeleteECRRepository(ctx, ecrRepo); err != nil {
 		fmt.Printf("  ECR %s: %v (continuing)\n", ecrRepo, err)
 	}
-
-	engineRepo := cfg.Engine.DockerImageName
-	if engineRepo == "" {
-		engineRepo = "ludus-engine"
-	}
-	if engineRepo != ecrRepo {
-		if err := cleaner.DeleteECRRepository(ctx, engineRepo); err != nil {
-			fmt.Printf("  ECR %s: %v (continuing)\n", engineRepo, err)
-		}
-	}
 }
 
 // cleanupS3Bucket deletes the ludus builds S3 bucket.


### PR DESCRIPTION
The ludus-engine repo is a build input, not a deployable asset. Deleting it during destroy was a data-loss risk requiring the engine image to be rebuilt from source. Only delete ludus-server (the game server image) which is the actual deployable output.

Closes #275