### PR TITLE
[codex] Fix default container engine max jobs

### DIFF
--- a/internal/dockerbuild/dockerfile.go
+++ b/internal/dockerbuild/dockerfile.go
@@ -2,6 +2,8 @@ package dockerbuild
 
 import "fmt"
 
+const defaultMaxJobs = 4
+
 // DockerfileOptions configures engine Dockerfile generation.
 type DockerfileOptions struct {
 	// MaxJobs is the default compile parallelism baked into the image.
@@ -29,10 +31,7 @@ type DockerfileOptions struct {
 // The runtime stage installs the same build deps because BuildCookRun invokes
 // compilers and linkers during game builds.
 func GenerateEngineDockerfile(opts DockerfileOptions) string {
-	maxJobs := opts.MaxJobs
-	if maxJobs <= 0 {
-		maxJobs = 4
-	}
+	maxJobs := resolveMaxJobs(opts.MaxJobs)
 
 	baseImage := opts.BaseImage
 	if baseImage == "" {
@@ -140,6 +139,13 @@ COPY --chown=ue:ue --from=builder /engine/Makefile               /engine/Makefil
 
 CMD ["echo", "Ludus Engine Image Ready - use with: ludus game build --backend docker|podman"]
 `, baseImage, deps, maxJobs, stage3, stage4Scw, stage4Ue)
+}
+
+func resolveMaxJobs(maxJobs int) int {
+	if maxJobs <= 0 {
+		return defaultMaxJobs
+	}
+	return maxJobs
 }
 
 // GeneratePrebuiltEngineDockerfile returns a 2-stage Dockerfile that packages

--- a/internal/dockerbuild/engine.go
+++ b/internal/dockerbuild/engine.go
@@ -176,7 +176,7 @@ func (b *EngineImageBuilder) runDockerBuild(ctx context.Context, cli, imageTag, 
 	args := []string{
 		"build",
 		"--platform", "linux/amd64",
-		"--build-arg", fmt.Sprintf("MAX_JOBS=%d", b.opts.MaxJobs),
+		"--build-arg", fmt.Sprintf("MAX_JOBS=%d", resolveMaxJobs(b.opts.MaxJobs)),
 		"-t", imageTag,
 		"-f", dfPath,
 	}

--- a/internal/dockerbuild/engine_test.go
+++ b/internal/dockerbuild/engine_test.go
@@ -239,3 +239,41 @@ func TestBuild_ForcesAmd64Platform(t *testing.T) {
 		})
 	}
 }
+
+func TestBuild_NormalizesMaxJobs(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(tmpDir, "Setup.sh"), []byte("#!/bin/sh"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		maxJobs int
+		want    string
+	}{
+		{name: "zero uses default", maxJobs: 0, want: "MAX_JOBS=4"},
+		{name: "negative uses default", maxJobs: -1, want: "MAX_JOBS=4"},
+		{name: "configured value", maxJobs: 12, want: "MAX_JOBS=12"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := runner.NewRunner(false, true)
+			var buf bytes.Buffer
+			r.Stdout = &buf
+
+			b := NewEngineImageBuilder(EngineImageOptions{
+				SourcePath: tmpDir,
+				Runtime:    "docker",
+				MaxJobs:    tt.maxJobs,
+			}, r)
+
+			if _, err := b.Build(context.Background()); err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if got := buf.String(); !strings.Contains(got, tt.want) {
+				t.Errorf("build command should contain %q, got: %s", tt.want, got)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- normalize nonpositive container engine job counts to the existing default of 4
- use the same normalized value in the generated Dockerfile and `docker build` argument
- test zero, negative, and explicitly configured job counts in the emitted command

## Root cause
The generated Dockerfile declared `ARG MAX_JOBS=4`, but the build command always supplied `--build-arg MAX_JOBS=0` when `engine.maxJobs` was unset. That override caused the Dockerfile to execute invalid `make -j0` commands.

The fix retains the existing conservative default of 4 jobs instead of using unrestricted host CPU parallelism, which could increase memory failures during Unreal Engine builds.

## Validation
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`

Fixes #297.