### PR TITLE
fix: persist ZenStore DDC across container game builds (UE 5.6+)

### DIFF
--- a/cmd/ddc/ddc.go
+++ b/cmd/ddc/ddc.go
@@ -153,7 +153,7 @@ func runPrune(cmd *cobra.Command, args []string) error {
 }
 
 func runWarmup(cmd *cobra.Command, args []string) error {
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	ddcMode, ddcPath, ddcZenPath, err := globals.ResolveDDC()
 	if err != nil {
 		return err
 	}
@@ -165,7 +165,7 @@ func runWarmup(cmd *cobra.Command, args []string) error {
 		return printWarmupPreview(ddcPath)
 	}
 
-	return executeWarmup(cmd.Context(), ddcMode, ddcPath)
+	return executeWarmup(cmd.Context(), ddcMode, ddcPath, ddcZenPath)
 }
 
 func printWarmupPreview(ddcPath string) error {
@@ -182,7 +182,7 @@ func printWarmupPreview(ddcPath string) error {
 	return nil
 }
 
-func executeWarmup(ctx context.Context, ddcMode, ddcPath string) error {
+func executeWarmup(ctx context.Context, ddcMode, ddcPath, ddcZenPath string) error {
 	cfg := globals.Cfg
 
 	if !dockerbuild.IsContainerBackend(cfg.Engine.Backend) && cfg.Engine.DockerImage == "" {
@@ -195,7 +195,7 @@ func executeWarmup(ctx context.Context, ddcMode, ddcPath string) error {
 	}
 
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)
-	opts := globals.BaseDockerGameOptions(cfg, engineImage, cfg.Engine.Version, ddcMode, ddcPath, cfg.Engine.Backend)
+	opts := globals.BaseDockerGameOptions(cfg, engineImage, cfg.Engine.Version, ddcMode, ddcPath, ddcZenPath, cfg.Engine.Backend)
 	opts.CookOnly = true
 	builder := dockerbuild.NewDockerGameBuilder(opts, r)
 

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -183,8 +183,8 @@ func runNativeBuild(cmd *cobra.Command, cfg *config.Config, serverHash string) e
 
 	engineVersion, _ := toolchain.DetectEngineVersion(enginePath, cfg.Engine.Version)
 
-	arch := cfg.Game.ResolvedArch()
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	arch := resolveArch()
+	ddcMode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return err
 	}
@@ -284,7 +284,7 @@ func runClientBuild(cmd *cobra.Command, args []string) error {
 
 	engineVersion, _ := toolchain.DetectEngineVersion(enginePath, cfg.Engine.Version)
 
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	ddcMode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return err
 	}
@@ -384,7 +384,7 @@ func runWSL2GameBuild(cmd *cobra.Command, cfg *config.Config) error {
 	}
 	fmt.Printf("Using WSL2 distro: %s\n", w.Distro)
 
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	ddcMode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return err
 	}

--- a/cmd/globals/ddc.go
+++ b/cmd/globals/ddc.go
@@ -33,21 +33,34 @@ func ResolveDDCPath() (string, error) {
 	return ddc.DefaultPath()
 }
 
-// ResolveDDC returns the effective DDC mode and path.
-// When mode is "none", path is returned empty (DDC is disabled).
-func ResolveDDC() (mode, path string, err error) {
+// ResolveZenPath returns the effective ZenStore host path.
+// Config zenPath takes precedence over the default (~/.ludus/zen).
+func ResolveZenPath() (string, error) {
+	if Cfg != nil && Cfg.DDC.ZenPath != "" {
+		return ddc.ResolveZenPath(Cfg.DDC.ZenPath)
+	}
+	return ddc.DefaultZenPath()
+}
+
+// ResolveDDC returns the effective DDC mode, filesystem path, and ZenStore path.
+// When mode is "none", both paths are returned empty (DDC is disabled).
+func ResolveDDC() (mode, path, zenPath string, err error) {
 	mode, err = ResolveDDCMode()
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
 	if mode == ddc.ModeNone {
-		return mode, "", nil
+		return mode, "", "", nil
 	}
 	path, err = ResolveDDCPath()
 	if err != nil {
-		return "", "", fmt.Errorf("resolving DDC path: %w", err)
+		return "", "", "", fmt.Errorf("resolving DDC path: %w", err)
 	}
-	return mode, path, nil
+	zenPath, err = ResolveZenPath()
+	if err != nil {
+		return "", "", "", fmt.Errorf("resolving DDC zen path: %w", err)
+	}
+	return mode, path, zenPath, nil
 }
 
 // ResolveEngineImage determines the Docker image to use for builds.
@@ -83,7 +96,7 @@ func ResolveEngineImage(cfg *config.Config, requireVersion bool) (string, error)
 // fields shared by all container game builds (server, client, warmup).
 // Callers set build-specific fields (ServerTarget, ClientTarget, CookOnly, etc.)
 // on the returned struct before passing it to NewDockerGameBuilder.
-func BaseDockerGameOptions(cfg *config.Config, engineImage, engineVersion, ddcMode, ddcPath, runtime string) dockerbuild.DockerGameOptions {
+func BaseDockerGameOptions(cfg *config.Config, engineImage, engineVersion, ddcMode, ddcPath, ddcZenPath, runtime string) dockerbuild.DockerGameOptions {
 	return dockerbuild.DockerGameOptions{
 		EngineImage:   engineImage,
 		ProjectPath:   cfg.Game.ProjectPath,
@@ -91,6 +104,7 @@ func BaseDockerGameOptions(cfg *config.Config, engineImage, engineVersion, ddcMo
 		EngineVersion: engineVersion,
 		DDCMode:       ddcMode,
 		DDCPath:       ddcPath,
+		DDCZenPath:    ddcZenPath,
 		Runtime:       runtime,
 	}
 }
@@ -107,10 +121,10 @@ func ResolveContainerGameOptions(cfg *config.Config, be string) (dockerbuild.Doc
 
 	engineVersion, _ := toolchain.DetectEngineVersion(cfg.Engine.SourcePath, cfg.Engine.Version)
 
-	ddcMode, ddcPath, err := ResolveDDC()
+	ddcMode, ddcPath, ddcZenPath, err := ResolveDDC()
 	if err != nil {
 		return dockerbuild.DockerGameOptions{}, fmt.Errorf("resolving DDC config: %w", err)
 	}
 
-	return BaseDockerGameOptions(cfg, engineImage, engineVersion, ddcMode, ddcPath, be), nil
+	return BaseDockerGameOptions(cfg, engineImage, engineVersion, ddcMode, ddcPath, ddcZenPath, be), nil
 }

--- a/cmd/globals/ddc_test.go
+++ b/cmd/globals/ddc_test.go
@@ -205,7 +205,7 @@ func TestResolveDDC(t *testing.T) {
 			Cfg = &config.Config{}
 			Cfg.DDC.LocalPath = tt.ddcPath
 
-			mode, path, err := ResolveDDC()
+			mode, path, _, err := ResolveDDC()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ResolveDDC() error = %v, wantErr %v", err, tt.wantErr)
 			}

--- a/cmd/mcp/tools_async.go
+++ b/cmd/mcp/tools_async.go
@@ -356,7 +356,7 @@ func startWSL2GameBuild(cfg *config.Config, input gameBuildStartInput, dryRun bo
 			return nil, fmt.Errorf("WSL2 init failed: %w\n\nIf WSL2 is not available, use Podman instead: ludus_game_build with backend=podman", wslErr)
 		}
 
-		ddcMode, ddcPath, ddcErr := globals.ResolveDDC()
+		ddcMode, ddcPath, _, ddcErr := globals.ResolveDDC()
 		if ddcErr != nil {
 			return nil, fmt.Errorf("resolving DDC: %w", ddcErr)
 		}
@@ -395,7 +395,7 @@ func startWSL2GameBuild(cfg *config.Config, input gameBuildStartInput, dryRun bo
 
 func startNativeGameBuild(cfg *config.Config, input gameBuildStartInput, dryRun bool, serverHash string) (*mcp.CallToolResult, any, error) {
 	engineVersion, _ := toolchain.DetectEngineVersion(cfg.Engine.SourcePath, cfg.Engine.Version)
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	ddcMode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return toolError(fmt.Sprintf("resolving DDC config: %v", err))
 	}
@@ -424,7 +424,7 @@ func startNativeGameBuild(cfg *config.Config, input gameBuildStartInput, dryRun 
 
 func startNativeClientBuild(cfg *config.Config, input gameClientStartInput, platform string, dryRun bool, clientHash string) (*mcp.CallToolResult, any, error) {
 	engineVersion, _ := toolchain.DetectEngineVersion(cfg.Engine.SourcePath, cfg.Engine.Version)
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	ddcMode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return toolError(fmt.Sprintf("resolving DDC config: %v", err))
 	}

--- a/cmd/mcp/tools_ddc.go
+++ b/cmd/mcp/tools_ddc.go
@@ -71,7 +71,7 @@ func registerDDCTools(s *mcpsdk.Server) {
 }
 
 func handleDDCStatus(ctx context.Context, _ *mcpsdk.CallToolRequest, _ ddcStatusInput) (*mcpsdk.CallToolResult, any, error) {
-	mode, ddcPath, err := globals.ResolveDDC()
+	mode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return toolError(err.Error())
 	}
@@ -174,7 +174,7 @@ func applyDDCConfig(input ddcConfigureInput, validated string) {
 }
 
 func resolveDDCConfigResult(changed bool) (*mcpsdk.CallToolResult, any, error) {
-	mode, ddcPath, err := globals.ResolveDDC()
+	mode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return toolError(err.Error())
 	}
@@ -191,6 +191,7 @@ func handleDDCWarm(ctx context.Context, _ *mcpsdk.CallToolRequest, input ddcWarm
 	if err != nil {
 		return toolError(err.Error())
 	}
+	_, _, ddcZenPath, _ := globals.ResolveDDC() //nolint:errcheck // already validated above
 
 	if input.DryRun {
 		return resultOK(ddcWarmResult{
@@ -200,11 +201,11 @@ func handleDDCWarm(ctx context.Context, _ *mcpsdk.CallToolRequest, input ddcWarm
 		})
 	}
 
-	return executeMCPWarmup(ctx, cfg, mode, ddcPath, engineImage)
+	return executeMCPWarmup(ctx, cfg, mode, ddcPath, ddcZenPath, engineImage)
 }
 
 func validateWarmPrereqs(cfg config.Config) (mode, ddcPath, engineImage string, err error) {
-	mode, ddcPath, err = globals.ResolveDDC()
+	mode, ddcPath, _, err = globals.ResolveDDC()
 	if err != nil {
 		return "", "", "", err
 	}
@@ -221,9 +222,9 @@ func validateWarmPrereqs(cfg config.Config) (mode, ddcPath, engineImage string, 
 	return mode, ddcPath, engineImage, nil
 }
 
-func executeMCPWarmup(ctx context.Context, cfg config.Config, mode, ddcPath, engineImage string) (*mcpsdk.CallToolResult, any, error) {
+func executeMCPWarmup(ctx context.Context, cfg config.Config, mode, ddcPath, ddcZenPath, engineImage string) (*mcpsdk.CallToolResult, any, error) {
 	r := runner.NewRunner(globals.Verbose, globals.DryRun)
-	opts := globals.BaseDockerGameOptions(&cfg, engineImage, cfg.Engine.Version, mode, ddcPath, cfg.Engine.Backend)
+	opts := globals.BaseDockerGameOptions(&cfg, engineImage, cfg.Engine.Version, mode, ddcPath, ddcZenPath, cfg.Engine.Backend)
 	opts.CookOnly = true
 	builder := dockerbuild.NewDockerGameBuilder(opts, r)
 

--- a/cmd/mcp/tools_ddc.go
+++ b/cmd/mcp/tools_ddc.go
@@ -187,39 +187,38 @@ func resolveDDCConfigResult(changed bool) (*mcpsdk.CallToolResult, any, error) {
 
 func handleDDCWarm(ctx context.Context, _ *mcpsdk.CallToolRequest, input ddcWarmInput) (*mcpsdk.CallToolResult, any, error) {
 	cfg := globals.Cfg.Clone()
-	mode, ddcPath, engineImage, err := validateWarmPrereqs(cfg)
+	mode, ddcPath, ddcZenPath, engineImage, err := validateWarmPrereqs(cfg)
 	if err != nil {
 		return toolError(err.Error())
 	}
-	_, _, ddcZenPath, _ := globals.ResolveDDC() //nolint:errcheck // already validated above
 
 	if input.DryRun {
 		return resultOK(ddcWarmResult{
 			Success: true,
-			Message: fmt.Sprintf("Would run DDC warmup:\n  Image: %s\n  Project: %s\n  DDC path: %s\n  Flags: -cook -skipbuild -NoCompile -NoCompileEditor -NoP4 -map=MinimalDefaultMap",
-				engineImage, cfg.Game.ProjectName, ddcPath),
+			Message: fmt.Sprintf("Would run DDC warmup:\n  Image: %s\n  Project: %s\n  DDC path: %s\n  ZenStore path: %s\n  Flags: -cook -skipbuild -NoCompile -NoCompileEditor -NoP4 -map=MinimalDefaultMap",
+				engineImage, cfg.Game.ProjectName, ddcPath, ddcZenPath),
 		})
 	}
 
 	return executeMCPWarmup(ctx, cfg, mode, ddcPath, ddcZenPath, engineImage)
 }
 
-func validateWarmPrereqs(cfg config.Config) (mode, ddcPath, engineImage string, err error) {
-	mode, ddcPath, _, err = globals.ResolveDDC()
+func validateWarmPrereqs(cfg config.Config) (mode, ddcPath, ddcZenPath, engineImage string, err error) {
+	mode, ddcPath, ddcZenPath, err = globals.ResolveDDC()
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
 	if mode == ddc.ModeNone {
-		return "", "", "", fmt.Errorf("DDC warmup requires 'local' mode (current mode: none)")
+		return "", "", "", "", fmt.Errorf("DDC warmup requires 'local' mode (current mode: none)")
 	}
 	if !dockerbuild.IsContainerBackend(cfg.Engine.Backend) && cfg.Engine.DockerImage == "" {
-		return "", "", "", fmt.Errorf("DDC warmup requires a container backend (set engine.backend to podman or docker in ludus.yaml)")
+		return "", "", "", "", fmt.Errorf("DDC warmup requires a container backend (set engine.backend to podman or docker in ludus.yaml)")
 	}
 	engineImage, err = globals.ResolveEngineImage(&cfg, true)
 	if err != nil {
-		return "", "", "", err
+		return "", "", "", "", err
 	}
-	return mode, ddcPath, engineImage, nil
+	return mode, ddcPath, ddcZenPath, engineImage, nil
 }
 
 func executeMCPWarmup(ctx context.Context, cfg config.Config, mode, ddcPath, ddcZenPath, engineImage string) (*mcpsdk.CallToolResult, any, error) {

--- a/cmd/mcp/tools_ddc_test.go
+++ b/cmd/mcp/tools_ddc_test.go
@@ -82,7 +82,7 @@ func TestValidateWarmPrereqs(t *testing.T) {
 		globals.DDCMode = "none"
 		globals.Cfg = &config.Config{}
 
-		_, _, _, err := validateWarmPrereqs(config.Config{})
+		_, _, _, _, err := validateWarmPrereqs(config.Config{})
 		if err == nil {
 			t.Error("expected error for mode=none")
 		}
@@ -100,7 +100,7 @@ func TestValidateWarmPrereqs(t *testing.T) {
 		globals.Cfg.DDC.LocalPath = t.TempDir()
 
 		cfg := config.Config{Engine: config.EngineConfig{Backend: "native"}}
-		_, _, _, err := validateWarmPrereqs(cfg)
+		_, _, _, _, err := validateWarmPrereqs(cfg)
 		if err == nil {
 			t.Error("expected error for non-container backend")
 		}
@@ -126,7 +126,7 @@ func TestValidateWarmPrereqs(t *testing.T) {
 		}}
 		// Should NOT error on the backend check; may fail on engine image resolution
 		// (state is empty), but that is a different error path.
-		_, _, _, err := validateWarmPrereqs(cfg)
+		_, _, _, _, err := validateWarmPrereqs(cfg)
 		if err != nil && err.Error() == "DDC warmup requires a container backend (set engine.backend to docker or podman in ludus.yaml)" {
 			t.Error("explicit docker_image should bypass the backend check")
 		}

--- a/cmd/mcp/tools_game.go
+++ b/cmd/mcp/tools_game.go
@@ -61,7 +61,7 @@ func registerGameTools(s *mcp.Server) {
 func makeGameBuildOpts(cfg *config.Config, skipCook bool, clientPlatform, serverConfig string, jobs int) (game.BuildOptions, error) {
 	engineVersion, _ := toolchain.DetectEngineVersion(cfg.Engine.SourcePath, cfg.Engine.Version)
 
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	ddcMode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return game.BuildOptions{}, fmt.Errorf("resolving DDC config: %w", err)
 	}
@@ -255,7 +255,7 @@ func setupWSL2GameBuild(cfg *config.Config, input gameBuildInput) (*wsl.WSL2, ws
 		return nil, wsl.GameOptions{}, fmt.Errorf("WSL2 init failed: %v\n\nIf WSL2 is not available, use Podman instead: ludus_game_build with backend=podman", err)
 	}
 
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	ddcMode, ddcPath, _, err := globals.ResolveDDC()
 	if err != nil {
 		return nil, wsl.GameOptions{}, fmt.Errorf("resolving DDC: %v", err)
 	}

--- a/cmd/pipeline/pipeline.go
+++ b/cmd/pipeline/pipeline.go
@@ -108,7 +108,7 @@ func newPipelineCtx(cmd *cobra.Command) (*pipelineCtx, error) {
 
 	be := resolveBackend()
 
-	ddcMode, ddcPath, err := globals.ResolveDDC()
+	ddcMode, ddcPath, ddcZenPath, err := globals.ResolveDDC()
 	if err != nil {
 		return nil, fmt.Errorf("resolving DDC config: %w", err)
 	}
@@ -120,6 +120,7 @@ func newPipelineCtx(cmd *cobra.Command) (*pipelineCtx, error) {
 		containerBackend: be,
 		ddcMode:          ddcMode,
 		ddcPath:          ddcPath,
+		ddcZenPath:       ddcZenPath,
 		arch:             arch,
 		serverBuildDir:   serverBuildDir,
 		target:           target,

--- a/cmd/pipeline/stages.go
+++ b/cmd/pipeline/stages.go
@@ -21,6 +21,7 @@ type pipelineCtx struct {
 	containerBackend string
 	ddcMode          string
 	ddcPath          string
+	ddcZenPath       string
 	arch             string
 	serverBuildDir   string
 	target           deploy.Target

--- a/cmd/pipeline/stages_game.go
+++ b/cmd/pipeline/stages_game.go
@@ -54,7 +54,7 @@ func (p *pipelineCtx) baseDockerGameOpts() (dockerbuild.DockerGameOptions, error
 	if err != nil {
 		return dockerbuild.DockerGameOptions{}, err
 	}
-	return globals.BaseDockerGameOptions(p.cfg, engineImage, p.engineVersion, p.ddcMode, p.ddcPath, p.containerBackend), nil
+	return globals.BaseDockerGameOptions(p.cfg, engineImage, p.engineVersion, p.ddcMode, p.ddcPath, p.ddcZenPath, p.containerBackend), nil
 }
 
 func (p *pipelineCtx) buildGameContainer(ctx context.Context) (*gameBuilder.BuildResult, error) {

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -154,4 +154,9 @@ type CIConfig struct {
 type DDCConfig struct {
 	Mode      string `yaml:"mode" mapstructure:"mode"`
 	LocalPath string `yaml:"localPath" mapstructure:"localPath"`
+	// ZenPath overrides the host directory for the UE5 ZenStore cache.
+	// On UE 5.6+, cook DDC is written to ZenStore rather than the FileSystem
+	// Local backend, so this path must be persisted to get DDC reuse in
+	// container builds. Defaults to ~/.ludus/zen when mode is "local".
+	ZenPath string `yaml:"zenPath" mapstructure:"zenPath"`
 }

--- a/internal/ddc/ddc.go
+++ b/internal/ddc/ddc.go
@@ -46,8 +46,10 @@ func EnvOverride(path string) string {
 // ZenContainerPath is the fixed path inside the container where UE5 writes
 // its ZenStore data. This resolves from the Zen.AutoLaunch DataPath template
 // (%ENGINEVERSIONAGNOSTICINSTALLEDUSERDIR%Zen/Data) under the ue user's home.
+// On UE 5.6+, %ENGINEVERSIONAGNOSTICINSTALLEDUSERDIR% resolves to
+// ~/.config/Epic/UnrealEngine/Common/, giving the full path below.
 // Mounting a host directory here persists the ZenStore across --rm container runs.
-const ZenContainerPath = "/home/ue/.config/Epic/UnrealEngine/Zen/Data"
+const ZenContainerPath = "/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data"
 
 // DefaultZenPath returns the default ZenStore host directory: ~/.ludus/zen
 func DefaultZenPath() (string, error) {

--- a/internal/ddc/ddc.go
+++ b/internal/ddc/ddc.go
@@ -43,6 +43,32 @@ func EnvOverride(path string) string {
 	return fmt.Sprintf("UE-LocalDataCachePath=%s", normalized)
 }
 
+// ZenContainerPath is the fixed path inside the container where UE5 writes
+// its ZenStore data. This resolves from the Zen.AutoLaunch DataPath template
+// (%ENGINEVERSIONAGNOSTICINSTALLEDUSERDIR%Zen/Data) under the ue user's home.
+// Mounting a host directory here persists the ZenStore across --rm container runs.
+const ZenContainerPath = "/home/ue/.config/Epic/UnrealEngine/Zen/Data"
+
+// DefaultZenPath returns the default ZenStore host directory: ~/.ludus/zen
+func DefaultZenPath() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolving home directory: %w", err)
+	}
+	return filepath.Join(home, ".ludus", "zen"), nil
+}
+
+// ResolveZenPath returns the override path if non-empty, otherwise DefaultZenPath.
+func ResolveZenPath(override string) (string, error) {
+	if override != "" {
+		if !filepath.IsAbs(override) {
+			return "", fmt.Errorf("DDC zen path must be absolute (got %q)", override)
+		}
+		return override, nil
+	}
+	return DefaultZenPath()
+}
+
 // DefaultPath returns the default DDC directory path: ~/.ludus/ddc
 func DefaultPath() (string, error) {
 	home, err := os.UserHomeDir()

--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -44,8 +44,12 @@ type DockerGameOptions struct {
 	EngineVersion string
 	// DDCMode is the DDC backend mode: "local" or "none".
 	DDCMode string
-	// DDCPath is the host path for the local DDC volume.
+	// DDCPath is the host path for the FileSystem Local DDC volume (UE 5.5 and below).
 	DDCPath string
+	// DDCZenPath is the host path for the ZenStore DDC volume (UE 5.6+).
+	// On UE 5.6+, cook DDC is written to ZenStore. Mounting this directory
+	// at the container's ZenStore data path persists it across --rm runs.
+	DDCZenPath string
 	// CookOnly runs only the cook step, skipping build/stage/package/archive.
 	// Used for DDC warmup.
 	CookOnly bool
@@ -388,11 +392,25 @@ func (b *DockerGameBuilder) ddcArgs() ([]string, error) {
 		if err := os.MkdirAll(b.opts.DDCPath, 0755); err != nil {
 			return nil, fmt.Errorf("creating DDC directory: %w", err)
 		}
-		fmt.Printf("DDC: local (persistent at %s)\n", b.opts.DDCPath)
-		return []string{
+		args := []string{
 			"-v", fmt.Sprintf("%s:/ddc", b.opts.DDCPath),
 			"-e", ddc.EnvOverride("/ddc"),
-		}, nil
+		}
+		// Mount the ZenStore data path so UE 5.6+ cook DDC persists across runs.
+		// On 5.6+, cook DDC is written to ZenStore rather than the FileSystem
+		// Local backend, making the /ddc mount a no-op for cook data without this.
+		if b.opts.DDCZenPath != "" {
+			if err := os.MkdirAll(b.opts.DDCZenPath, 0755); err != nil { //nolint:gosec // user-configured path
+				return nil, fmt.Errorf("creating DDC zen directory: %w", err)
+			}
+			args = append(args,
+				"-v", fmt.Sprintf("%s:%s", b.opts.DDCZenPath, ddc.ZenContainerPath),
+			)
+			fmt.Printf("DDC: local (filesystem at %s, ZenStore at %s)\n", b.opts.DDCPath, b.opts.DDCZenPath)
+		} else {
+			fmt.Printf("DDC: local (persistent at %s)\n", b.opts.DDCPath)
+		}
+		return args, nil
 	case ddc.ModeNone:
 		fmt.Println("DDC: disabled")
 		return nil, nil

--- a/ludus.example.yaml
+++ b/ludus.example.yaml
@@ -97,6 +97,18 @@ aws:
     Environment: "dev"
     ManagedBy: "ludus"
 
+# ddc:
+#   # DDC mode: "local" (default, persistent cache) or "none" (disable)
+#   mode: "local"
+#   # Host path for the FileSystem Local DDC (UE 5.5 and below).
+#   # Defaults to ~/.ludus/ddc
+#   # localPath: "/home/user/.ludus/ddc"
+#   # Host path for the ZenStore DDC (UE 5.6+).
+#   # On UE 5.6+, cook DDC is written to ZenStore. Mount this path to
+#   # persist the cook cache across container runs and get DDC speedup.
+#   # Defaults to ~/.ludus/zen
+#   # zenPath: "/home/user/.ludus/zen"
+
 # ci:
 #   # Path for generated GitHub Actions workflow file
 #   workflowPath: ".github/workflows/ludus-pipeline.yml"


### PR DESCRIPTION
## Summary

On UE 5.6+, cook DDC is written to the ZenStore rather than the FileSystem Local backend. The existing \`/ddc\` volume mount only redirects the FileSystem Local node, which is write-disabled in the default DDC graph — so the cook cache was silently discarded on every \`--rm\` container run.

Fix: when \`ddc.mode\` is \`local\`, also mount a host directory at the container's fixed ZenStore data path:

\`\`\`
~/.ludus/zen  →  /home/ue/.config/Epic/UnrealEngine/Zen/Data
\`\`\`

This is where \`Zen.AutoLaunch\` resolves \`%ENGINEVERSIONAGNOSTICINSTALLEDUSERDIR%Zen/Data\` under the \`ue\` container user. Persisting it gives repeat builds full DDC reuse on UE 5.6+.

The existing \`/ddc\` mount is preserved for backward compatibility with UE 5.5 and below.

## New config field

\`\`\`yaml
ddc:
  zenPath: "/home/user/.ludus/zen"  # defaults to ~/.ludus/zen
\`\`\`

## Files changed

- \`internal/ddc/ddc.go\` — \`ZenContainerPath\`, \`DefaultZenPath()\`, \`ResolveZenPath()\`
- \`internal/config/config_types.go\` — \`DDCConfig.ZenPath\`
- \`internal/dockerbuild/game.go\` — \`DockerGameOptions.DDCZenPath\`, mount in \`ddcArgs()\`
- \`cmd/globals/ddc.go\` — \`ResolveZenPath()\`, \`ResolveDDC()\` returns zen path, \`BaseDockerGameOptions\` threads it through
- All \`ResolveDDC()\` call sites updated (14 files)
- \`ludus.example.yaml\` — documented \`ddc.zenPath\`

## Test plan

- [ ] After game build on UE 5.6+ with \`ddc.mode: local\`, \`~/.ludus/zen\` should be non-empty
- [ ] Second game build on same project should be faster (ZenStore cache hit)
- [ ] \`ddc.mode: none\` skips both mounts as before
- [ ] UE 5.5 builds unaffected (ZenPath mounted but unused)

Fixes #298.