### PR TITLE
feat: mask AWS account IDs in terminal output by default

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -126,7 +126,7 @@ The `--arch` flag threads through the entire pipeline: game build → container 
 Full style guide in [AGENTS.md](AGENTS.md). Key points for quick reference:
 
 - **Errors**: `fmt.Errorf("context: %w", err)`. No sentinel errors, no custom types. AWS errors via `smithy.APIError` + `errors.As()`. `internal/diagnose/` matches error patterns to user-facing hints — add new patterns there rather than embedding hint strings in command code.
-- **Output**: `fmt.Println`/`fmt.Printf` for status. No logging library. JSON conditional on `globals.JSONOutput`.
+- **Output**: `fmt.Println`/`fmt.Printf` for status. No logging library. JSON conditional on `globals.JSONOutput`. Human-readable stdout is filtered through `internal/output` (account-ID masking) when `privacy.maskAccountId` is on and `--show-account-id` is not set — installed once in root `PersistentPreRunE`, skipped for `--json` and `mcp`. Mask new sensitive identifiers by adding a pattern to `internal/output/sanitize.go`, not at call sites.
 - **Shell execution**: Always through `runner.Runner`, never raw `exec.Command`.
 - **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. 32/36 internal packages have tests. AWS-heavy packages (ec2fleet) and interface-only packages (deploy, version) rely on E2E or integration coverage.
 - **Platform code**: `_windows.go` / `_unix.go` suffixes with `//go:build` tags.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Edit `ludus.yaml` with your environment settings. Key fields:
 | `anywhere.locationName` | Custom location name for Anywhere fleet | `custom-ludus-dev` |
 | `aws.region` | AWS region | `us-east-1` |
 | `aws.accountId` | AWS account ID (for ECR URI) | (required for container targets) |
+| `privacy.maskAccountId` | Mask the AWS account ID in ECR URIs/ARNs in terminal output (JSON/MCP unaffected). Override per-run with `--show-account-id` | `true` |
 
 See [`internal/config/config.go`](internal/config/config.go) for the full list of configuration keys including CI, EC2 fleet, and content validation options.
 

--- a/cmd/doctor/checks_masking.go
+++ b/cmd/doctor/checks_masking.go
@@ -1,0 +1,23 @@
+package doctor
+
+import (
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+// checkAccountIDMasking reports whether AWS account IDs are masked in
+// human-readable output. The --show-account-id flag overrides the config.
+func checkAccountIDMasking(cfg *config.Config) diagnostic {
+	d := diagnostic{name: "Account ID Masking", status: "ok"}
+
+	switch {
+	case globals.ShowAccountID:
+		d.message = "disabled for this run (--show-account-id)"
+	case cfg != nil && !cfg.Privacy.MaskAccountID:
+		d.message = "disabled (privacy.maskAccountId=false)"
+	default:
+		d.message = "enabled (account IDs masked in output)"
+	}
+
+	return d
+}

--- a/cmd/doctor/checks_masking_test.go
+++ b/cmd/doctor/checks_masking_test.go
@@ -1,0 +1,55 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestCheckAccountIDMasking(t *testing.T) {
+	tests := []struct {
+		name        string
+		cfg         *config.Config
+		showFlag    bool
+		wantStatus  string
+		wantMessage string
+	}{
+		{
+			name:        "enabled by default",
+			cfg:         &config.Config{Privacy: config.PrivacyConfig{MaskAccountID: true}},
+			wantStatus:  "ok",
+			wantMessage: "enabled",
+		},
+		{
+			name:        "disabled via config",
+			cfg:         &config.Config{Privacy: config.PrivacyConfig{MaskAccountID: false}},
+			wantStatus:  "ok",
+			wantMessage: "privacy.maskAccountId=false",
+		},
+		{
+			name:        "disabled via flag",
+			cfg:         &config.Config{Privacy: config.PrivacyConfig{MaskAccountID: true}},
+			showFlag:    true,
+			wantStatus:  "ok",
+			wantMessage: "--show-account-id",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			orig := globals.ShowAccountID
+			t.Cleanup(func() { globals.ShowAccountID = orig })
+			globals.ShowAccountID = tt.showFlag
+
+			got := checkAccountIDMasking(tt.cfg)
+			if got.status != tt.wantStatus {
+				t.Errorf("status = %q, want %q", got.status, tt.wantStatus)
+			}
+			if !strings.Contains(got.message, tt.wantMessage) {
+				t.Errorf("message = %q, want substring %q", got.message, tt.wantMessage)
+			}
+		})
+	}
+}

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -51,6 +51,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	checks = append(checks, checkAppleSiliconContainer(cfg))
 	checks = append(checks, checkDockerfileSecurity(cfg)...)
 	checks = append(checks, checkGitState())
