### PR TITLE
fix: backend-aware disk validation (enforce container 1 TB requirement)

### DIFF
--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/dockerbuild"
 	"github.com/jpvelasco/ludus/internal/toolchain"
 )
 
@@ -22,6 +23,43 @@ type CheckResult struct {
 	Passed  bool   `json:"passed"`
 	Warning bool   `json:"warning,omitempty"`
 	Message string `json:"message"`
+}
+
+// Disk space requirements (GB). Native builds need room for a built engine
+// (~280–320 GB). Container builds need far more: the multi-stage Docker build
+// accumulates ~200 GB of BuildKit cache on top of the engine image, source, and
+// artifacts (see README; 2 TB recommended, 1 TB minimum).
+const (
+	nativeDiskRequiredGB    = 300
+	containerDiskRequiredGB = 1000
+)
+
+// diskSpaceRequiredGB returns the free-disk requirement for the given backend.
+// Container backends (docker/podman) require the larger container minimum.
+func diskSpaceRequiredGB(backend string) int {
+	if dockerbuild.IsContainerBackend(backend) {
+		return containerDiskRequiredGB
+	}
+	return nativeDiskRequiredGB
+}
+
+// diskSpaceResult builds the Disk Space CheckResult from the measured free space
+// and the configured backend. Platform files compute freeGB via the appropriate
+// syscall and delegate here so the threshold logic is shared and testable.
+func diskSpaceResult(freeGB uint64, backend string) CheckResult {
+	requiredGB := diskSpaceRequiredGB(backend)
+	if freeGB < uint64(requiredGB) {
+		return CheckResult{
+			Name:    "Disk Space",
+			Passed:  false,
+			Message: fmt.Sprintf("%d GB free, need %d GB", freeGB, requiredGB),
+		}
+	}
+	return CheckResult{
+		Name:    "Disk Space",
+		Passed:  true,
+		Message: fmt.Sprintf("%d GB free", freeGB),
+	}
 }
 
 // Checker validates that all prerequisites for the Ludus pipeline are met.

--- a/internal/prereq/checker_darwin.go
+++ b/internal/prereq/checker_darwin.go
@@ -30,21 +30,7 @@ func (c *Checker) checkDiskSpace() CheckResult {
 	}
 
 	freeGB := (stat.Bavail * uint64(stat.Bsize)) / (1024 * 1024 * 1024)
-	const requiredGB = 300
-
-	if freeGB < requiredGB {
-		return CheckResult{
-			Name:    "Disk Space",
-			Passed:  false,
-			Message: fmt.Sprintf("%d GB free, need %d GB", freeGB, requiredGB),
-		}
-	}
-
-	return CheckResult{
-		Name:    "Disk Space",
-		Passed:  true,
-		Message: fmt.Sprintf("%d GB free", freeGB),
-	}
+	return diskSpaceResult(freeGB, c.Backend)
 }
 
 func (c *Checker) platformChecks() []CheckResult {

--- a/internal/prereq/checker_disk_test.go
+++ b/internal/prereq/checker_disk_test.go
@@ -1,0 +1,60 @@
+package prereq
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiskSpaceResult(t *testing.T) {
+	tests := []struct {
+		name       string
+		freeGB     uint64
+		backend    string
+		wantPassed bool
+		wantNeedGB int
+	}{
+		{
+			name:       "native build with ample disk passes",
+			freeGB:     400,
+			backend:    "",
+			wantPassed: true,
+			wantNeedGB: nativeDiskRequiredGB,
+		},
+		{
+			name:       "native build below 300 fails",
+			freeGB:     250,
+			backend:    "native",
+			wantPassed: false,
+			wantNeedGB: nativeDiskRequiredGB,
+		},
+		{
+			name:       "container build with 300-999 GB fails (needs 1 TB)",
+			freeGB:     500,
+			backend:    "docker",
+			wantPassed: false,
+			wantNeedGB: containerDiskRequiredGB,
+		},
+		{
+			name:       "container build above 1 TB passes",
+			freeGB:     1100,
+			backend:    "podman",
+			wantPassed: true,
+			wantNeedGB: containerDiskRequiredGB,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			res := diskSpaceResult(tt.freeGB, tt.backend)
+			if res.Name != "Disk Space" {
+				t.Errorf("Name = %q, want \"Disk Space\"", res.Name)
+			}
+			if res.Passed != tt.wantPassed {
+				t.Errorf("Passed = %v, want %v (msg: %s)", res.Passed, tt.wantPassed, res.Message)
+			}
+			if !tt.wantPassed && !strings.Contains(res.Message, "need") {
+				t.Errorf("failing result should state requirement, got: %s", res.Message)
+			}
+		})
+	}
+}

--- a/internal/prereq/checker_docker.go
+++ b/internal/prereq/checker_docker.go
@@ -147,7 +147,10 @@ func podmanMachineResourceWarning(podmanBin string) string {
 }
 
 const (
-	podmanMinDiskGB = 300
+	// The podman machine VM is where the container build runs, so its virtual
+	// disk must hold the same container-build footprint as a host (engine image
+	// + ~200 GB BuildKit cache + artifacts).
+	podmanMinDiskGB = containerDiskRequiredGB
 	podmanMinMemMB  = 8 * 1024 // 8 GB in MB
 )
 
