### PR TITLE
feat: make Zen Store the default DDC backend; deprecate legacy FileSystem cache

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -148,6 +148,38 @@ says `c6i.large` (x86), Ludus switches to `c7g.large` (Graviton) and tells you.
 
 On macOS with container backends (`--backend docker`/`podman`), engine builds are forced to `linux/amd64` (QEMU user-mode emulation required; Epic only provides an x86_64 Linux toolchain). Game builds with `--arch arm64` (Graviton) cross-compile inside the emulated amd64 environment; the resulting engine image stays amd64 (even for later arm64 game containers). Pre-built amd64 engine images (from Linux/CI) are recommended to avoid emulation cost. The `--arch` flag and mismatch handling apply as above.
 
+### DDC Backend (Zen vs legacy FileSystem)
+
+Unreal Engine uses the **Zen Store** as its default local DDC backend from **UE 5.4 onward** (the
+legacy FileSystem DDC is delete-only since 5.4). Ludus supports UE 5.4–5.7, so `ddc.mode` defaults
+to `zen` unconditionally — there is no version gate. (An earlier assumption that ZenStore applied
+only to UE 5.6+ was incorrect; if you find a "5.6+" reference to DDC, it is a bug.)
+
+`zen` means different concrete things per build path, because only containers have an ephemeral
+filesystem that loses the cache:
+
+```
+mode: zen
+  container (docker/podman)  -> bind-mount host ~/.ludus/zen at the container's
+                                Zen data path (ddc.ZenContainerPath) so it survives --rm
+                                [internal/dockerbuild/game.go: zenDDCArgs]
+  native / wsl2 (binary)     -> no-op: UE autolaunches its Zen Store into the real
+                                home dir, which already persists across runs
+                                [internal/game/ddc.go: setupDDC; internal/wsl/game.go]
+
+mode: local (deprecated)
+  container                  -> mount host ~/.ludus/ddc at /ddc + UE-LocalDataCachePath
+  native / wsl2              -> set UE-LocalDataCachePath to the host path
+```
+
+Consequence: `ludus ddc clean|prune|status` manage the Ludus-owned directories (the Zen mount for
+containers, the FileSystem cache for `local`). They do **not** manage the native/WSL2 Zen location
+(UE owns it in the user's home). Docker and Podman are identical here — the backend string only
+selects the executable in `ContainerCLI`.
+
+A deprecation warning for `mode: local` is centralized in `ddc.LocalModeDeprecationWarning` and
+surfaced from config load (`cmd/root`), `ludus doctor` (`checkDDCMode`), and `ludus ddc status`.
+
 ### Configuration Flow
 
 ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Zen Store is now the default DDC backend.** `ddc.mode` defaults to `zen` (the Unreal Zen Store), UE's default local DDC backend since UE 5.4. Applies to all supported engine versions (5.4–5.7). Container builds mount the host Zen directory (`ddc.zenPath`, default `~/.ludus/zen`); native and WSL2 builds use UE's own Zen Store, which already persists. The earlier "ZenStore on UE 5.6+ only" assumption was incorrect and has been corrected throughout the code and docs.
+- **`ddc.mode: local` (legacy FileSystem DDC) is deprecated.** Still honored, but `ludus doctor`, `ludus ddc status`, and config load now warn that it is delete-only in UE since 5.4 and recommend `zen`.
+
+### Fixed
+- Chown the Docker-created ZenStore mount parents (`/home/ue/.config`, `/home/ue/.config/Epic`) so container game builds with a Zen DDC mount no longer fail with "Access to /home/ue/.config/Unreal Engine denied" (#340)
+
 ## [0.6.0] - 2026-06-22
 
 Adds ARM64/Graviton dedicated server builds, build observability (on-disk logs + optional OpenTelemetry tracing), and AWS account ID masking, alongside a broad set of container-build reliability fixes.

--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ Edit `ludus.yaml` with your environment settings. Key fields:
 | `anywhere.locationName` | Custom location name for Anywhere fleet | `custom-ludus-dev` |
 | `aws.region` | AWS region | `us-east-1` |
 | `aws.accountId` | AWS account ID (for ECR URI) | (required for container targets) |
-| `ddc.mode` | Derived Data Cache mode: `local` (persistent) or `none` (disabled) | `local` |
-| `ddc.localPath` | Host path for the FileSystem Local DDC (UE 5.5 and below) | `~/.ludus/ddc` |
-| `ddc.zenPath` | Host path for the ZenStore DDC (UE 5.6+) — persists the cook cache across container runs | `~/.ludus/zen` |
+| `ddc.mode` | Derived Data Cache mode: `zen` (Zen Store, default), `local` (legacy FileSystem cache, deprecated), or `none` (disabled) | `zen` |
+| `ddc.zenPath` | Host path for the Zen Store DDC — persists the cook cache across container runs | `~/.ludus/zen` |
+| `ddc.localPath` | Host path for the legacy FileSystem DDC (mode `local` only) | `~/.ludus/ddc` |
 | `observability.logs.enabled` | Persist build output to per-run log files | `true` |
 | `observability.logs.dir` | Build log directory (project-local) | `.ludus/logs` |
 | `observability.logs.retainRuns` | Number of run logs to keep before pruning oldest | `20` |
@@ -478,12 +478,15 @@ Run `ludus doctor` for macOS + container environment checks.
 
 One of the biggest time sinks in UE5 dedicated server builds is a cold Derived Data Cache (DDC). Every container run previously started with a completely cold cache, forcing hours of shader compilation and asset derivation.
 
-Ludus now makes DDC **persistent by default**:
+Ludus makes DDC **persistent by default**, using the **Unreal Zen Store** — the default local DDC backend in Unreal Engine since UE 5.4 (the legacy FileSystem DDC has been delete-only since 5.4). All UE versions Ludus supports (5.4–5.7) default to Zen.
 
-- `--ddc local` (default) — Persistent cache stored on the host (`~/.ludus/ddc`)
+- `--ddc zen` (default) — Persists UE's Zen Store cook cache. For container builds (Docker/Podman), the host Zen directory (`~/.ludus/zen`) is mounted into the container so the cache survives `--rm`. For native and WSL2 builds, UE's autolaunched Zen Store already persists in your home directory, so Ludus leaves it untouched.
+- `--ddc local` (deprecated) — Legacy FileSystem cache on the host (`~/.ludus/ddc`), redirected via `UE-LocalDataCachePath`. Retained for edge cases; prefer `zen`.
 - `--ddc none` — Disable DDC (useful for clean CI runs)
-- Works consistently for container builds (Docker/Podman) and native/binary builds
+- Docker and Podman build identically — DDC behaves the same on both.
 - `ludus ddc` subcommands: `status`, `clean`, `prune`, `warmup`
+
+> **Note:** `ludus ddc clean`/`prune`/`status` manage the Ludus-owned cache directories (the Zen mount for container builds, the FileSystem cache for `local`). For native/WSL2 `zen` builds, UE owns the cache location in your home directory, so those subcommands don't apply there.
 
 **Expected benefit**: Subsequent cooks are typically **40-70% faster**, especially the "Compiling Shaders..." phase.
 
@@ -510,8 +513,9 @@ Configure DDC in `ludus.yaml`:
 
 ```yaml
 ddc:
-  mode: "local"           # "local" (default) or "none"
-  localPath: ""           # Override path (default: ~/.ludus/ddc)
+  mode: "zen"             # "zen" (default), "local" (legacy FileSystem cache), or "none"
+  zenPath: ""             # Zen Store host path (default: ~/.ludus/zen)
+  localPath: ""           # Legacy FileSystem path, mode "local" only (default: ~/.ludus/ddc)
 ```
 
 #### DDC Performance — Up to 59% Faster Cooks on WSL2 Native

--- a/cmd/ddc/ddc.go
+++ b/cmd/ddc/ddc.go
@@ -73,7 +73,10 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	ddcPath, err := globals.ResolveDDCPath()
+
+	// Report the path for the active backend: zen mode persists the ZenStore
+	// directory, local mode the legacy FileSystem cache. "none" has no path.
+	ddcPath, err := statusPath(mode)
 	if err != nil {
 		return err
 	}
@@ -96,6 +99,27 @@ func runStatus(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Path: %s\n", ddcPath)
 	fmt.Printf("  Size: %s\n", formatSize(size))
 	return nil
+}
+
+// warmupPath returns the cache path the warmup cook will populate for the
+// active mode: the ZenStore dir for zen, the FileSystem dir for local.
+func warmupPath(mode, ddcPath, ddcZenPath string) string {
+	if mode == ddc.ModeZen {
+		return ddcZenPath
+	}
+	return ddcPath
+}
+
+// statusPath returns the host cache path to report for the given DDC mode.
+func statusPath(mode string) (string, error) {
+	switch mode {
+	case ddc.ModeZen:
+		return globals.ResolveZenPath()
+	case ddc.ModeLocal:
+		return globals.ResolveDDCPath()
+	default: // none
+		return "", nil
+	}
 }
 
 func runClean(cmd *cobra.Command, args []string) error {
@@ -156,12 +180,12 @@ func runWarmup(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	if ddcMode != ddc.ModeLocal {
-		return fmt.Errorf("DDC warmup requires mode 'local' (current: %q)", ddcMode)
+	if ddcMode == ddc.ModeNone {
+		return fmt.Errorf("DDC warmup requires DDC to be enabled; set ddc.mode to %q or %q (current: %q)", ddc.ModeZen, ddc.ModeLocal, ddcMode)
 	}
 
 	if globals.DryRun {
-		return printWarmupPreview(ddcPath)
+		return printWarmupPreview(warmupPath(ddcMode, ddcPath, ddcZenPath))
 	}
 
 	return executeWarmup(cmd.Context(), ddcMode, ddcPath, ddcZenPath)

--- a/cmd/ddc/ddc_test.go
+++ b/cmd/ddc/ddc_test.go
@@ -1,6 +1,26 @@
 package ddc
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/ddc"
+)
+
+func TestWarmupPath(t *testing.T) {
+	const localPath, zenPath = "/host/ddc", "/host/zen"
+	tests := []struct {
+		mode string
+		want string
+	}{
+		{ddc.ModeZen, zenPath},     // zen warms the ZenStore dir
+		{ddc.ModeLocal, localPath}, // local warms the FileSystem dir
+	}
+	for _, tt := range tests {
+		if got := warmupPath(tt.mode, localPath, zenPath); got != tt.want {
+			t.Errorf("warmupPath(%q) = %q, want %q", tt.mode, got, tt.want)
+		}
+	}
+}
 
 func TestFormatSize(t *testing.T) {
 	tests := []struct {

--- a/cmd/doctor/checks_build.go
+++ b/cmd/doctor/checks_build.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jpvelasco/ludus/internal/cache"
 	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/ddc"
 	"github.com/jpvelasco/ludus/internal/state"
 )
 
@@ -113,5 +114,31 @@ func checkCacheIntegrity() diagnostic {
 
 	d.status = "ok"
 	d.message = "cache file readable"
+	return d
+}
+
+// checkDDCMode reports the configured DDC backend and warns when the deprecated
+// legacy FileSystem cache (mode "local") is in effect.
+func checkDDCMode(cfg *config.Config) diagnostic {
+	d := diagnostic{name: "DDC Mode"}
+
+	mode, err := ddc.ValidateDDCMode(cfg.DDC.Mode)
+	if err != nil {
+		d.status = "fail"
+		d.message = err.Error()
+		return d
+	}
+
+	switch mode {
+	case ddc.ModeLocal:
+		d.status = "warn"
+		d.message = ddc.LocalModeDeprecationWarning
+	case ddc.ModeNone:
+		d.status = "ok"
+		d.message = "DDC disabled (mode: none)"
+	default: // zen
+		d.status = "ok"
+		d.message = "using Zen Store DDC (recommended)"
+	}
 	return d
 }

--- a/cmd/doctor/checks_build_test.go
+++ b/cmd/doctor/checks_build_test.go
@@ -3,8 +3,34 @@ package doctor
 import (
 	"testing"
 
+	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/state"
 )
+
+func TestCheckDDCMode(t *testing.T) {
+	tests := []struct {
+		name       string
+		mode       string
+		wantStatus string
+	}{
+		{name: "empty defaults to zen ok", mode: "", wantStatus: "ok"},
+		{name: "zen ok", mode: "zen", wantStatus: "ok"},
+		{name: "none ok", mode: "none", wantStatus: "ok"},
+		{name: "local warns (deprecated)", mode: "local", wantStatus: "warn"},
+		{name: "invalid fails", mode: "garbage", wantStatus: "fail"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{}
+			cfg.DDC.Mode = tt.mode
+			got := checkDDCMode(cfg)
+			if got.status != tt.wantStatus {
+				t.Errorf("checkDDCMode(%q).status = %q, want %q (msg: %q)", tt.mode, got.status, tt.wantStatus, got.message)
+			}
+		})
+	}
+}
 
 func TestClientBinaryIssue(t *testing.T) {
 	tests := []struct {

--- a/cmd/doctor/doctor.go
+++ b/cmd/doctor/doctor.go
@@ -45,6 +45,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	checks = append(checks, checkStaleBuildArtifacts(cfg))
 	checks = append(checks, checkBuildState())
 	checks = append(checks, checkCacheIntegrity())
+	checks = append(checks, checkDDCMode(cfg))
 	checks = append(checks, checkDiskSpace(cfg))
 	checks = append(checks, checkAWSCredentialExpiry())
 	checks = append(checks, checkDockerDaemon())

--- a/cmd/globals/ddc.go
+++ b/cmd/globals/ddc.go
@@ -2,6 +2,7 @@ package globals
 
 import (
 	"fmt"
+	"os"
 
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/ddc"
@@ -21,6 +22,20 @@ func ResolveDDCMode() (string, error) {
 		mode = Cfg.DDC.Mode
 	}
 	return ddc.ValidateDDCMode(mode)
+}
+
+// WarnIfLegacyDDC prints the legacy-DDC deprecation notice to stderr when the
+// effective mode resolves to "local". Written to stderr so it never corrupts
+// --json or mcp stdout. Called once per invocation from config load
+// (PersistentPreRunE), so it covers every command (including ddc status).
+// ludus doctor reports the same guidance as a structured diagnostic via
+// checkDDCMode. Invalid modes are ignored here (validated elsewhere with a
+// proper error).
+func WarnIfLegacyDDC() {
+	mode, err := ResolveDDCMode()
+	if err == nil && mode == ddc.ModeLocal {
+		fmt.Fprintf(os.Stderr, "Warning: %s\n", ddc.LocalModeDeprecationWarning)
+	}
 }
 
 // ResolveDDCPath returns the effective DDC host path.

--- a/cmd/globals/ddc_test.go
+++ b/cmd/globals/ddc_test.go
@@ -54,9 +54,11 @@ func TestResolveDDCMode(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"default", "", "", "local", false},
+		{"default", "", "", "zen", false},
+		{"flag zen", "zen", "", "zen", false},
 		{"flag local", "local", "", "local", false},
 		{"flag none", "none", "", "none", false},
+		{"config zen", "", "zen", "zen", false},
 		{"config local", "", "local", "local", false},
 		{"config none", "", "none", "none", false},
 		{"flag overrides config", "none", "local", "none", false},
@@ -180,17 +182,26 @@ func TestResolveDDC(t *testing.T) {
 		absPath = `C:\test\ddc`
 	}
 
+	absZen := "/test/zen"
+	if runtime.GOOS == "windows" {
+		absZen = `C:\test\zen`
+	}
+
 	tests := []struct {
-		name     string
-		mode     string
-		ddcPath  string
-		wantMode string
-		wantPath string
-		wantErr  bool
+		name        string
+		mode        string
+		ddcPath     string
+		zenPath     string
+		wantMode    string
+		wantPath    string
+		wantZenPath string
+		wantErr     bool
 	}{
-		{"local mode returns both", "local", absPath, "local", absPath, false},
-		{"none mode returns empty path", "none", "", "none", "", false},
-		{"invalid mode errors", "garbage", "", "", "", true},
+		{"default (empty) resolves to zen", "", "", absZen, "zen", "", absZen, false},
+		{"zen mode returns zen path", "zen", "", absZen, "zen", "", absZen, false},
+		{"local mode returns local path", "local", absPath, "", "local", absPath, "", false},
+		{"none mode returns empty paths", "none", "", "", "none", "", "", false},
+		{"invalid mode errors", "garbage", "", "", "", "", "", true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -204,8 +215,9 @@ func TestResolveDDC(t *testing.T) {
 			DDCMode = tt.mode
 			Cfg = &config.Config{}
 			Cfg.DDC.LocalPath = tt.ddcPath
+			Cfg.DDC.ZenPath = tt.zenPath
 
-			mode, path, _, err := ResolveDDC()
+			mode, path, zenPath, err := ResolveDDC()
 			if (err != nil) != tt.wantErr {
 				t.Fatalf("ResolveDDC() error = %v, wantErr %v", err, tt.wantErr)
 			}
@@ -215,8 +227,16 @@ func TestResolveDDC(t *testing.T) {
 			if mode != tt.wantMode {
 				t.Errorf("mode = %q, want %q", mode, tt.wantMode)
 			}
-			if path != tt.wantPath {
+			// wantPath/wantZenPath of "" means "don't assert exact value"
+			// (the resolver fills defaults we don't pin here).
+			if tt.wantPath != "" && path != tt.wantPath {
 				t.Errorf("path = %q, want %q", path, tt.wantPath)
+			}
+			if tt.wantZenPath != "" && zenPath != tt.wantZenPath {
+				t.Errorf("zenPath = %q, want %q", zenPath, tt.wantZenPath)
+			}
+			if tt.wantMode == "none" && (path != "" || zenPath != "") {
+				t.Errorf("none mode should return empty paths, got path=%q zenPath=%q", path, zenPath)
 			}
 		})
 	}

--- a/cmd/root/root.go
+++ b/cmd/root/root.go
@@ -120,6 +120,13 @@ Use --profile to manage multiple configurations (e.g., different UE versions):
 			}
 		}
 
+		// Warn once if the legacy FileSystem DDC is in effect. Skip for mcp,
+		// whose stdout carries JSON-RPC (the warning goes to stderr, but mcp
+		// clients shouldn't see build-time guidance noise).
+		if cmd.Name() != "mcp" {
+			globals.WarnIfLegacyDDC()
+		}
+
 		// Initialize optional OTLP tracing (no-op unless enabled in config/env).
 		if err := globals.InitTracing(cmd.Context()); err != nil {
 			fmt.Fprintf(os.Stderr, "Warning: OTLP tracing init failed: %v\n", err)
@@ -146,7 +153,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&globals.JSONOutput, "json", false, "output in JSON format")
 	rootCmd.PersistentFlags().BoolVar(&globals.DryRun, "dry-run", false, "print commands without executing")
 	rootCmd.PersistentFlags().StringVar(&globals.Profile, "profile", "", "state profile for multi-version workflows (e.g., ue57-ec2)")
-	rootCmd.PersistentFlags().StringVar(&globals.DDCMode, "ddc", "", `DDC mode: "local" (default) or "none" (disable cache)`)
+	rootCmd.PersistentFlags().StringVar(&globals.DDCMode, "ddc", "", `DDC mode: "zen" (default), "local" (legacy FileSystem cache), or "none" (disable cache)`)
 	rootCmd.PersistentFlags().BoolVar(&globals.NoLogs, "no-logs", false, "do not write build output to .ludus/logs")
 	rootCmd.PersistentFlags().BoolVar(&globals.ShowAccountID, "show-account-id", false, "show the AWS account ID in output (default: masked)")
 

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -47,7 +47,7 @@ func Defaults() *Config {
 			RunnerLabels: []string{"self-hosted", "linux", "x64"},
 		},
 		DDC: DDCConfig{
-			Mode: "local",
+			Mode: "zen",
 		},
 		Observability: ObservabilityConfig{
 			Logs: LogsConfig{

--- a/internal/config/config_defaults_test.go
+++ b/internal/config/config_defaults_test.go
@@ -30,7 +30,7 @@ func TestDefaults(t *testing.T) {
 		{"ec2fleet.serverSdkVersion", cfg.EC2Fleet.ServerSDKVersion, "5.4.0"},
 		{"ci.workflowPath", cfg.CI.WorkflowPath, ".github/workflows/ludus-pipeline.yml"},
 		{"ci.runnerDir", cfg.CI.RunnerDir, "~/actions-runner"},
-		{"ddc.mode", cfg.DDC.Mode, "local"},
+		{"ddc.mode", cfg.DDC.Mode, "zen"},
 		{"ddc.localPath", cfg.DDC.LocalPath, ""},
 	}
 	for _, tt := range stringChecks {

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -192,11 +192,15 @@ type CIConfig struct {
 
 // DDCConfig holds Derived Data Cache settings for UE5 builds.
 type DDCConfig struct {
-	Mode      string `yaml:"mode" mapstructure:"mode"`
+	// Mode selects the DDC backend: "zen" (default), "local" (legacy
+	// FileSystem cache, deprecated), or "none".
+	Mode string `yaml:"mode" mapstructure:"mode"`
+	// LocalPath is the host directory for the legacy FileSystem DDC (mode
+	// "local" only). Defaults to ~/.ludus/ddc.
 	LocalPath string `yaml:"localPath" mapstructure:"localPath"`
-	// ZenPath overrides the host directory for the UE5 ZenStore cache.
-	// On UE 5.6+, cook DDC is written to ZenStore rather than the FileSystem
-	// Local backend, so this path must be persisted to get DDC reuse in
-	// container builds. Defaults to ~/.ludus/zen when mode is "local".
+	// ZenPath overrides the host directory for the UE5 Zen Store cache, UE's
+	// default local DDC backend since 5.4. In container builds this path must
+	// be persisted to get cook DDC reuse across --rm runs. Defaults to
+	// ~/.ludus/zen when mode is "zen".
 	ZenPath string `yaml:"zenPath" mapstructure:"zenPath"`
 }

--- a/internal/ddc/ddc.go
+++ b/internal/ddc/ddc.go
@@ -12,22 +12,33 @@ import (
 
 // DDC mode constants. Use these instead of raw string comparisons.
 const (
-	ModeLocal = "local" // Persistent local filesystem cache (default).
+	ModeZen   = "zen"   // Unreal Zen Store DDC (default; UE's default local backend since 5.4).
+	ModeLocal = "local" // Legacy FileSystem DDC (deprecated; delete-only in UE since 5.4).
 	ModeNone  = "none"  // DDC disabled; no cache volume mounted.
 )
 
 // ValidateDDCMode returns the normalized mode or an error for unknown values.
-// Empty string is normalized to ModeLocal (the default).
+// Empty string is normalized to ModeZen (the default): Unreal Engine uses the
+// Zen Store as its default local DDC backend from UE 5.4 onward (the legacy
+// FileSystem DDC is delete-only since 5.4), and Ludus supports UE 5.4+.
 func ValidateDDCMode(mode string) (string, error) {
 	switch mode {
-	case "", ModeLocal:
+	case "", ModeZen:
+		return ModeZen, nil
+	case ModeLocal:
 		return ModeLocal, nil
 	case ModeNone:
 		return ModeNone, nil
 	default:
-		return "", fmt.Errorf("invalid DDC mode %q: valid values are %q (persistent cache, default) or %q (disable cache)", mode, ModeLocal, ModeNone)
+		return "", fmt.Errorf("invalid DDC mode %q: valid values are %q (Zen Store, default), %q (legacy FileSystem cache, deprecated), or %q (disable cache)", mode, ModeZen, ModeLocal, ModeNone)
 	}
 }
+
+// LocalModeDeprecationWarning is the user-facing message shown when an explicit
+// ddc.mode: local is in effect. Surfaced from config load, ludus doctor, and
+// ludus ddc status so the guidance is consistent everywhere.
+const LocalModeDeprecationWarning = "ddc.mode: local uses the legacy FileSystem DDC (delete-only since UE 5.4). " +
+	"Zen is now the default and recommended for best performance — set ddc.mode: zen."
 
 // EnvOverride returns the environment variable string that redirects UE5's
 // local DDC backend to path. UE5's BaseEngine.ini configures the Local backend
@@ -45,10 +56,11 @@ func EnvOverride(path string) string {
 
 // ZenContainerPath is the fixed path inside the container where UE5 writes
 // its ZenStore data. This resolves from the Zen.AutoLaunch DataPath template
-// (%ENGINEVERSIONAGNOSTICINSTALLEDUSERDIR%Zen/Data) under the ue user's home.
-// On UE 5.6+, %ENGINEVERSIONAGNOSTICINSTALLEDUSERDIR% resolves to
+// (%ENGINEVERSIONAGNOSTICINSTALLEDUSERDIR%Zen/Data) under the ue user's home,
+// where %ENGINEVERSIONAGNOSTICINSTALLEDUSERDIR% resolves to
 // ~/.config/Epic/UnrealEngine/Common/, giving the full path below.
-// Mounting a host directory here persists the ZenStore across --rm container runs.
+// UE uses the Zen Store as its default local DDC backend from 5.4 onward, so
+// mounting a host directory here persists the cook DDC across --rm container runs.
 const ZenContainerPath = "/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data"
 
 // DefaultZenPath returns the default ZenStore host directory: ~/.ludus/zen

--- a/internal/ddc/ddc_path_test.go
+++ b/internal/ddc/ddc_path_test.go
@@ -12,8 +12,9 @@ func TestValidateDDCMode(t *testing.T) {
 		want    string
 		wantErr bool
 	}{
-		{"", "local", false},
-		{"local", "local", false},
+		{"", "zen", false}, // empty now defaults to zen (Zen is UE 5.4+ default)
+		{"zen", "zen", false},
+		{"local", "local", false}, // still valid, but deprecated
 		{"none", "none", false},
 		{"shared", "", true},
 		{"LOCAL", "", true},

--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -42,13 +42,14 @@ type DockerGameOptions struct {
 	OutputDir string
 	// EngineVersion is the detected engine version (for workarounds).
 	EngineVersion string
-	// DDCMode is the DDC backend mode: "local" or "none".
+	// DDCMode is the DDC backend mode: "zen" (default), "local", or "none".
 	DDCMode string
-	// DDCPath is the host path for the FileSystem Local DDC volume (UE 5.5 and below).
+	// DDCPath is the host path for the legacy FileSystem DDC volume (mode "local").
 	DDCPath string
-	// DDCZenPath is the host path for the ZenStore DDC volume (UE 5.6+).
-	// On UE 5.6+, cook DDC is written to ZenStore. Mounting this directory
-	// at the container's ZenStore data path persists it across --rm runs.
+	// DDCZenPath is the host path for the ZenStore DDC volume (mode "zen").
+	// UE uses the Zen Store as its default local DDC backend from 5.4 onward;
+	// cook DDC is written there. Mounting this directory at the container's
+	// ZenStore data path persists it across --rm runs.
 	DDCZenPath string
 	// CookOnly runs only the cook step, skipping build/stage/package/archive.
 	// Used for DDC warmup.
@@ -408,43 +409,56 @@ func (b *DockerGameBuilder) runBuildContainer(ctx context.Context, outputDir, sc
 }
 
 // ddcArgs returns the extra container args (volume mounts and env vars) for the
-// configured DDC mode. It also creates the local DDC directory if needed.
+// configured DDC mode. It also creates the host cache directory if needed.
+//
+// Zen (the default, UE's default local backend since 5.4) mounts only the
+// ZenStore data path, where the cook DDC is written. Legacy local mounts only
+// the FileSystem cache at /ddc via UE-LocalDataCachePath.
 func (b *DockerGameBuilder) ddcArgs() ([]string, error) {
 	switch b.opts.DDCMode {
+	case ddc.ModeZen:
+		return b.zenDDCArgs()
 	case ddc.ModeLocal:
-		if b.opts.DDCPath == "" {
-			return nil, fmt.Errorf("DDC mode is %q but no path configured; set ddc.localPath in ludus.yaml or use --ddc none", ddc.ModeLocal)
-		}
-		if err := os.MkdirAll(b.opts.DDCPath, 0755); err != nil {
-			return nil, fmt.Errorf("creating DDC directory: %w", err)
-		}
-		args := []string{
-			"-v", fmt.Sprintf("%s:/ddc", b.opts.DDCPath),
-			"-e", ddc.EnvOverride("/ddc"),
-		}
-		// Mount the ZenStore data path so UE 5.6+ cook DDC persists across runs.
-		// On 5.6+, cook DDC is written to ZenStore rather than the FileSystem
-		// Local backend, making the /ddc mount a no-op for cook data without this.
-		if b.opts.DDCZenPath != "" {
-			if err := os.MkdirAll(b.opts.DDCZenPath, 0755); err != nil { //nolint:gosec // user-configured path
-				return nil, fmt.Errorf("creating DDC zen directory: %w", err)
-			}
-			args = append(args,
-				"-v", fmt.Sprintf("%s:%s", b.opts.DDCZenPath, ddc.ZenContainerPath),
-			)
-			fmt.Printf("DDC: local (filesystem at %s, ZenStore at %s)\n", b.opts.DDCPath, b.opts.DDCZenPath)
-		} else {
-			fmt.Printf("DDC: local (persistent at %s)\n", b.opts.DDCPath)
-		}
-		return args, nil
+		return b.localDDCArgs()
 	case ddc.ModeNone:
 		fmt.Println("DDC: disabled")
 		return nil, nil
 	case "":
 		return nil, nil
 	default:
-		return nil, fmt.Errorf("unsupported DDC mode %q; valid values are %q or %q", b.opts.DDCMode, ddc.ModeLocal, ddc.ModeNone)
+		return nil, fmt.Errorf("unsupported DDC mode %q; valid values are %q, %q, or %q", b.opts.DDCMode, ddc.ModeZen, ddc.ModeLocal, ddc.ModeNone)
 	}
+}
+
+// zenDDCArgs mounts the host ZenStore directory at the container's Zen data path
+// so the cook DDC persists across --rm runs.
+func (b *DockerGameBuilder) zenDDCArgs() ([]string, error) {
+	if b.opts.DDCZenPath == "" {
+		return nil, fmt.Errorf("DDC mode is %q but no zen path configured; set ddc.zenPath in ludus.yaml or use --ddc none", ddc.ModeZen)
+	}
+	if err := os.MkdirAll(b.opts.DDCZenPath, 0755); err != nil { //nolint:gosec // user-configured path
+		return nil, fmt.Errorf("creating DDC zen directory: %w", err)
+	}
+	fmt.Printf("DDC: zen (ZenStore at %s)\n", b.opts.DDCZenPath)
+	return []string{
+		"-v", fmt.Sprintf("%s:%s", b.opts.DDCZenPath, ddc.ZenContainerPath),
+	}, nil
+}
+
+// localDDCArgs mounts the legacy FileSystem DDC at /ddc and redirects UE's
+// local backend there via UE-LocalDataCachePath.
+func (b *DockerGameBuilder) localDDCArgs() ([]string, error) {
+	if b.opts.DDCPath == "" {
+		return nil, fmt.Errorf("DDC mode is %q but no path configured; set ddc.localPath in ludus.yaml or use --ddc none", ddc.ModeLocal)
+	}
+	if err := os.MkdirAll(b.opts.DDCPath, 0755); err != nil {
+		return nil, fmt.Errorf("creating DDC directory: %w", err)
+	}
+	fmt.Printf("DDC: local (persistent at %s)\n", b.opts.DDCPath)
+	return []string{
+		"-v", fmt.Sprintf("%s:/ddc", b.opts.DDCPath),
+		"-e", ddc.EnvOverride("/ddc"),
+	}, nil
 }
 
 // BuildClient runs the game client build inside a Docker container.

--- a/internal/dockerbuild/game_ddc_test.go
+++ b/internal/dockerbuild/game_ddc_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jpvelasco/ludus/internal/ddc"
 	"github.com/jpvelasco/ludus/internal/runner"
 )
 
@@ -60,6 +61,64 @@ func TestDDCArgs(t *testing.T) {
 			b := NewDockerGameBuilder(DockerGameOptions{DDCMode: tt.ddcMode, DDCPath: tt.ddcPath}, r)
 			checkDDCArgs(t, b, tt.wantErr, tt.wantNoArgs, tt.wantArgs)
 		})
+	}
+}
+
+func TestDDCArgs_ZenMountsOnlyZenPath(t *testing.T) {
+	zenDir := filepath.Join(t.TempDir(), "zen")
+	ddcDir := filepath.Join(t.TempDir(), "ddc")
+	r := runner.NewRunner(false, false)
+	b := NewDockerGameBuilder(DockerGameOptions{
+		DDCMode:    ddc.ModeZen,
+		DDCPath:    ddcDir, // present but must NOT be mounted in zen mode
+		DDCZenPath: zenDir,
+	}, r)
+
+	args, err := b.ddcArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, zenDir+":"+ddc.ZenContainerPath) {
+		t.Errorf("zen mode should mount zen path at %s; got %v", ddc.ZenContainerPath, args)
+	}
+	// Zen mode must NOT mount the legacy /ddc filesystem volume or set the env override.
+	if strings.Contains(joined, ":/ddc") || strings.Contains(joined, "UE-LocalDataCachePath") {
+		t.Errorf("zen mode must not mount the legacy FileSystem DDC; got %v", args)
+	}
+	if _, err := os.Stat(zenDir); err != nil {
+		t.Errorf("zen directory should have been created: %v", err)
+	}
+}
+
+func TestDDCArgs_ZenWithoutPathErrors(t *testing.T) {
+	r := runner.NewRunner(false, false)
+	b := NewDockerGameBuilder(DockerGameOptions{DDCMode: ddc.ModeZen}, r)
+	if _, err := b.ddcArgs(); err == nil || !strings.Contains(err.Error(), "no zen path configured") {
+		t.Errorf("zen mode without a zen path should error clearly; got %v", err)
+	}
+}
+
+func TestDDCArgs_LocalMountsOnlyFilesystem(t *testing.T) {
+	ddcDir := filepath.Join(t.TempDir(), "ddc")
+	r := runner.NewRunner(false, false)
+	b := NewDockerGameBuilder(DockerGameOptions{
+		DDCMode:    ddc.ModeLocal,
+		DDCPath:    ddcDir,
+		DDCZenPath: filepath.Join(t.TempDir(), "zen"), // present but must NOT be mounted in local mode
+	}, r)
+
+	args, err := b.ddcArgs()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	joined := strings.Join(args, " ")
+	if !strings.Contains(joined, ":/ddc") || !strings.Contains(joined, "UE-LocalDataCachePath=/ddc") {
+		t.Errorf("local mode should mount the FileSystem DDC at /ddc; got %v", args)
+	}
+	if strings.Contains(joined, ddc.ZenContainerPath) {
+		t.Errorf("local mode must not mount the ZenStore path; got %v", args)
 	}
 }
 

--- a/internal/game/builder_ddc_test.go
+++ b/internal/game/builder_ddc_test.go
@@ -19,6 +19,11 @@ func TestSetupDDC(t *testing.T) {
 		errMsg  string
 	}{
 		{
+			name:    "zen mode is a no-op (UE persists its own Zen Store natively)",
+			opts:    BuildOptions{DDCMode: "zen", DDCPath: "/some/path"},
+			wantEnv: false,
+		},
+		{
 			name:    "mode none returns nil",
 			opts:    BuildOptions{DDCMode: "none", DDCPath: "/some/path"},
 			wantEnv: false,

--- a/internal/game/ddc.go
+++ b/internal/game/ddc.go
@@ -7,18 +7,23 @@ import (
 	"github.com/jpvelasco/ludus/internal/ddc"
 )
 
-// setupDDC configures DDC by setting the UE-LocalDataCachePath environment
-// variable on the runner. This overrides UE5's default local DDC path without
-// modifying any project or engine files. Returns an error if the DDC directory
-// cannot be created (permission denied, disk full, etc.).
+// setupDDC configures DDC for a native (non-container) build.
+//
+// For "zen" (the default), it is a no-op: UE autolaunches its Zen Store into the
+// user's real home directory, which already persists across runs — there is no
+// ephemeral container filesystem to redirect, so Ludus leaves it untouched.
+// For "local" (legacy), it sets UE-LocalDataCachePath to redirect UE5's
+// FileSystem backend to a persistent path. Returns an error if the local DDC
+// directory cannot be created (permission denied, disk full, etc.).
 func (b *Builder) setupDDC() error {
 	switch b.opts.DDCMode {
+	case ddc.ModeZen, ddc.ModeNone, "":
+		// Zen: UE's own Zen Store persists natively; nothing to redirect.
+		return nil
 	case ddc.ModeLocal:
 		return b.setupLocalDDC()
-	case ddc.ModeNone, "":
-		return nil
 	default:
-		return fmt.Errorf("unsupported DDC mode %q; valid values are %q or %q", b.opts.DDCMode, ddc.ModeLocal, ddc.ModeNone)
+		return fmt.Errorf("unsupported DDC mode %q; valid values are %q, %q, or %q", b.opts.DDCMode, ddc.ModeZen, ddc.ModeLocal, ddc.ModeNone)
 	}
 }
 

--- a/ludus.example.yaml
+++ b/ludus.example.yaml
@@ -100,16 +100,19 @@ aws:
     ManagedBy: "ludus"
 
 # ddc:
-#   # DDC mode: "local" (default, persistent cache) or "none" (disable)
-#   mode: "local"
-#   # Host path for the FileSystem Local DDC (UE 5.5 and below).
-#   # Defaults to ~/.ludus/ddc
-#   # localPath: "/home/user/.ludus/ddc"
-#   # Host path for the ZenStore DDC (UE 5.6+).
-#   # On UE 5.6+, cook DDC is written to ZenStore. Mount this path to
-#   # persist the cook cache across container runs and get DDC speedup.
+#   # DDC mode: "zen" (default, Unreal Zen Store), "local" (legacy FileSystem
+#   # cache, deprecated), or "none" (disable).
+#   # Unreal Engine uses the Zen Store as its default local DDC backend from
+#   # UE 5.4 onward (the legacy FileSystem cache is delete-only since 5.4).
+#   mode: "zen"
+#   # Host path for the Zen Store DDC. For container builds this is mounted into
+#   # the container so the cook cache persists across --rm runs. Native/WSL2
+#   # builds use UE's own Zen Store in your home dir (this path is not used).
 #   # Defaults to ~/.ludus/zen
 #   # zenPath: "/home/user/.ludus/zen"
+#   # Host path for the legacy FileSystem DDC (mode "local" only).
+#   # Defaults to ~/.ludus/ddc
+#   # localPath: "/home/user/.ludus/ddc"
 
 # privacy:
 #   # Mask the 12-digit AWS account ID in ECR URIs/ARNs in terminal output


### PR DESCRIPTION
## Summary

Makes the **Unreal Zen Store** the default DDC backend and deprecates the legacy FileSystem cache.

Unreal Engine uses the Zen Store as its default local DDC backend **from UE 5.4 onward** (the legacy FileSystem DDC is delete-only since 5.4 — per Epic's "Using Derived Data Cache" docs). Ludus supports UE 5.4–5.7, so Zen is now the **unconditional** default — no version gate.

This also **corrects a wrong assumption** baked into #330: that ZenStore applied only to UE 5.6+ (with FileSystem for 5.5 and below). That was inaccurate; the "5.6+" framing is removed from all comments, config, and docs.

## What changed

**Config model**
- New `ddc.mode: zen` (default). Empty mode resolves to `zen` everywhere.
- `ddc.mode: local` (legacy FileSystem cache) still honored, but **deprecated** with a warning.
- `ddc.mode: none` unchanged.
- Existing explicit `mode: local` configs keep working (honored + warned); only new/empty configs get `zen`.

**Per build path** (Docker and Podman are identical — backend only selects the executable):

| Path | `zen` (default) | `local` (deprecated) |
|---|---|---|
| Container | bind-mount host Zen dir at the container Zen data path (survives `--rm`) | mount `/ddc` + `UE-LocalDataCachePath` |
| Native / WSL2 | **hands-off** — UE's own Zen Store persists in the real home dir | `UE-LocalDataCachePath` override |

`ddcArgs()` now mounts **only** the Zen path for `zen` and **only** `/ddc` for `local` (previously `local` conflated both).

**Deprecation warning** — centralized in `ddc.LocalModeDeprecationWarning`, surfaced once per run from config load and as a `ludus doctor` diagnostic (`checkDDCMode`). Written to stderr (never pollutes `--json`/`mcp` stdout).

**Bug caught in review:** `ludus ddc warmup` previously hard-required `mode: local` — it would have failed for every default-config user. Now accepts `zen` (preferred) and `local`, rejecting only `none`.

**Docs corrected:** README (DDC section + config table), ARCHITECTURE.md (new "DDC Backend" design-decision section for developers), `ludus.example.yaml`, CHANGELOG, and all inline comments.

## Relationship to #347

Independent branches off main; they compose cleanly. #347 fixes the Zen-mount chown (keyed on `DDCZenPath != ""`), which `zen` mode sets — so the fix fires for the new default once both merge.

## Test plan

- [x] `ddcArgs` zen/local split asserted (mounts only the correct volume per mode)
- [x] zen-mode error when no zen path; native `setupDDC` zen no-op
- [x] `ValidateDDCMode`/`ResolveDDC`/`ResolveDDCMode` cover empty→zen, zen, local, none, invalid
- [x] `checkDDCMode` doctor diagnostic (ok/warn/fail)
- [x] `warmupPath` helper (zen→zen dir, local→fs dir)
- [x] Manual smoke test: default→zen, explicit local warns once, invalid mode clear error
- [x] `go build`, `go test ./...`, `golangci-lint run ./...` all clean