### PR TITLE
docs: document logs command, observability & DDC config

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -56,10 +56,12 @@ ludus/
 │   ├── ci/                     # ludus ci init|runner
 │   ├── buildgraph/             # ludus buildgraph (XML generation)
 │   ├── ddc/                    # ludus ddc status|clean|prune|warmup
+│   ├── logs/                   # ludus logs list|path|tail (per-run build logs)
 │   └── mcp/                    # MCP server (26 tools for AI agents)
 ├── internal/                   # Business logic (unexported)
 │   ├── config/                 # Config loading, arch helpers
 │   ├── runner/                 # Shell execution abstraction
+│   ├── retry/                  # Retry with exponential backoff for Docker/AWS calls
 │   ├── engine/                 # UE5 engine build orchestration
 │   ├── game/                   # Server + client build via RunUAT
 │   ├── cleanup/                # AWS resource cleanup helpers
@@ -89,6 +91,8 @@ ludus/
 │   ├── awsutil/                # Shared AWS SDK helpers (credentials, region)
 │   ├── ci/                     # GitHub Actions workflow + runner management
 │   ├── progress/               # Elapsed-time progress indicators
+│   ├── buildlog/               # Per-run build log persistence (.ludus/logs/)
+│   ├── tracing/                # Optional OpenTelemetry (OTLP) trace export
 │   ├── version/                # Build version injection
 │   └── wsl/                    # WSL2 detection and path translation
 └── npm/                        # npm wrapper for `npx ludus-cli mcp`
@@ -170,3 +174,15 @@ Ludus persists two files in `.ludus/`:
 
 Profiles (`--profile <name>`) isolate both: config reads from `ludus-<name>.yaml`,
 state writes to `.ludus/profiles/<name>.json`.
+
+## Build Observability
+
+Build output is observable in two complementary ways, both opt-out/opt-in rather than always-on noise:
+
+- **On-disk logs** (`internal/buildlog`) — CLI runners tee stdout/stderr to a per-run file
+  under `.ludus/logs/`, opened lazily on first use and pruned to `observability.logs.retainRuns`.
+  Query with `ludus logs list|path|tail`; disable with `--no-logs`. Dry-run is never logged.
+- **Distributed traces** (`internal/tracing`) — optional OpenTelemetry (OTLP) export emitting one
+  span per pipeline stage under a `ludus.run` root span. A no-op with zero overhead unless
+  `observability.otlp.enabled` (or standard `OTEL_*` env vars) is set; initialized in root
+  `PersistentPreRunE` and flushed on exit.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,14 @@ Edit `ludus.yaml` with your environment settings. Key fields:
 | `anywhere.locationName` | Custom location name for Anywhere fleet | `custom-ludus-dev` |
 | `aws.region` | AWS region | `us-east-1` |
 | `aws.accountId` | AWS account ID (for ECR URI) | (required for container targets) |
+| `ddc.mode` | Derived Data Cache mode: `local` (persistent) or `none` (disabled) | `local` |
+| `ddc.localPath` | Host path for the FileSystem Local DDC (UE 5.5 and below) | `~/.ludus/ddc` |
+| `ddc.zenPath` | Host path for the ZenStore DDC (UE 5.6+) — persists the cook cache across container runs | `~/.ludus/zen` |
+| `observability.logs.enabled` | Persist build output to per-run log files | `true` |
+| `observability.logs.dir` | Build log directory (project-local) | `.ludus/logs` |
+| `observability.logs.retainRuns` | Number of run logs to keep before pruning oldest | `20` |
+| `observability.otlp.enabled` | Export per-stage build spans via OpenTelemetry (OTLP) | `false` |
+| `observability.otlp.endpoint` | OTLP collector endpoint (host:port) | (empty) |
 
 See [`internal/config/config.go`](internal/config/config.go) for the full list of configuration keys including CI, EC2 fleet, and content validation options.
 
@@ -227,6 +235,11 @@ See [`internal/config/config.go`](internal/config/config.go) for the full list o
 ./ludus ddc warmup --verbose
 ./ludus ddc clean
 ./ludus ddc prune --days 30
+
+# Build logs (build output is persisted to .ludus/logs/ by default)
+./ludus logs list                # list recent build runs
+./ludus logs path                # print the latest run's log path
+./ludus logs tail                # tail the latest run's log
 
 # Quick config changes
 ./ludus config set game.arch arm64

--- a/README.md
+++ b/README.md
@@ -573,6 +573,35 @@ Cache keys per stage:
 - **Game client**: engine cache key + .uproject mtime/size, client target, platform
 - **Container**: server build directory file manifest, project name, server target, server port, image tag
 
+### Build observability
+
+Build output is captured two ways, so a failed build hours into a CI run is never lost to a scrolled-off terminal.
+
+**On-disk logs.** Every run tees its stdout/stderr to a timestamped file under `.ludus/logs/` (project-local). This is on by default; the newest `observability.logs.retainRuns` files are kept and older ones pruned.
+
+```bash
+./ludus logs list                # list recent runs, newest first
+./ludus logs path                # absolute path to the latest run's log
+./ludus logs tail                # tail the latest run's log
+./ludus run --no-logs            # disable logging for this run
+```
+
+Dry-run output is never written to disk.
+
+**Distributed tracing (optional).** When enabled, Ludus exports one OpenTelemetry span per pipeline stage under a single `ludus.run` root span — useful for seeing where time goes across engine/game/container/deploy in a collector like Jaeger or Grafana Tempo. It is a no-op with zero overhead unless turned on, via config or the standard `OTEL_*` environment variables.
+
+```yaml
+observability:
+  logs:
+    enabled: true            # persist per-run logs (default: true)
+    dir: ".ludus/logs"       # log directory (project-local)
+    retainRuns: 20           # keep N newest runs, prune the rest
+  otlp:
+    enabled: false           # export per-stage traces (default: false)
+    endpoint: "localhost:4318"   # OTLP/HTTP collector endpoint
+    insecure: true           # plaintext (typical for a local collector)
+```
+
 ### Global flags
 
 | Flag | Description |
@@ -583,6 +612,7 @@ Cache keys per stage:
 | `--config <path>` | Config file path (default: `./ludus.yaml`) |
 | `--profile <name>` | Use a named profile (isolates config and state) |
 | `--ddc <mode>` | DDC mode: `local` (persistent cache, default) or `none` (disable) |
+| `--no-logs` | Do not write build output to `.ludus/logs` |
 
 ## Build time estimates
 


### PR DESCRIPTION
## Summary

Backfills user/contributor docs for features merged since v0.5.1 that weren't yet documented. Found via an audit of README/ARCHITECTURE against current code.

**README.md**
- New config-table rows: `ddc.mode` / `ddc.localPath` / `ddc.zenPath` (ZenStore persistence, UE 5.6+) and `observability.logs.*` / `observability.otlp.*`.
- New Usage block for the `ludus logs list|path|tail` command, which was previously undocumented.

**ARCHITECTURE.md**
- Module map: added `cmd/logs/`, `internal/buildlog`, `internal/tracing`, and `internal/retry` (all exist on main but were missing from the map).
- New **Build Observability** design subsection (on-disk per-run logs + optional OTLP tracing).

## Notes
- Docs-only; no code change.
- Verified the MCP tool count is still **26** (an audit pass mis-suggested 29 by counting table rows — left unchanged).
- Account-ID masking (`privacy.maskAccountId`) is intentionally **not** included here — it's unmerged on #336 and carries its own docs.