### PR TITLE
[codex] Fix engine push image references

### DIFF
--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -304,24 +304,23 @@ func runPush(cmd *cobra.Command, args []string) error {
 
 	cfg := globals.Cfg
 
-	imageTag, err := globals.ResolveEngineImage(cfg, false)
+	imageName, imageTag, err := globals.ResolveEngineImageParts(cfg)
 	if err != nil {
 		return err
-	}
-
-	imageName := cfg.Engine.DockerImageName
-	if imageName == "" {
-		imageName = "ludus-engine"
 	}
 
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)
 	builder := dockerbuild.NewEngineImageBuilder(dockerbuild.EngineImageOptions{
 		ImageName: imageName,
+		ImageTag:  imageTag,
 	}, r)
 
-	repoName := imageName
+	repoName := cfg.Engine.DockerImageName
+	if repoName == "" {
+		repoName = "ludus-engine"
+	}
 
-	fmt.Printf("Pushing engine image %s to ECR...\n", imageTag)
+	fmt.Printf("Pushing engine image %s to ECR...\n", builder.FullImageTag())
 	if err := builder.Push(cmd.Context(), ecr.PushOptions{
 		ECRRepository: repoName,
 		AWSRegion:     cfg.AWS.Region,

--- a/cmd/globals/image.go
+++ b/cmd/globals/image.go
@@ -1,0 +1,40 @@
+package globals
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+// ResolveEngineImageParts returns the repository/name and tag of the engine
+// image that should be pushed. Untagged references use Docker's "latest" tag.
+func ResolveEngineImageParts(cfg *config.Config) (string, string, error) {
+	imageRef, err := ResolveEngineImage(cfg, false)
+	if err != nil {
+		return "", "", err
+	}
+	return splitImageReference(imageRef)
+}
+
+func splitImageReference(imageRef string) (string, string, error) {
+	if imageRef == "" {
+		return "", "", fmt.Errorf("engine image reference is empty")
+	}
+	if strings.Contains(imageRef, "@") {
+		return "", "", fmt.Errorf("engine image reference %q uses a digest; configure a tagged image for push", imageRef)
+	}
+
+	lastSlash := strings.LastIndex(imageRef, "/")
+	lastColon := strings.LastIndex(imageRef, ":")
+	if lastColon <= lastSlash {
+		return imageRef, "latest", nil
+	}
+
+	name := imageRef[:lastColon]
+	tag := imageRef[lastColon+1:]
+	if name == "" || tag == "" {
+		return "", "", fmt.Errorf("invalid engine image reference %q", imageRef)
+	}
+	return name, tag, nil
+}

--- a/cmd/globals/image_test.go
+++ b/cmd/globals/image_test.go
@@ -1,0 +1,36 @@
+package globals
+
+import "testing"
+
+func TestSplitImageReference(t *testing.T) {
+	tests := []struct {
+		name      string
+		imageRef  string
+		wantName  string
+		wantTag   string
+		wantError bool
+	}{
+		{name: "name and tag", imageRef: "ludus-engine:5.7", wantName: "ludus-engine", wantTag: "5.7"},
+		{name: "registry path", imageRef: "registry.example.com/team/ludus-engine:5.7", wantName: "registry.example.com/team/ludus-engine", wantTag: "5.7"},
+		{name: "registry port", imageRef: "localhost:5000/ludus-engine:dev", wantName: "localhost:5000/ludus-engine", wantTag: "dev"},
+		{name: "untagged", imageRef: "ludus-engine", wantName: "ludus-engine", wantTag: "latest"},
+		{name: "digest", imageRef: "ludus-engine@sha256:abc123", wantError: true},
+		{name: "empty", imageRef: "", wantError: true},
+		{name: "empty tag", imageRef: "ludus-engine:", wantError: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotTag, err := splitImageReference(tt.imageRef)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("splitImageReference() error = %v, wantError %v", err, tt.wantError)
+			}
+			if gotName != tt.wantName {
+				t.Errorf("splitImageReference() name = %q, want %q", gotName, tt.wantName)
+			}
+			if gotTag != tt.wantTag {
+				t.Errorf("splitImageReference() tag = %q, want %q", gotTag, tt.wantTag)
+			}
+		})
+	}
+}

--- a/cmd/mcp/tools_engine.go
+++ b/cmd/mcp/tools_engine.go
@@ -309,26 +309,27 @@ func handleEnginePush(ctx context.Context, _ *mcp.CallToolRequest, input engineP
 	cfg := globals.Cfg
 	r := newToolRunner(input.DryRun)
 
-	imageTag, err := globals.ResolveEngineImage(cfg, false)
+	imageName, imageTag, err := globals.ResolveEngineImageParts(cfg)
 	if err != nil {
 		return resultErr(enginePushResult{Error: err.Error()})
 	}
 
-	imageName := cfg.Engine.DockerImageName
-	if imageName == "" {
-		imageName = "ludus-engine"
-	}
-
 	b := dockerbuild.NewEngineImageBuilder(dockerbuild.EngineImageOptions{
 		ImageName: imageName,
+		ImageTag:  imageTag,
 	}, r)
 
 	var result enginePushResult
-	result.ImageTag = imageTag
+	result.ImageTag = b.FullImageTag()
+
+	repoName := cfg.Engine.DockerImageName
+	if repoName == "" {
+		repoName = "ludus-engine"
+	}
 
 	captured, err := withCapture(func() error {
 		return b.Push(ctx, ecr.PushOptions{
-			ECRRepository: imageName,
+			ECRRepository: repoName,
 			AWSRegion:     cfg.AWS.Region,
 			AWSAccountID:  cfg.AWS.AccountID,
 			ImageTag:      imageTag,


### PR DESCRIPTION
## Summary
- split the resolved engine image into its repository/name and tag
- use the actual built local tag as the `docker tag` source
- pass only the tag portion to the ECR destination
- apply the same behavior to CLI and MCP engine push paths

## Root cause
The push path constructed `EngineImageBuilder` without an image tag, so the local source defaulted to `ludus-engine:latest`. It then passed the full resolved image reference, such as `ludus-engine:5.7`, as the remote ECR tag, producing an invalid double-colon reference.

## Validation
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`

Fixes #294.