### PR TITLE
fix: fast-fail container runtime check before game container build

### DIFF
--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -228,6 +228,12 @@ func runNativeBuild(cmd *cobra.Command, cfg *config.Config, serverHash string) e
 }
 
 func runContainerBuild(cmd *cobra.Command, be string, cfg *config.Config) error {
+	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
+	checker.Backend = be
+	if err := prereq.Validate(checker.CheckGameContainerReady()); err != nil {
+		return err
+	}
+
 	engineHash := cache.EngineKey(cfg)
 	serverHash := cache.GameServerKey(cfg, engineHash)
 

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -228,10 +228,15 @@ func runNativeBuild(cmd *cobra.Command, cfg *config.Config, serverHash string) e
 }
 
 func runContainerBuild(cmd *cobra.Command, be string, cfg *config.Config) error {
-	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
-	checker.Backend = be
-	if err := prereq.Validate(checker.CheckGameContainerReady()); err != nil {
-		return err
+	// Skip the runtime preflight under --dry-run: it probes docker/podman
+	// (exec.LookPath + `docker info`) and would hard-fail on a host without a
+	// running daemon, instead of printing the would-be container command.
+	if !globals.DryRun {
+		checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
+		checker.Backend = be
+		if err := prereq.Validate(checker.CheckGameContainerReady()); err != nil {
+			return err
+		}
 	}
 
 	engineHash := cache.EngineKey(cfg)

--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -106,6 +106,42 @@ func (c *Checker) CheckDockerReady() []CheckResult {
 	return []CheckResult{c.checkDocker(), c.checkCrossArchEmulation(), c.checkGoVersion()}
 }
 
+// CheckGameContainerReady validates that the container runtime is reachable
+// before starting a container-backend game build.
+func (c *Checker) CheckGameContainerReady() []CheckResult {
+	return []CheckResult{c.checkContainerRuntime(), c.checkCrossArchEmulation()}
+}
+
+// checkContainerRuntime verifies that the configured container backend (docker
+// or podman) is installed and its daemon/machine is running. Unlike
+// checkDocker/checkPodman (which are advisory in RunAll), this returns a
+// hard failure when the selected backend is unreachable.
+func (c *Checker) checkContainerRuntime() CheckResult {
+	switch c.Backend {
+	case "podman":
+		res := c.checkPodman()
+		notReady := !res.Passed || (res.Warning && (strings.Contains(res.Message, "not running") || strings.Contains(res.Message, "not found")))
+		if notReady {
+			return CheckResult{
+				Name:    "Container Runtime",
+				Passed:  false,
+				Message: fmt.Sprintf("podman backend selected but not ready: %s", res.Message),
+			}
+		}
+		return CheckResult{Name: "Container Runtime", Passed: true, Message: res.Message}
+	default: // docker
+		res := c.checkDocker()
+		if !res.Passed {
+			return CheckResult{
+				Name:    "Container Runtime",
+				Passed:  false,
+				Message: fmt.Sprintf("docker backend selected but not ready: %s — install Docker Desktop or start the docker service, then retry", res.Message),
+			}
+		}
+		return CheckResult{Name: "Container Runtime", Passed: true, Message: res.Message}
+	}
+}
+
 // CheckPushReady validates prerequisites for push commands (container/engine push).
 func (c *Checker) CheckPushReady() []CheckResult {
 	return []CheckResult{c.checkDocker(), c.checkAWSCredentials()}


### PR DESCRIPTION
## Summary
- Before starting a container-backend game build, validates the selected runtime (docker or podman) is installed and its daemon/machine is running
- Hard failure with an actionable message instead of a raw `exec: docker not found` deep inside the build
- Added `CheckGameContainerReady()` to the prereq package; follows the same pattern as `CheckDockerReady()`

## Test plan
- [ ] `ludus game build --backend docker` with Docker daemon stopped → should print `[FAIL] Container Runtime: docker backend selected but not ready: ...` and exit before touching any build cache
- [ ] `ludus game build --backend podman` with podman machine stopped → same
- [ ] Normal container build (daemon running) → no change in behavior

Fixes #289.