@@ -164,9 +167,9 @@ func podmanResourceWarningFromResources(res podmanMachineResources) string {
 	if len(issues) == 0 {
 		return ""
 	}
-	return fmt.Sprintf("podman machine under-provisioned for UE5 engine builds: %s — "+
+	return fmt.Sprintf("podman machine under-provisioned for UE5 container builds: %s — "+
 		"recreate with: podman machine stop && podman machine rm && "+
-		"podman machine init --disk-size 400 --memory 12288 --cpus 8 && podman machine start",
+		"podman machine init --disk-size 1100 --memory 12288 --cpus 8 && podman machine start",
 		strings.Join(issues, ", "))
 }
 

--- a/internal/prereq/checker_podman_machine_test.go
+++ b/internal/prereq/checker_podman_machine_test.go
@@ -70,7 +70,7 @@ func TestPodmanMachineResourceWarning_WellProvisioned(t *testing.T) {
 	// podmanMachineResourceWarning runs a real command — on machines without podman
 	// it returns "" (best-effort), which is the correct behavior.
 	// We test the warning logic directly via the helper functions instead.
-	res := podmanMachineResources{DiskSize: 400, Memory: 12288}
+	res := podmanMachineResources{DiskSize: 1100, Memory: 12288}
 	warn := podmanResourceWarningFromResources(res)
 	if warn != "" {
 		t.Errorf("expected no warning for well-provisioned machine, got: %s", warn)
@@ -86,13 +86,13 @@ func TestPodmanMachineResourceWarning_LowDisk(t *testing.T) {
 	if !strings.Contains(warn, "disk") {
 		t.Errorf("expected 'disk' in warning, got: %s", warn)
 	}
-	if !strings.Contains(warn, "300") {
+	if !strings.Contains(warn, "1000") {
 		t.Errorf("expected required disk size in warning, got: %s", warn)
 	}
 }
 
 func TestPodmanMachineResourceWarning_LowMemory(t *testing.T) {
-	res := podmanMachineResources{DiskSize: 400, Memory: 2048}
+	res := podmanMachineResources{DiskSize: 1100, Memory: 2048}
 	warn := podmanResourceWarningFromResources(res)
 	if warn == "" {
 		t.Error("expected warning for low memory, got empty string")
@@ -117,7 +117,7 @@ func TestPodmanMachineResourceWarning_BothLow(t *testing.T) {
 }
 
 func TestPodmanMachineResourceWarning_AtThreshold(t *testing.T) {
-	res := podmanMachineResources{DiskSize: 300, Memory: 8 * 1024}
+	res := podmanMachineResources{DiskSize: containerDiskRequiredGB, Memory: 8 * 1024}
 	warn := podmanResourceWarningFromResources(res)
 	if warn != "" {
 		t.Errorf("expected no warning at exact thresholds, got: %s", warn)

--- a/internal/prereq/checker_unix.go
+++ b/internal/prereq/checker_unix.go
@@ -25,21 +25,7 @@ func (c *Checker) checkDiskSpace() CheckResult {
 	}
 
 	freeGB := (stat.Bavail * uint64(stat.Bsize)) / (1024 * 1024 * 1024)
-	const requiredGB = 300
-
-	if freeGB < requiredGB {
-		return CheckResult{
-			Name:    "Disk Space",
-			Passed:  false,
-			Message: fmt.Sprintf("%d GB free, need %d GB", freeGB, requiredGB),
-		}
-	}
-
-	return CheckResult{
-		Name:    "Disk Space",
-		Passed:  true,
-		Message: fmt.Sprintf("%d GB free", freeGB),
-	}
+	return diskSpaceResult(freeGB, c.Backend)
 }
 
 func (c *Checker) platformChecks() []CheckResult {

--- a/internal/prereq/checker_windows.go
+++ b/internal/prereq/checker_windows.go
@@ -419,21 +419,7 @@ func (c *Checker) checkDiskSpace() CheckResult {
 	}
 
 	freeGB := freeBytesAvailable / (1024 * 1024 * 1024)
-	const requiredGB = 300
-
-	if freeGB < requiredGB {
-		return CheckResult{
-			Name:    "Disk Space",
-			Passed:  false,
-			Message: fmt.Sprintf("%d GB free, need %d GB", freeGB, requiredGB),
-		}
-	}
-
-	return CheckResult{
-		Name:    "Disk Space",
-		Passed:  true,
-		Message: fmt.Sprintf("%d GB free", freeGB),
-	}
+	return diskSpaceResult(freeGB, c.Backend)
 }
 
 type memoryStatusEx struct {


### PR DESCRIPTION
Closes #331.

## Problem

`ludus init` validated a flat **300 GB** free-disk floor on every backend. Container builds need far more (~1 TB: engine image + ~200 GB BuildKit cache + build artifacts), so a host with 300–999 GB free passed validation and could then fail mid-build with a disk-full error. Documented in #317 as a known gap; this enforces it.

## Changes

- Add a backend-aware `diskSpaceResult` helper in `checker.go` (`nativeDiskRequiredGB = 300`, `containerDiskRequiredGB = 1000`). The three platform `checkDiskSpace` funcs (unix/windows/darwin) now share it instead of each hardcoding 300 — container backends (`docker`/`podman`) require the container minimum.
- Raise the podman-machine disk threshold to the container minimum (the VM is where the container build + BuildKit cache actually live) and bump the recreate hint to `--disk-size 1100`.
- Tests: threshold matrix for `diskSpaceResult`; updated podman-machine resource tests.

Verified with `go test`, `GOOS=darwin go vet`, and `golangci-lint` (0 issues).