### PR TITLE
fix: self-healing npm install/upgrade for ludus-cli

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,6 +40,13 @@ Not all stages run for every target — the pipeline checks `target.Capabilities
 - `cmd/root/init.go` — the `init` command lives here, not in a separate `cmd/init/` package
 - `internal/` — all business logic, one primary type per file, unexported packages
 
+Beyond the six pipeline stages, these top-level commands exist:
+- `ludus setup` (`cmd/setup/`) — interactive first-time wizard: scans system, auto-detects UE source/version, picks deploy target, writes `ludus.yaml` (`--profile` writes `ludus-<name>.yaml`).
+- `ludus config` (`cmd/configcmd/`) — `get`/`set`/`view` for `ludus.yaml` via dot-notation keys (e.g. `ludus config set engine.version 5.7.3`).
+- `ludus doctor` (`cmd/doctor/`) — deeper diagnostics than `init` (stale DLLs, toolchain mismatch, disk, partial build state, AWS credential expiry, cache integrity). Use when `init` passes but something is broken.
+- `ludus ci` (`cmd/ci/`, `internal/ci/`) — `ci init` generates a GitHub Actions workflow; `ci runner` manages a self-hosted runner agent.
+- `ludus logs` (`cmd/logs/`), `ludus resources` (`cmd/resources/`), `ludus ddc` (`cmd/ddc/`), `ludus buildgraph` (`cmd/buildgraph/`) — see their respective sections below.
+
 ### Deploy Target System
 
 All backends implement `deploy.Target` interface (`internal/deploy/target.go`). Five targets: `gamelift`, `stack`, `ec2`, `anywhere`, `binary`. Factory in `cmd/globals/resolve.go` instantiates the correct target from config.
@@ -121,7 +128,7 @@ Full style guide in [AGENTS.md](AGENTS.md). Key points for quick reference:
 - **Errors**: `fmt.Errorf("context: %w", err)`. No sentinel errors, no custom types. AWS errors via `smithy.APIError` + `errors.As()`. `internal/diagnose/` matches error patterns to user-facing hints — add new patterns there rather than embedding hint strings in command code.
 - **Output**: `fmt.Println`/`fmt.Printf` for status. No logging library. JSON conditional on `globals.JSONOutput`.
 - **Shell execution**: Always through `runner.Runner`, never raw `exec.Command`.
-- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. 30/34 internal packages have tests. AWS-heavy packages (ec2fleet) and interface-only packages (deploy, version) rely on E2E or integration coverage.
+- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. 32/36 internal packages have tests. AWS-heavy packages (ec2fleet) and interface-only packages (deploy, version) rely on E2E or integration coverage.
 - **Platform code**: `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
 - **Imports**: Two groups separated by a blank line — stdlib first, then third-party and project imports together (alphabetically sorted). Aliases only to resolve conflicts (e.g. `gltypes`, `cftypes`).
 - **Naming**: Acronyms fully uppercase (`ID`, `URI`, `ARN`, `ECR`). Constructors `New*` returning a pointer. Single-letter pointer receivers matching type initial (`b *Builder`, `d *Deployer`). `context.Context` is the first parameter for all I/O or long-running methods.
@@ -149,3 +156,5 @@ Approved feature designs are kept locally (not in the public repo). Check local 
 Tag `vX.Y.Z` on main → `.github/workflows/release.yml` → GoReleaser builds 5 binaries → `scripts/embed-checksums.js` writes SHA-256 into `npm/package.json` → `npm publish` from `npm/` directory. `scripts/validate_ue_versions.sh` validates UE version consistency at init/CI time.
 
 npm package: `ludus-cli`. README in `npm/README.md`, keywords in `npm/package.json`.
+
+The published tarball is a thin shim and ships **no binary** (`bin/` is git/npm-ignored). `npm/install.js` exports `ensureBinary()`, which downloads the platform archive from the GitHub release, SHA-256-verifies it against `package.json`'s `binaryChecksums`, extracts atomically (unique temp dir + rename), and writes a `bin/.installed-version` marker. `postinstall` runs it once; `npm/run.js` (the `bin` entry) also calls it before every spawn, so a skipped postinstall (`ignore-scripts`/pnpm), a failed download, or a version-skewed binary self-heals on first run. The marker comparison short-circuits the common path (cheap file reads, no network). **All `ensureBinary` progress must go to stderr** — `ludus mcp` (JSON-RPC) and `--json` write to stdout. `LUDUS_SKIP_AUTO_DOWNLOAD=1` bypasses the self-heal for air-gapped/self-managed binaries. Tests: `cd npm && npm test` (`node --test`, network-free).

