### PR TITLE
fix: wire OutputDir in BaseDockerGameOptions to prevent build path mismatch

### DIFF
--- a/cmd/globals/ddc.go
+++ b/cmd/globals/ddc.go
@@ -106,12 +106,13 @@ func BaseDockerGameOptions(cfg *config.Config, engineImage, engineVersion, ddcMo
 		DDCPath:       ddcPath,
 		DDCZenPath:    ddcZenPath,
 		Runtime:       runtime,
-		// OutputDir is derived from projectPath so the game build always writes
-		// to the same location that container build reads from. Without this,
-		// the Docker game builder defaults to ./PackagedServer relative to cwd,
-		// which diverges from ResolveServerBuildDir when projectPath is a
-		// .uproject file path rather than a directory.
-		OutputDir: config.ResolveServerBuildDir(cfg),
+		// OutputDir is the PackagedServer archive root, derived from projectPath
+		// so the game build writes where container build reads. The Docker game
+		// builder appends the platform subdirectory itself, so this must be the
+		// root (not ResolveServerBuildDir, which already includes the platform —
+		// passing that would double it to .../PackagedServer/LinuxServer/LinuxServer).
+		// Without it, the builder defaults to ./PackagedServer relative to cwd.
+		OutputDir: config.ResolveServerArchiveRoot(cfg),
 	}
 }
 

--- a/cmd/globals/ddc.go
+++ b/cmd/globals/ddc.go
@@ -106,6 +106,12 @@ func BaseDockerGameOptions(cfg *config.Config, engineImage, engineVersion, ddcMo
 		DDCPath:       ddcPath,
 		DDCZenPath:    ddcZenPath,
 		Runtime:       runtime,
+		// OutputDir is derived from projectPath so the game build always writes
+		// to the same location that container build reads from. Without this,
+		// the Docker game builder defaults to ./PackagedServer relative to cwd,
+		// which diverges from ResolveServerBuildDir when projectPath is a
+		// .uproject file path rather than a directory.
+		OutputDir: config.ResolveServerBuildDir(cfg),
 	}
 }
 

--- a/internal/config/config_game.go
+++ b/internal/config/config_game.go
@@ -49,14 +49,26 @@ func (g *GameConfig) ResolvedArch() string {
 	return NormalizeArch(g.Arch)
 }
 
-// ResolveServerBuildDir determines the packaged server build directory from config.
+// ResolveServerBuildDir determines the packaged server build directory from
+// config, including the platform subdirectory (e.g. .../PackagedServer/LinuxServer).
 func ResolveServerBuildDir(cfg *Config) string {
-	platformDir := ServerPlatformDir(cfg.Game.ResolvedArch())
+	root := ResolveServerArchiveRoot(cfg)
+	if root == "" {
+		return ""
+	}
+	return filepath.Join(root, ServerPlatformDir(cfg.Game.ResolvedArch()))
+}
+
+// ResolveServerArchiveRoot returns the PackagedServer archive root (without the
+// platform subdirectory). This is the value passed as the Docker game builder's
+// archive directory, since it appends the platform subdirectory itself — passing
+// the platform-qualified path would double it (.../PackagedServer/LinuxServer/LinuxServer).
+func ResolveServerArchiveRoot(cfg *Config) string {
 	if cfg.Game.ProjectPath != "" {
-		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer", platformDir)
+		return filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "PackagedServer")
 	}
 	if cfg.Engine.SourcePath != "" && cfg.Game.ProjectName == "Lyra" {
-		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer", platformDir)
+		return filepath.Join(cfg.Engine.SourcePath, "Samples", "Games", "Lyra", "PackagedServer")
 	}
 	return ""
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -59,3 +59,59 @@ func TestResolveServerBuildDir(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveServerArchiveRoot(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectPath string
+		sourcePath  string
+		projectName string
+		arch        string
+		want        string
+	}{
+		{
+			name:        "custom project with projectPath (no platform dir)",
+			projectPath: "/games/MyGame/MyGame.uproject",
+			arch:        "amd64",
+			want:        filepath.Join("/games/MyGame", "PackagedServer"),
+		},
+		{
+			name:        "Lyra with engine source (no platform dir)",
+			sourcePath:  "/engine",
+			projectName: "Lyra",
+			arch:        "arm64",
+			want:        filepath.Join("/engine", "Samples", "Games", "Lyra", "PackagedServer"),
+		},
+		{
+			name: "neither set returns empty",
+			arch: "amd64",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &Config{
+				Engine: EngineConfig{SourcePath: tt.sourcePath},
+				Game: GameConfig{
+					ProjectPath: tt.projectPath,
+					ProjectName: tt.projectName,
+					Arch:        tt.arch,
+				},
+			}
+			got := ResolveServerArchiveRoot(cfg)
+			if got != tt.want {
+				t.Errorf("ResolveServerArchiveRoot() = %q, want %q", got, tt.want)
+			}
+			// Anti-doubling invariant: the build dir is exactly the archive root
+			// plus one platform subdirectory. The Docker game builder appends the
+			// platform itself, so it must be handed the root — never the build dir.
+			if got != "" {
+				want := filepath.Join(got, ServerPlatformDir(cfg.Game.ResolvedArch()))
+				if bd := ResolveServerBuildDir(cfg); bd != want {
+					t.Errorf("ResolveServerBuildDir() = %q, want archiveRoot+platform %q", bd, want)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Closes #327. See issue for details.