+	checks = append(checks, checkAccountIDMasking(cfg))
 
 	return printDiagnostics(checks)
 }

--- a/cmd/globals/globals.go
+++ b/cmd/globals/globals.go
@@ -22,6 +22,17 @@ var Profile string
 // Set via --ddc flag, overrides config file.
 var DDCMode string
 
+// ShowAccountID forces the AWS account ID to be shown in human-readable output,
+// overriding privacy.maskAccountId. Set via the --show-account-id flag.
+var ShowAccountID bool
+
+// MaskAccountIDEnabled reports whether AWS account IDs should be masked in
+// human-readable output. The --show-account-id flag takes precedence over the
+// privacy.maskAccountId config value.
+func MaskAccountIDEnabled() bool {
+	return Cfg != nil && Cfg.Privacy.MaskAccountID && !ShowAccountID
+}
+
 // ResolveBackend returns the effective build backend.
 // CLI flag takes precedence over config.
 func ResolveBackend(flagValue string) string {

--- a/cmd/globals/masking_test.go
+++ b/cmd/globals/masking_test.go
@@ -1,0 +1,52 @@
+package globals
+
+import (
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestMaskAccountIDEnabled(t *testing.T) {
+	tests := []struct {
+		name     string
+		cfg      *config.Config
+		showFlag bool
+		want     bool
+	}{
+		{
+			name: "masking on by default",
+			cfg:  &config.Config{Privacy: config.PrivacyConfig{MaskAccountID: true}},
+			want: true,
+		},
+		{
+			name:     "flag overrides config",
+			cfg:      &config.Config{Privacy: config.PrivacyConfig{MaskAccountID: true}},
+			showFlag: true,
+			want:     false,
+		},
+		{
+			name: "config disabled",
+			cfg:  &config.Config{Privacy: config.PrivacyConfig{MaskAccountID: false}},
+			want: false,
+		},
+		{
+			name: "nil config",
+			cfg:  nil,
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origCfg, origFlag := Cfg, ShowAccountID
+			t.Cleanup(func() { Cfg, ShowAccountID = origCfg, origFlag })
+
+			Cfg = tt.cfg
+			ShowAccountID = tt.showFlag
+
+			if got := MaskAccountIDEnabled(); got != tt.want {
+				t.Errorf("MaskAccountIDEnabled() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -25,6 +25,7 @@ import (
 	"github.com/jpvelasco/ludus/cmd/status"
 	"github.com/jpvelasco/ludus/internal/config"
 	ddcpkg "github.com/jpvelasco/ludus/internal/ddc"
+	"github.com/jpvelasco/ludus/internal/output"
 	"github.com/jpvelasco/ludus/internal/state"
 	"github.com/jpvelasco/ludus/internal/toolchain"
 	"github.com/jpvelasco/ludus/internal/version"
@@ -32,6 +33,10 @@ import (
 )
 
 var cfgFile string
+
+// stdoutRedirect holds the active account-ID masking filter over os.Stdout,
+// installed in PersistentPreRunE and drained/restored in Execute.
+var stdoutRedirect *output.Redirect
 
 var rootCmd = &cobra.Command{
 	Use:          "ludus",
@@ -84,6 +89,17 @@ Use --profile to manage multiple configurations (e.g., different UE versions):
 		}
 		globals.Cfg = cfg
 
+		// Mask AWS account IDs in human-readable output unless disabled. JSON and
+		// MCP output must carry real IDs for downstream consumers, so the filter
+		// is not installed for those.
+		if globals.MaskAccountIDEnabled() && !globals.JSONOutput && cmd.Name() != "mcp" {
+			if red, err := output.Install(); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: account ID masking unavailable: %v\n", err)
+			} else {
+				stdoutRedirect = red
+			}
+		}
+
 		// Auto-detect engine version from Build.version if not set in config
 		if cfg.Engine.SourcePath != "" && cfg.Engine.Version == "" {
 			if bv, err := toolchain.ParseBuildVersion(cfg.Engine.SourcePath); err == nil {
@@ -116,6 +132,9 @@ Use --profile to manage multiple configurations (e.g., different UE versions):
 func Execute() error {
 	ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer stop()
+	// Restore/drain stdout last (after other teardown writes) so any masked
+	// output is flushed. Runs on normal return and on panic.
+	defer func() { stdoutRedirect.Close() }()
 	defer globals.CloseBuildLog()
 	defer globals.ShutdownTracing(context.Background())
 	return rootCmd.ExecuteContext(ctx)
@@ -129,6 +148,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&globals.Profile, "profile", "", "state profile for multi-version workflows (e.g., ue57-ec2)")
 	rootCmd.PersistentFlags().StringVar(&globals.DDCMode, "ddc", "", `DDC mode: "local" (default) or "none" (disable cache)`)
 	rootCmd.PersistentFlags().BoolVar(&globals.NoLogs, "no-logs", false, "do not write build output to .ludus/logs")
+	rootCmd.PersistentFlags().BoolVar(&globals.ShowAccountID, "show-account-id", false, "show the AWS account ID in output (default: masked)")
 
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(setup.Cmd)

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -56,5 +56,8 @@ func Defaults() *Config {
 				RetainRuns: 20,
 			},
 		},
+		Privacy: PrivacyConfig{
+			MaskAccountID: true,
+		},
 	}
 }

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -13,6 +13,15 @@ type Config struct {
 	CI            CIConfig            `yaml:"ci"`
 	DDC           DDCConfig           `yaml:"ddc"`
 	Observability ObservabilityConfig `yaml:"observability"`
+	Privacy       PrivacyConfig       `yaml:"privacy"`
+}
+
+// PrivacyConfig controls masking of sensitive identifiers in terminal output.
+type PrivacyConfig struct {
+	// MaskAccountID masks the 12-digit AWS account ID in ECR URIs and ARNs in
+	// human-readable output (default: true). JSON/MCP output is never masked.
+	// Override per-invocation with the --show-account-id flag.
+	MaskAccountID bool `yaml:"maskAccountId" mapstructure:"maskAccountId"`
 }
 
 // ObservabilityConfig holds build-observability settings: on-disk logs and

--- a/internal/output/redirect.go
+++ b/internal/output/redirect.go
@@ -65,6 +65,8 @@ func (red *Redirect) drain(r *os.File) {
 	for {
 		line, err := br.ReadString('\n')
 		if line != "" {
+			// #nosec G705 -- red.real is the process's real stdout (a terminal/file),
+			// not a web response; XSS does not apply. The data is also masked here.
 			_, _ = io.WriteString(red.real, MaskAccountIDs(line))
 		}
 		if err != nil {

--- a/internal/output/redirect.go
+++ b/internal/output/redirect.go
@@ -1,0 +1,90 @@
+package output
+
+import (
+	"bufio"
+	"io"
+	"os"
+	"os/signal"
+	"sync"
+	"syscall"
+)
+
+// Redirect installs a filter over os.Stdout that masks AWS account IDs in
+// every line written through it. It works by pointing os.Stdout at the write
+// end of an os.Pipe and draining the read end through MaskAccountIDs in a
+// background goroutine. Use Install to set it up and Close to restore and drain.
+type Redirect struct {
+	real  *os.File // the original os.Stdout, restored on Close
+	w     *os.File // pipe write end (becomes os.Stdout)
+	wg    sync.WaitGroup
+	once  sync.Once
+	sigCh chan os.Signal
+}
+
+// Install redirects os.Stdout through the account-ID masking filter and returns
+// a *Redirect whose Close restores the original stdout. The caller is
+// responsible for calling Close (e.g. via defer) so buffered output is flushed.
+func Install() (*Redirect, error) {
+	r, w, err := os.Pipe()
+	if err != nil {
+		return nil, err
+	}
+
+	red := &Redirect{
+		real:  os.Stdout,
+		w:     w,
+		sigCh: make(chan os.Signal, 1),
+	}
+	os.Stdout = w
+
+	red.wg.Add(1)
+	go red.drain(r)
+
+	// Ensure buffered output is flushed if the process is interrupted: Cobra
+	// installs no handler that would run our deferred Close, so a raw signal
+	// would otherwise lose in-flight lines.
+	signal.Notify(red.sigCh, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		if _, ok := <-red.sigCh; ok {
+			red.Close()
+		}
+	}()
+
+	return red, nil
+}
+
+// drain reads the pipe line by line, masks each chunk, and writes it to the
+// real stdout. It uses ReadString rather than bufio.Scanner so that lines
+// longer than 64 KB are not silently truncated, and it flushes the final
+// non-newline-terminated chunk at EOF.
+func (red *Redirect) drain(r *os.File) {
+	defer red.wg.Done()
+	defer func() { _ = r.Close() }()
+
+	br := bufio.NewReader(r)
+	for {
+		line, err := br.ReadString('\n')
+		if line != "" {
+			_, _ = io.WriteString(red.real, MaskAccountIDs(line))
+		}
+		if err != nil {
+			return
+		}
+	}
+}
+
+// Close restores os.Stdout, stops the signal handler, and waits for all
+// buffered output to be masked and flushed. It is safe to call multiple times
+// and on a nil receiver.
+func (red *Redirect) Close() {
+	if red == nil {
+		return
+	}
+	red.once.Do(func() {
+		signal.Stop(red.sigCh)
+		close(red.sigCh)
+		os.Stdout = red.real
+		_ = red.w.Close() // signals EOF to drain
+		red.wg.Wait()
+	})
+}

--- a/internal/output/redirect_test.go
+++ b/internal/output/redirect_test.go
@@ -1,0 +1,101 @@
+package output
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+)
+
+// captureRealStdout swaps os.Stdout for a temp file so that Install captures it
+// as the "real" stdout, then returns what was written there after fn runs.
+func captureRealStdout(t *testing.T, fn func()) string {
+	t.Helper()
+
+	tmp, err := os.CreateTemp(t.TempDir(), "stdout")
+	if err != nil {
+		t.Fatalf("CreateTemp: %v", err)
+	}
+	orig := os.Stdout
+	os.Stdout = tmp
+	t.Cleanup(func() { os.Stdout = orig })
+
+	fn()
+
+	if err := tmp.Close(); err != nil {
+		t.Fatalf("close temp: %v", err)
+	}
+	data, err := os.ReadFile(tmp.Name())
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	return string(data)
+}
+
+func TestRedirectMasksStdout(t *testing.T) {
+	out := captureRealStdout(t, func() {
+		red, err := Install()
+		if err != nil {
+			t.Fatalf("Install: %v", err)
+		}
+		fmt.Println("image: 123456789012.dkr.ecr.us-east-1.amazonaws.com/ludus:latest")
+		red.Close()
+	})
+
+	if strings.Contains(out, "123456789012") {
+		t.Errorf("expected account ID to be masked, got: %q", out)
+	}
+	if !strings.Contains(out, "************.dkr.ecr.us-east-1.amazonaws.com") {
+		t.Errorf("expected masked ECR host, got: %q", out)
+	}
+}
+
+func TestRedirectPreservesLongLines(t *testing.T) {
+	// A line well over bufio.Scanner's default 64 KB token cap, proving the
+	// drain loop does not truncate. The ARN at the end must survive and be masked.
+	long := strings.Repeat("x", 100*1024)
+	out := captureRealStdout(t, func() {
+		red, err := Install()
+		if err != nil {
+			t.Fatalf("Install: %v", err)
+		}
+		fmt.Println(long + " arn:aws:gamelift:us-east-1:123456789012:fleet/x")
+		red.Close()
+	})
+
+	if len(out) < 100*1024 {
+		t.Errorf("long line truncated: got %d bytes", len(out))
+	}
+	if strings.Contains(out, ":123456789012:") {
+		t.Errorf("expected account ID in long line to be masked, got tail: %q", out[len(out)-80:])
+	}
+}
+
+func TestRedirectFlushesUnterminatedChunk(t *testing.T) {
+	out := captureRealStdout(t, func() {
+		red, err := Install()
+		if err != nil {
+			t.Fatalf("Install: %v", err)
+		}
+		fmt.Print("no newline: 123456789012.dkr.ecr.us-east-1.amazonaws.com")
+		red.Close()
+	})
+
+	if !strings.Contains(out, "************.dkr.ecr") {
+		t.Errorf("expected unterminated chunk flushed and masked, got: %q", out)
+	}
+}
+
+func TestRedirectCloseIdempotent(t *testing.T) {
+	captureRealStdout(t, func() {
+		red, err := Install()
+		if err != nil {
+			t.Fatalf("Install: %v", err)
+		}
+		red.Close()
+		red.Close() // must not panic or block
+	})
+
+	var nilRed *Redirect
+	nilRed.Close() // must be a no-op
+}

--- a/internal/output/sanitize.go
+++ b/internal/output/sanitize.go
@@ -1,0 +1,28 @@
+// Package output provides terminal-output sanitization for ludus, masking
+// sensitive identifiers (AWS account IDs) from human-readable output while
+// leaving JSON/MCP output untouched.
+package output
+
+import "regexp"
+
+// mask is the placeholder substituted for a 12-digit AWS account ID.
+const mask = "************"
+
+var (
+	// ecrAccountRe matches the account ID at the start of an ECR registry host,
+	// e.g. "123456789012.dkr.ecr.us-east-1.amazonaws.com".
+	ecrAccountRe = regexp.MustCompile(`(\d{12})(\.dkr\.ecr\.)`)
+
+	// arnAccountRe matches the account ID field (the 5th colon-delimited field)
+	// of an ARN, e.g. "arn:aws:gamelift:us-east-1:123456789012:fleet/...".
+	arnAccountRe = regexp.MustCompile(`(arn:[a-z0-9-]*:[a-z0-9-]*:[a-z0-9-]*:)(\d{12})(:)`)
+)
+
+// MaskAccountIDs replaces 12-digit AWS account IDs that appear inside an ECR
+// hostname or an ARN with a fixed-width mask. Bare 12-digit numbers in other
+// contexts (timestamps, build IDs) are left untouched to avoid false positives.
+func MaskAccountIDs(s string) string {
+	s = ecrAccountRe.ReplaceAllString(s, mask+"$2")
+	s = arnAccountRe.ReplaceAllString(s, "${1}"+mask+"$3")
+	return s
+}

--- a/internal/output/sanitize_test.go
+++ b/internal/output/sanitize_test.go
@@ -1,0 +1,56 @@
+package output
+
+import "testing"
+
+func TestMaskAccountIDs(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "ECR URI",
+			in:   "Pushed engine image: 123456789012.dkr.ecr.us-east-1.amazonaws.com/ludus-server:latest",
+			want: "Pushed engine image: ************.dkr.ecr.us-east-1.amazonaws.com/ludus-server:latest",
+		},
+		{
+			name: "ARN",
+			in:   "Container group definition ready: arn:aws:gamelift:us-east-1:123456789012:containergroupdefinition/ludus",
+			want: "Container group definition ready: arn:aws:gamelift:us-east-1:************:containergroupdefinition/ludus",
+		},
+		{
+			name: "bare 12-digit number untouched",
+			in:   "build id 123456789012 completed",
+			want: "build id 123456789012 completed",
+		},
+		{
+			name: "epoch timestamp untouched",
+			in:   "started at 1718000000000 ms",
+			want: "started at 1718000000000 ms",
+		},
+		{
+			name: "multiple ids on one line",
+			in:   "123456789012.dkr.ecr.us-east-1.amazonaws.com and arn:aws:s3:us-east-1:987654321098:bucket/x",
+			want: "************.dkr.ecr.us-east-1.amazonaws.com and arn:aws:s3:us-east-1:************:bucket/x",
+		},
+		{
+			name: "shorter id untouched",
+			in:   "12345678901.dkr.ecr.us-east-1.amazonaws.com",
+			want: "12345678901.dkr.ecr.us-east-1.amazonaws.com",
+		},
+		{
+			name: "empty string",
+			in:   "",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := MaskAccountIDs(tt.in)
+			if got != tt.want {
+				t.Errorf("MaskAccountIDs(%q) = %q, want %q", tt.in, got, tt.want)
+			}
+		})
+	}
+}

--- a/ludus.example.yaml
+++ b/ludus.example.yaml
@@ -111,6 +111,12 @@ aws:
 #   # Defaults to ~/.ludus/zen
 #   # zenPath: "/home/user/.ludus/zen"
 
+# privacy:
+#   # Mask the 12-digit AWS account ID in ECR URIs/ARNs in terminal output
+#   # (default: true). JSON and MCP output are never masked. Override per-run
+#   # with the --show-account-id flag.
+#   maskAccountId: true
+
 # observability:
 #   logs:
 #     # Tee build output to per-run log files (default: true).


### PR DESCRIPTION
## Summary

ECR URIs (`<account-id>.dkr.ecr.<region>.amazonaws.com/...`) and ARNs printed by ludus embed the 12-digit AWS account ID, which leaks into terminal output during `deploy`, engine push, `status`, `doctor`, `resources`, etc. — easy to expose in screen shares, recordings, CI logs, or screenshots. This masks account IDs to `************` by default, with an opt-out.

## Approach

- **Global stdout filter** (`internal/output`): `os.Stdout` is redirected through an `os.Pipe` once in root `PersistentPreRunE`; a goroutine drains it line-by-line through `MaskAccountIDs` and writes to the real stdout. One interception point covers all current and future human-readable prints — no per-call-site retrofitting.
- **JSON/MCP never masked**: the filter is not installed when `--json` is set or for the `mcp` command, so scripts and the MCP JSON-RPC consumer receive real account IDs.
- **Contextual regex**: only IDs inside an ECR hostname or an ARN are masked — bare 12-digit numbers (timestamps, build IDs, raw `aws.accountId` config values) are left untouched.

## Robustness notes

- Drains with `bufio.Reader.ReadString` rather than `bufio.Scanner` to avoid silently truncating lines over 64 KB (build/log output).
- `Close()` (via `sync.Once`) restores stdout, signals EOF, and waits for a full drain; nil-safe and idempotent. Runs via `defer` in `Execute()` (covers panics) and via a SIGINT/SIGTERM handler so buffered lines flush on interrupt.

## Config / flags

- `privacy.maskAccountId` in `ludus.yaml` (default `true`)
- `--show-account-id` persistent flag (overrides config per-run)
- `ludus doctor` reports the current masking status

## Test plan

- [x] `go build`
- [x] `go test ./...` (new tests in `internal/output`, `cmd/globals`, `cmd/doctor`)
- [x] `golangci-lint run ./...` — 0 issues
- [x] Unit: ECR + ARN masking, bare-ID false-positive guard, >64 KB line not truncated, unterminated chunk flushed, double/nil `Close()`
- [x] `ludus doctor` shows enabled / `--show-account-id` / `privacy.maskAccountId=false` states
- [x] `ludus config get aws.accountId` returns the raw ID unmasked (contextual regex)

## Out of scope

- Masking `--json`/MCP output (intentional — consumers need real IDs)
- Masking stderr verbose `+ cmd` traces (ECR URIs are printed to stdout)