--- a/npm/README.md
+++ b/npm/README.md
@@ -10,11 +10,23 @@ Ludus handles the entire workflow that would otherwise require dozens of manual 
 npm install -g ludus-cli
 ```
 
+Upgrade to the latest version the same way:
+
+```bash
+npm install -g ludus-cli@latest
+```
+
 Or run directly:
 
 ```bash
 npx ludus-cli --help
 ```
+
+The package downloads a small prebuilt binary on install. If your environment
+blocks install scripts (e.g. `--ignore-scripts`, pnpm, locked-down CI), `ludus`
+fetches the matching binary on first run instead — no extra steps. To manage the
+binary yourself (air-gapped setups), set `LUDUS_SKIP_AUTO_DOWNLOAD=1` and place
+the `ludus` binary under the package's `bin/` directory.
 
 ## What it does
 

--- a/npm/install.js
+++ b/npm/install.js
@@ -9,6 +9,7 @@ const { spawnSync } = require("child_process");
 
 const REPO = "jpvelasco/ludus";
 const MAX_REDIRECTS = 5;
+const MARKER = ".installed-version";
 
 const PLATFORM_MAP = {
   linux: "linux",
@@ -20,6 +21,18 @@ const ARCH_MAP = {
   x64: "amd64",
   arm64: "arm64",
 };
+
+// log writes routine progress to stderr (never stdout) so it can't corrupt
+// `ludus mcp` JSON-RPC or `--json` output, and stays quiet when silent.
+function log(silent, msg) {
+  if (!silent) {
+    console.error(msg);
+  }
+}
+
+function binaryName(platform = process.platform) {
+  return platform === "win32" ? "ludus.exe" : "ludus";
+}
 
 function getPackageVersion() {
   const pkg = JSON.parse(
@@ -52,6 +65,21 @@ function getArchiveName(version, platform, arch) {
   return `ludus_${version}_${os}_${cpu}.${ext}`;
 }
 
+// needsDownload reports whether the binary must be (re)fetched: true when the
+// binary is missing, or when the recorded marker version doesn't match the
+// package version (drift after a skipped/failed install or an upgrade).
+function needsDownload(binDir, version) {
+  if (!fs.existsSync(path.join(binDir, binaryName()))) {
+    return true;
+  }
+  try {
+    const installed = fs.readFileSync(path.join(binDir, MARKER), "utf8").trim();
+    return installed !== version;
+  } catch {
+    return true;
+  }
+}
+
 function download(url, redirectCount = 0) {
   return new Promise((resolve, reject) => {
     if (redirectCount > MAX_REDIRECTS) {
@@ -75,10 +103,10 @@ function download(url, redirectCount = 0) {
   });
 }
 
-function verifyChecksum(buffer, archiveName) {
+function verifyChecksum(buffer, archiveName, { silent = false } = {}) {
   const expected = getExpectedChecksum(archiveName);
   if (!expected) {
-    console.log("ludus-cli: no checksum available, skipping verification");
+    log(silent, "ludus-cli: no checksum available, skipping verification");
     return;
   }
 
@@ -90,7 +118,7 @@ function verifyChecksum(buffer, archiveName) {
         `  Actual:   ${actual}`
     );
   }
-  console.log("ludus-cli: checksum verified (SHA-256)");
+  log(silent, "ludus-cli: checksum verified (SHA-256)");
 }
 
 // Escape a string for use inside PowerShell single quotes.
@@ -110,9 +138,25 @@ function spawnOrFail(cmd, args, label) {
   }
 }
 
+// placeBinary moves src onto dest atomically. renameSync is atomic on POSIX and
+// overwrites; on Windows it refuses to overwrite an existing file, so fall back
+// to removing dest first (the binary is never running during a self-heal).
+function placeBinary(src, dest) {
+  try {
+    fs.renameSync(src, dest);
+  } catch (err) {
+    if (err.code === "EEXIST" || err.code === "EPERM") {
+      fs.rmSync(dest, { force: true });
+      fs.renameSync(src, dest);
+    } else {
+      throw err;
+    }
+  }
+}
+
 function extract(buffer, archiveName, binDir) {
-  const tmpDir = path.join(__dirname, ".tmp-install");
-  fs.mkdirSync(tmpDir, { recursive: true });
+  // Unique temp dir per run so concurrent invocations don't clobber each other.
+  const tmpDir = fs.mkdtempSync(path.join(__dirname, ".tmp-install-"));
 
   const archivePath = path.join(tmpDir, archiveName);
   fs.writeFileSync(archivePath, buffer);
@@ -137,48 +181,74 @@ function extract(buffer, archiveName, binDir) {
     }
 
     // Find the binary in the extracted files
-    const binaryName = process.platform === "win32" ? "ludus.exe" : "ludus";
-    const extractedBinary = path.join(tmpDir, binaryName);
+    const bn = binaryName();
+    const extractedBinary = path.join(tmpDir, bn);
 
     if (!fs.existsSync(extractedBinary)) {
-      throw new Error(`Binary ${binaryName} not found in archive`);
+      throw new Error(`Binary ${bn} not found in archive`);
+    }
+
+    if (process.platform !== "win32") {
+      fs.chmodSync(extractedBinary, 0o755);
     }
 
     fs.mkdirSync(binDir, { recursive: true });
-    const destBinary = path.join(binDir, binaryName);
-    fs.copyFileSync(extractedBinary, destBinary);
-
-    if (process.platform !== "win32") {
-      fs.chmodSync(destBinary, 0o755);
-    }
+    placeBinary(extractedBinary, path.join(binDir, bn));
   } finally {
     fs.rmSync(tmpDir, { recursive: true, force: true });
   }
 }
 
-async function main() {
+// ensureBinary makes the platform binary present and matching the package
+// version, downloading it if missing or stale. It is a no-op (cheap file reads
+// only) when the binary already matches. Safe to call on every CLI invocation.
+// All progress goes to stderr; routine chatter is suppressed when silent.
+async function ensureBinary({ silent = false } = {}) {
   const version = getPackageVersion();
   if (version === "0.0.0") {
-    console.error("ludus-cli: skipping binary download for development version");
+    log(silent, "ludus-cli: skipping binary download for development version");
+    return;
+  }
+
+  const binDir = path.join(__dirname, "bin");
+  if (!needsDownload(binDir, version)) {
     return;
   }
 
   const archiveName = getArchiveName(version, process.platform, process.arch);
   const url = `https://github.com/${REPO}/releases/download/v${version}/${archiveName}`;
