### PR TITLE
fix: chown ZenStore mount parents so container game build doesn't fail (#340)

### DIFF
--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -159,8 +159,22 @@ else
     find /engine/Engine/Plugins -path '*/Build/Scripts/obj' -type d -exec chown -R ue:ue {} + 2>/dev/null || true
     chown ue:ue /engine/Engine/Binaries/Linux/*.sym 2>/dev/null || true
 fi
+`
 
-# Re-exec the build as the ue user, preserving container env vars (-p).
+	// When a ZenStore mount is configured, Docker auto-creates the bind-mount
+	// parents (/home/ue/.config and /home/ue/.config/Epic) owned by root. UAT
+	// runs as ue and mkdir's its config dir (/home/ue/.config/Unreal Engine)
+	// as a sibling of the mount, which fails on the root-owned parent (#340).
+	// Chown the parents non-recursively — the mount itself is already owned via
+	// the host dir, so a recursive chown is unnecessary and risks copy-up.
+	if b.opts.DDCZenPath != "" {
+		script += `# Fix ownership of Docker-created ZenStore mount parents so UAT (as ue)
+# can create its sibling config dir /home/ue/.config/Unreal Engine (#340).
+chown ue:ue /home/ue/.config /home/ue/.config/Epic 2>/dev/null || true
+`
+	}
+
+	script += `# Re-exec the build as the ue user, preserving container env vars (-p).
 # Override HOME because su -p keeps HOME=/root from the container's root user,
 # and .NET SDK / UE tools write to $HOME/.dotnet, $HOME/.local, etc.
 exec su -p ue -c "export HOME=/home/ue && cd /engine && bash /build.sh"

--- a/internal/dockerbuild/game_preamble_test.go
+++ b/internal/dockerbuild/game_preamble_test.go
@@ -4,6 +4,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jpvelasco/ludus/internal/ddc"
 	"github.com/jpvelasco/ludus/internal/runner"
 )
 
@@ -26,6 +27,39 @@ func TestScriptPreamble(t *testing.T) {
 	// NuGet workaround is NOT in the preamble (moved to container -e args)
 	if strings.Contains(got, "NuGetAuditLevel") {
 		t.Error("NuGet workaround should not be in preamble (use envArgs instead)")
+	}
+}
+
+func TestScriptPreamble_ZenMountParentChown(t *testing.T) {
+	r := runner.NewRunner(false, false)
+
+	// When a ZenStore mount is configured, Docker auto-creates the bind-mount
+	// parents (/home/ue/.config and /home/ue/.config/Epic) owned by root. The
+	// preamble must chown them to ue, or UAT (running as ue) fails creating its
+	// sibling config dir /home/ue/.config/Unreal Engine (#340).
+	withZen := NewDockerGameBuilder(DockerGameOptions{
+		DDCMode:    ddc.ModeLocal,
+		DDCPath:    "/tmp/ddc",
+		DDCZenPath: "/tmp/zen",
+	}, r)
+	got := withZen.scriptPreamble()
+	for _, want := range []string{
+		"chown ue:ue /home/ue/.config",
+		"/home/ue/.config/Epic",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("preamble with Zen mount should chown the mount parents; missing %q\ngot:\n%s", want, got)
+		}
+	}
+
+	// Without a Zen mount there is no root-owned .config tree to fix, so the
+	// preamble must not touch /home/ue/.config.
+	noZen := NewDockerGameBuilder(DockerGameOptions{
+		DDCMode: ddc.ModeLocal,
+		DDCPath: "/tmp/ddc",
+	}, r)
+	if strings.Contains(noZen.scriptPreamble(), "/home/ue/.config") {
+		t.Error("preamble without a Zen mount should not reference /home/ue/.config")
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #340 — the #330 ZenStore DDC persistence fix (v0.6.0) introduced a permission failure that blocks every container game build with `ddc.mode: local` (the default).

The ZenStore bind-mount makes Docker auto-create the mount parents `/home/ue/.config` and `/home/ue/.config/Epic` owned by **root**. `scriptPreamble()` chowns `/engine`, `/output`, `/ddc`, and `/project` to `ue` but never the `.config` tree, so UAT (running as `ue`) fails creating its sibling config dir `/home/ue/.config/Unreal Engine` ~9 min in:

```
System.UnauthorizedAccessException: Access to the path '/home/ue/.config/Unreal Engine' is denied
```

Same failure family as #295 (Docker-created bind-mount parents are root-owned and the preamble's chown set didn't cover them).

## Change

When a ZenStore mount is configured (`DDCZenPath != ""`), the preamble now chowns the Docker-created mount parents non-recursively:

```sh
chown ue:ue /home/ue/.config /home/ue/.config/Epic 2>/dev/null || true
```

Non-recursive is sufficient — the mount itself is owned via the host dir, and a recursive chown would risk an overlayfs copy-up. The chown is only emitted when a Zen mount is active, so non-Zen builds are untouched.

## Relationship to #346

This unblocks the build so the ZenStore mount actually receives cook data. #346 (claimed wrong mount path) is most likely a downstream symptom — the build died here before the mount was ever populated, so the host dir looked empty. The `ZenContainerPath` constant already includes the `Common/` segment #346 asks for. Verifying #346 is resolved is part of the upcoming live validation run; no path change is made here.

## Test plan

- [x] New `TestScriptPreamble_ZenMountParentChown` asserts the `.config` chown appears when a Zen mount is configured and is absent otherwise
- [x] `go test ./...` passes
- [x] `golangci-lint run ./...` clean
- [x] `go build` succeeds