### PR TITLE
fix: recursively chown /project in pre-existing-ue preamble branch

### DIFF
--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -148,7 +148,12 @@ if ! id ue >/dev/null 2>&1; then
 else
     # User exists (new engine image) but mounted volumes need ownership
     chown ue:ue /output /ddc 2>/dev/null || true
-    chown ue:ue /project 2>/dev/null || true
+    # /project is the user's source tree; UAT (as ue) edits subdirs in place
+    # (e.g. sed -i on Config/DefaultEngine.ini), so it must be recursive — a
+    # non-recursive chown leaves root-owned subdirs and the build fails with
+    # "sed: couldn't open temporary file .../Config/...". Unlike /engine this
+    # is small, so recursive chown is safe (no large overlayfs copy-up).
+    chown -R ue:ue /project 2>/dev/null || true
     # Engine root may be root-owned in images where user ue pre-exists; UAT (as ue)
     # mkdir's build outputs (Intermediate/, Saved/, DerivedDataCache/) directly under
     # /engine and /engine/Engine. Chown ONLY these parent dirs (non-recursive) so the

--- a/internal/dockerbuild/game_preamble_test.go
+++ b/internal/dockerbuild/game_preamble_test.go
@@ -63,6 +63,28 @@ func TestScriptPreamble_ZenMountParentChown(t *testing.T) {
 	}
 }
 
+func TestScriptPreamble_RecursiveProjectChown(t *testing.T) {
+	r := runner.NewRunner(false, false)
+	b := NewDockerGameBuilder(DockerGameOptions{}, r)
+	got := b.scriptPreamble()
+
+	// Every /project chown must be recursive. The project is the user's source
+	// tree (with subdirs like Config/ that UAT's sed -i edits as the ue user);
+	// a non-recursive chown leaves root-owned subdirs and the build fails with
+	// "sed: couldn't open temporary file .../Config/...". /engine stays
+	// non-recursive (copy-up cost), but /project must be -R in both the
+	// new-user and pre-existing-ue branches.
+	for line := range strings.SplitSeq(got, "\n") {
+		if strings.Contains(line, "/project") && strings.Contains(line, "chown") &&
+			!strings.Contains(line, "chown -R") {
+			t.Errorf("preamble chowns /project non-recursively: %q", strings.TrimSpace(line))
+		}
+	}
+	if !strings.Contains(got, "chown -R ue:ue /project") {
+		t.Errorf("preamble must recursively chown /project (got:\n%s)", got)
+	}
+}
+
 func TestScriptPreamble_InstallsRuntimeDeps(t *testing.T) {
 	r := runner.NewRunner(false, false)
 	b := NewDockerGameBuilder(DockerGameOptions{EngineVersion: "5.7"}, r)


### PR DESCRIPTION
## Summary

Found during the v0.7.0 live validation run — building Lyra (UE 5.7.4) as a container on EC2. The game build failed at the `DefaultServerTarget` INI patch step:

```
sed: couldn't open temporary file /project/Config/sedXXXXXX: Permission denied
```

## Root cause

`scriptPreamble()` (`internal/dockerbuild/game.go`) has two user-setup branches:

- **New-user branch** (`useradd`): `chown -R ue:ue /project` ✓ recursive
- **Pre-existing-ue branch** (engine images that already ship the `ue` user): `chown ue:ue /project` ✗ **non-recursive**

In the non-recursive case, root-owned subdirectories like `Config/` keep their ownership. UAT then runs as `ue` and does `sed -i` on `Config/DefaultEngine.ini` (to set `DefaultServerTarget` for multi-target projects like Lyra). `sed -i` writes its temp file in the target's directory — which is still root-owned — so it fails with `Permission denied`.

This is the same failure family as #340 (a missed recursive chown of a Docker-mounted path), on a different path.

## Fix

Make the pre-existing-ue branch chown `/project` recursively, matching the new-user branch. `/project` is the user's source tree (small), so recursive chown is safe — unlike `/engine`, which intentionally stays non-recursive to avoid an expensive overlayfs copy-up of the multi-GB engine tree.

## Verification

- Root cause reproduced deterministically on the EC2 box: with the pre-existing-`ue` engine image and a root-owned `/project`, the non-recursive chown leaves `Config/` root-owned and `sed -i` as `ue` fails; a recursive chown fixes it.
- New unit test `TestScriptPreamble_RecursiveProjectChown` asserts every `/project` chown in the preamble is recursive (plain string scan, no regex).
- `go build`, `go test ./...`, `golangci-lint run ./...` all clean.

## Test plan

- [x] New unit test covers the recursive-chown invariant
- [x] Full build/test/lint green
- [ ] End-to-end: re-validated on EC2 against the published v0.7.1 (Lyra container build → deploy → Zen DDC persistence) — in progress