-  const binDir = path.join(__dirname, "bin");
 
-  console.log(`ludus-cli: downloading ${archiveName}...`);
+  // One concise notice whenever an actual download happens (even when silent),
+  // so a runtime self-heal isn't a silent multi-second hang.
+  console.error(`ludus-cli: fetching ludus binary v${version}...`);
+
+  log(silent, `ludus-cli: downloading ${archiveName}...`);
   const buffer = await download(url);
 
-  verifyChecksum(buffer, archiveName);
+  verifyChecksum(buffer, archiveName, { silent });
 
-  console.log("ludus-cli: extracting binary...");
+  log(silent, "ludus-cli: extracting binary...");
   extract(buffer, archiveName, binDir);
 
-  console.log("ludus-cli: installed successfully");
+  // Marker is written only after the binary is in place, so a crash mid-install
+  // never leaves a marker that falsely claims success.
+  fs.writeFileSync(path.join(binDir, MARKER), version);
+
+  log(silent, "ludus-cli: installed successfully");
 }
 
-main().catch((err) => {
-  console.error(`ludus-cli: installation failed: ${err.message}`);
-  process.exit(1);
-});
+if (require.main === module) {
+  ensureBinary({ silent: false }).catch((err) => {
+    console.error(`ludus-cli: installation failed: ${err.message}`);
+    process.exit(1);
+  });
+}
+
+module.exports = {
+  ensureBinary,
+  needsDownload,
+  getArchiveName,
+  getPackageVersion,
+  binaryName,
+  MARKER,
+};

