### PR TITLE
fix: don't assert no-QEMU on Apple Silicon in cross-arch native test

### DIFF
--- a/internal/prereq/checker_crossarch_test.go
+++ b/internal/prereq/checker_crossarch_test.go
@@ -54,7 +54,11 @@ func TestCheckCrossArchEmulation_NativeArchWithContainerBackend(t *testing.T) {
 			if !result.Passed {
 				t.Errorf("native %s target with %s backend should pass, got: %s", runtime.GOARCH, backend, result.Message)
 			}
-			if strings.Contains(result.Message, "QEMU") {
+			// Apple Silicon + container backend always emulates x86_64 (Epic
+			// toolchain is x86_64-only), so the QEMU note is expected there and
+			// is handled before the native-arch check. Only assert the
+			// no-emulation message off that path.
+			if !c.isAppleSiliconContainerBackend() && strings.Contains(result.Message, "QEMU") {
 				t.Errorf("native build should not mention QEMU emulation, got: %s", result.Message)
 			}
 		})


### PR DESCRIPTION
## Problem

`TestCheckCrossArchEmulation_NativeArchWithContainerBackend` (added in #321) fails on macOS CI (Apple Silicon runners). It asserts the result message never contains "QEMU", but on darwin/arm64 the `isAppleSiliconContainerBackend()` path fires first and correctly emits a QEMU emulation note (Epic ships only an x86_64 Linux toolchain, so even native-arch targets emulate there). This left main red on `Test (macos-latest)`.

## Fix

Gate the no-QEMU assertion to non-Apple-Silicon hosts. The `result.Passed` check still applies on every platform. Verified with `go test` (Windows) and `GOOS=darwin go vet`.