### PR TITLE
fix: recursively chown the ZenStore mount tree so container cook can use Zen DDC

### DIFF
--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -168,15 +168,19 @@ fi
 `
 
 	// When a ZenStore mount is configured, Docker auto-creates the bind-mount
-	// parents (/home/ue/.config and /home/ue/.config/Epic) owned by root. UAT
-	// runs as ue and mkdir's its config dir (/home/ue/.config/Unreal Engine)
-	// as a sibling of the mount, which fails on the root-owned parent (#340).
-	// Chown the parents non-recursively — the mount itself is already owned via
-	// the host dir, so a recursive chown is unnecessary and risks copy-up.
+	// parent chain (/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data) owned by
+	// root, and the host DDC dir backing the mount is itself root-owned. UAT runs
+	// as ue and needs to (a) write the Zen Data store, (b) create the sibling
+	// Zen/Install/zenserver dir, and (c) mkdir /home/ue/.config/Unreal Engine.
+	// Chowning only the top two levels (the original #340 fix) left the deeper
+	// Zen paths root-owned, so zenserver failed its readiness check, the DDC
+	// backend graph had no writable node, and the cook crashed (errno=13).
+	// Recursively chown the whole .config tree — it's small (no large overlayfs
+	// copy-up risk, unlike /engine) — so every Zen path is writable by ue.
 	if b.opts.DDCZenPath != "" {
-		script += `# Fix ownership of Docker-created ZenStore mount parents so UAT (as ue)
-# can create its sibling config dir /home/ue/.config/Unreal Engine (#340).
-chown ue:ue /home/ue/.config /home/ue/.config/Epic 2>/dev/null || true
+		script += `# Fix ownership of the Docker-created ZenStore mount tree so UAT (as ue) can
+# write the Zen Data store, create Zen/Install, and mkdir its config dir (#340).
+chown -R ue:ue /home/ue/.config 2>/dev/null || true
 `
 	}
 

--- a/internal/dockerbuild/game_preamble_test.go
+++ b/internal/dockerbuild/game_preamble_test.go
@@ -34,21 +34,26 @@ func TestScriptPreamble_ZenMountParentChown(t *testing.T) {
 	r := runner.NewRunner(false, false)
 
 	// When a ZenStore mount is configured, Docker auto-creates the bind-mount
-	// parents (/home/ue/.config and /home/ue/.config/Epic) owned by root. The
-	// preamble must chown them to ue, or UAT (running as ue) fails creating its
-	// sibling config dir /home/ue/.config/Unreal Engine (#340).
+	// chain (/home/ue/.config/.../Common/Zen/Data) owned by root, and the host
+	// DDC dir backing it is root-owned. The preamble must chown the WHOLE
+	// .config tree recursively, or zenserver (running as ue) can't write the Zen
+	// Data store / Install dir, the DDC backend has no writable node, and the
+	// cook crashes (#340; deepened after the original two-level fix proved
+	// insufficient during live UE 5.7.4 + Lyra validation).
 	withZen := NewDockerGameBuilder(DockerGameOptions{
-		DDCMode:    ddc.ModeLocal,
-		DDCPath:    "/tmp/ddc",
+		DDCMode:    ddc.ModeZen,
 		DDCZenPath: "/tmp/zen",
 	}, r)
 	got := withZen.scriptPreamble()
-	for _, want := range []string{
-		"chown ue:ue /home/ue/.config",
-		"/home/ue/.config/Epic",
-	} {
-		if !strings.Contains(got, want) {
-			t.Errorf("preamble with Zen mount should chown the mount parents; missing %q\ngot:\n%s", want, got)
+	if !strings.Contains(got, "chown -R ue:ue /home/ue/.config") {
+		t.Errorf("preamble with Zen mount must recursively chown /home/ue/.config; got:\n%s", got)
+	}
+	// Guard against regressing to a shallow, non-recursive .config chown that
+	// leaves the deeper Zen Data/Install paths root-owned.
+	for line := range strings.SplitSeq(got, "\n") {
+		if strings.Contains(line, "/home/ue/.config") && strings.Contains(line, "chown") &&
+			!strings.Contains(line, "chown -R") {
+			t.Errorf("preamble chowns .config non-recursively: %q", strings.TrimSpace(line))
 		}
 	}
 


### PR DESCRIPTION
## Summary

Found during the v0.7.1 live validation — the Lyra (UE 5.7.4) container cook crashed at startup because Zen DDC couldn't initialize. This deepens the #340 fix, which only chowned the top two `.config` levels.

## Root cause

The #340 preamble fix did `chown ue:ue /home/ue/.config /home/ue/.config/Epic` — two levels, non-recursive. But the Zen bind-mount creates a deeper chain (`/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data`), and the host DDC dir backing the mount is itself root-owned. Everything below `Epic/` stayed `root:root`, so during the cook:

```
LogUnixPlatformFile: Warning: open('.../Common/Zen/Data/.zen-startup-test-file') failed: errno=13 (Permission denied)
LogZenServiceInstance: Warning: Skipping Zen config default=.../Common/Zen/Data due to an invalid path
LogUnixPlatformFile: Warning: create dir('.../Common/Zen/Install/zenserver') failed: errno=13 (Permission denied)
LogDerivedDataCache: ZenLocal: Readiness check failed. It will be deactivated...
Fatal error: DerivedDataBackends.cpp Line 215 — no readable or writable nodes available
Signal 11 caught.
```

`zenserver` (running as `ue`) could neither write the Zen **Data** store nor create the sibling Zen/**Install** dir. With zen mode mounting only the Zen path (no FileSystem fallback), the DDC backend graph had no writable node and `UnrealEditor-Cmd` segfaulted (`ExitCode=139`) ~11s into cook.

## Fix

Recursively chown the whole `/home/ue/.config` tree in the preamble. It's small (no large overlayfs copy-up risk, unlike `/engine`), so recursive is safe and covers every Zen path `ue` needs.

## Verification

Reproduced and fixed deterministically on the EC2 box:
- Before: full `.config/.../Zen/Data` chain is `root:root`; `ue` cannot write (`UE_CANNOT_WRITE`).
- After `chown -R ue:ue /home/ue/.config`: `ue` can write the Data store (`UE_CAN_WRITE_NOW`) and create `Zen/Install/zenserver` (`INSTALL_DIR_OK`).

Updated `TestScriptPreamble_ZenMountParentChown` to assert the chown is recursive and guard against regressing to a shallow chown. `go build`, `go test ./...`, `golangci-lint run ./...` all clean.

## Test plan

- [x] Unit test asserts recursive `.config` chown + guards against shallow regression
- [x] Build/test/lint green
- [ ] End-to-end: Lyra container cook completes against published v0.7.2 (re-validation on EC2 in progress)