--- a/npm/install.test.js
+++ b/npm/install.test.js
@@ -1,0 +1,113 @@
+"use strict";
+
+const { test } = require("node:test");
+const assert = require("node:assert");
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const {
+  getArchiveName,
+  needsDownload,
+  binaryName,
+  MARKER,
+} = require("./install.js");
+
+test("getArchiveName: platform/arch matrix", () => {
+  assert.strictEqual(
+    getArchiveName("1.2.3", "win32", "x64"),
+    "ludus_1.2.3_windows_amd64.zip"
+  );
+  assert.strictEqual(
+    getArchiveName("1.2.3", "linux", "arm64"),
+    "ludus_1.2.3_linux_arm64.tar.gz"
+  );
+  assert.strictEqual(
+    getArchiveName("0.5.1", "darwin", "arm64"),
+    "ludus_0.5.1_darwin_arm64.tar.gz"
+  );
+  assert.strictEqual(
+    getArchiveName("0.5.1", "darwin", "x64"),
+    "ludus_0.5.1_darwin_amd64.tar.gz"
+  );
+});
+
+test("getArchiveName: unsupported platform/arch throws", () => {
+  assert.throws(() => getArchiveName("1.0.0", "sunos", "x64"), /Unsupported platform/);
+  assert.throws(() => getArchiveName("1.0.0", "linux", "mips"), /Unsupported platform/);
+});
+
+// The version regex lives in getPackageVersion; exercise it directly so we don't
+// depend on the repo package.json value.
+const VERSION_RE = /^\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?(\+[a-zA-Z0-9.]+)?$/;
+
+test("version regex: accepts valid semver", () => {
+  for (const v of ["0.0.0", "1.2.3", "0.5.1", "1.0.0-rc.1", "1.2.3+build.5"]) {
+    assert.ok(VERSION_RE.test(v), `expected ${v} to be valid`);
+  }
+});
+
+test("version regex: rejects injection-y / malformed strings", () => {
+  for (const v of [
+    "1.2.3; rm -rf /",
+    "../../etc/passwd",
+    "v1.2.3",
+    "1.2",
+    "latest",
+    "1.2.3 && echo hi",
+  ]) {
+    assert.ok(!VERSION_RE.test(v), `expected ${v} to be rejected`);
+  }
+});
+
+test("needsDownload: true when binary missing", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ludus-test-"));
+  try {
+    assert.strictEqual(needsDownload(dir, "1.2.3"), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("needsDownload: true when marker missing", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ludus-test-"));
+  try {
+    fs.writeFileSync(path.join(dir, binaryName()), "stub");
+    assert.strictEqual(needsDownload(dir, "1.2.3"), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("needsDownload: true when marker version mismatches (drift)", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ludus-test-"));
+  try {
+    fs.writeFileSync(path.join(dir, binaryName()), "stub");
+    fs.writeFileSync(path.join(dir, MARKER), "1.2.2");
+    assert.strictEqual(needsDownload(dir, "1.2.3"), true);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("needsDownload: false when binary present and marker matches", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ludus-test-"));
+  try {
+    fs.writeFileSync(path.join(dir, binaryName()), "stub");
+    fs.writeFileSync(path.join(dir, MARKER), "1.2.3");
+    assert.strictEqual(needsDownload(dir, "1.2.3"), false);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("needsDownload: tolerates trailing whitespace in marker", () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "ludus-test-"));
+  try {
+    fs.writeFileSync(path.join(dir, binaryName()), "stub");
+    fs.writeFileSync(path.join(dir, MARKER), "1.2.3\n");
+    assert.strictEqual(needsDownload(dir, "1.2.3"), false);
+  } finally {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/npm/package.json
+++ b/npm/package.json
@@ -11,7 +11,8 @@
     "ludus": "run.js"
   },
   "scripts": {
-    "postinstall": "node install.js"
+    "postinstall": "node install.js",
+    "test": "node --test"
   },
   "os": [
     "linux",

--- a/npm/run.js
+++ b/npm/run.js
@@ -3,31 +3,71 @@
 
 const path = require("path");
 const { spawn } = require("child_process");
+const { ensureBinary, binaryName } = require("./install.js");
 
-const binaryName = process.platform === "win32" ? "ludus.exe" : "ludus";
-const binaryPath = path.join(__dirname, "bin", binaryName);
+const binaryPath = path.join(__dirname, "bin", binaryName());
 
-const child = spawn(binaryPath, process.argv.slice(2), {
-  stdio: "inherit",
-});
+function spawnBinary() {
+  const child = spawn(binaryPath, process.argv.slice(2), {
+    stdio: "inherit",
+  });
 
-// Forward signals so the Go binary shuts down cleanly
-["SIGINT", "SIGTERM", "SIGHUP"].forEach((sig) => {
-  process.on(sig, () => child.kill(sig));
-});
+  // Forward signals so the Go binary shuts down cleanly
+  ["SIGINT", "SIGTERM", "SIGHUP"].forEach((sig) => {
+    process.on(sig, () => child.kill(sig));
+  });
 
-child.on("error", (err) => {
-  if (err.code === "ENOENT") {
-    console.error(
-      `ludus-cli: binary not found at ${binaryPath}\n` +
-        "Run 'npm rebuild ludus-cli' or reinstall the package."
-    );
-  } else {
-    console.error(`ludus-cli: failed to start: ${err.message}`);
+  child.on("error", (err) => {
+    if (err.code === "ENOENT") {
+      console.error(
+        `ludus-cli: binary not found at ${binaryPath}\n` +
+          "Reinstall with: npm install -g ludus-cli@latest"
+      );
+    } else {
+      console.error(`ludus-cli: failed to start: ${err.message}`);
+    }
+    process.exit(1);
+  });
+
+  child.on("exit", (code, signal) => {
+    process.exit(signal ? 1 : code || 0);
+  });
+}
+
+async function main() {
+  // Escape hatch: deliberately manage the binary yourself / air-gapped setups.
+  // Skip the self-heal and spawn whatever is present (ENOENT guidance if not).
+  if (process.env.LUDUS_SKIP_AUTO_DOWNLOAD) {
+    spawnBinary();
+    return;
   }
-  process.exit(1);
-});
 
-child.on("exit", (code, signal) => {
-  process.exit(signal ? 1 : code || 0);
-});
+  try {
+    // Self-heal: if postinstall was skipped (ignore-scripts, pnpm), failed
+    // mid-download, or the binary drifted from this package version, fetch the
+    // correct one. No-op (cheap file reads) when already in sync. silent:true
+    // keeps routine chatter off; an actual download still prints one stderr line.
+    await ensureBinary({ silent: true });
+  } catch (err) {
+    const code = err && err.code;
+    if (code === "EACCES" || code === "EPERM") {
+      console.error(
+        `ludus-cli: cannot write the ludus binary (permission denied).\n` +
+          "Reinstall with appropriate privileges:\n" +
+          "  sudo npm install -g ludus-cli@latest    (macOS/Linux)\n" +
+          "  run your shell as Administrator, then the same command (Windows)"
+      );
+    } else {
+      console.error(
+        `ludus-cli: could not fetch the ludus binary: ${err.message}\n` +
+          "Check your network/proxy and retry. If you manage the binary yourself,\n" +
+          "set LUDUS_SKIP_AUTO_DOWNLOAD=1 to bypass this step."
+      );
+    }
+    process.exit(1);
+  }
+
+  spawnBinary();
+}
+
+main();


### PR DESCRIPTION
## Problem

The `ludus-cli` npm package is a thin shim — the published tarball ships **no binary** (`bin/` is npm-ignored). A `postinstall` script downloads the platform binary from the GitHub release. This leaves the package and its binary able to drift out of sync, producing a "successfully installed" package that can't run:

- **postinstall skipped** — `ignore-scripts=true`, pnpm defaults, sandboxed/corp environments → `bin/` empty
- **postinstall failed mid-download** — network blip / checksum mismatch → `bin/` empty or partial
- **stale binary after upgrade** — package manager reuses `bin/` from a prior version → version skew

In all three, `run.js`'s old error advice (*"run `npm rebuild` or reinstall"*) was misleading, because the blocked step is scripts running at all.

## Fix

The package is now **self-healing**. `npm/install.js` exposes `ensureBinary()`; `run.js` calls it before every spawn:

- Re-fetches the correct binary when missing or version-skewed, tracked via a `bin/.installed-version` marker
- Common path short-circuits on cheap file reads (no subprocess, no network) — negligible hot-path latency
- **All progress routes to stderr** — never corrupts `ludus mcp` (JSON-RPC) or `--json` stdout (the MCP integration runs as `npx -y ludus-cli mcp`, where postinstall can be skipped, so the self-heal path fires for MCP clients)
- Distinct, actionable errors for network failure vs. `EACCES`/`EPERM` (permission)
- `LUDUS_SKIP_AUTO_DOWNLOAD=1` escape hatch for air-gapped / self-managed binaries
- `extract()` hardened for concurrency/atomicity (unique temp dir + rename; marker written only after success)

No release-pipeline changes, no per-platform packages. Upgrade stays `npm i -g ludus-cli@latest`.

## Test plan

- [x] `cd npm && npm test` — 9/9 network-free unit tests pass (`getArchiveName`, version regex, `needsDownload` drift matrix)
- [x] `node --check` on `install.js` + `run.js`
- [x] Hot path (binary + matching marker): no download, exit 0, **stdout clean / stderr empty**
- [x] Drift (stale marker): triggers fetch, "fetching…" notice on **stderr only**, stdout empty
- [x] Network failure: clear actionable error + escape-hatch hint, exit 1
- [x] Escape hatch: runs binary directly, no network
- [x] Dev build (`0.0.0`): skips download, no accidental network calls
- [x] `npm pack --dry-run`: ships only the 4 intended files (test file excluded)

## Out of scope

- Per-platform `optionalDependencies` packages (esbuild model) — bigger release-machinery change; revisit if pnpm/locked-down demand appears
- The local dual-prefix/PATH issue that surfaced this — machine config, not a package bug