### PR TITLE
fix: derive packaged dir from .uproject name; robust HOME fallback for DDC

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Derive the packaged content directory name from the `.uproject` filename instead of `game.projectName`. UE names the staged content dir after the `.uproject` (e.g. `LyraStarterGame6/`), so container builds and the anywhere/ec2 deployers failed to find the server binary when `projectName` differed from the `.uproject` name. `projectName` is now only a default for target names.
+- `ludus ddc status` (and DDC path resolution generally) no longer errors with "resolving home directory" when `$HOME` is unset (e.g. under SSM Run Command / some CI). Falls back to the user database, then `/root` on \*nix.
+
+### Documentation
+- Clarified `game.projectPath` vs `game.projectName` vs `game.serverTarget` semantics in the README, `ludus.example.yaml`, and config docs: `projectPath` (the `.uproject`) is the source of truth for paths; `projectName` only defaults target names.
+
 ## [0.7.2] - 2026-06-23
 
 Completes the Zen DDC container fix so cooks can actually use the Zen Store.

--- a/README.md
+++ b/README.md
@@ -146,9 +146,9 @@ Edit `ludus.yaml` with your environment settings. Key fields:
 | `engine.dockerImage` | Pre-built engine Docker image URI (skips engine build) | (empty) |
 | `engine.dockerImageName` | Local Docker image name for engine builds | `ludus-engine` |
 | `engine.dockerBaseImage` | Base Docker image for engine builds | `ubuntu:22.04` |
-| `game.projectName` | UE5 project name | `Lyra` |
-| `game.projectPath` | Full path to the `.uproject` file — must include the filename, not just the directory (e.g. `/home/user/MyGame/MyGame.uproject`) | (empty = auto-detect Lyra) |
-| `game.serverTarget` | Server build target name — the binary name without "Target" suffix (e.g. `LyraServer`, not `LyraServerTarget`) | `<projectName>Server` |
+| `game.projectName` | Convenience label, used **only** to default the target names (`<projectName>Server`, etc.). Not used for packaged/container paths and need not match the `.uproject` filename. | `Lyra` |
+| `game.projectPath` | Full path to the `.uproject` file — must include the filename (e.g. `/home/user/MyGame/MyGame.uproject`). **Source of truth for paths:** UE names the packaged content dir after the `.uproject` filename, so staged/container paths derive from this, not from `projectName`. | (empty = auto-detect Lyra) |
+| `game.serverTarget` | Server build target name — the binary name without "Target" suffix (e.g. `LyraServer`, not `LyraServerTarget`). Set explicitly when it differs from `<projectName>Server`. | `<projectName>Server` |
 | `game.serverMap` | Default server map | `L_Expanse` |
 | `container.serverPort` | Game server UDP port | `7777` |
 | `game.arch` | Target architecture: `amd64` or `arm64` (Graviton) | `amd64` |

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -107,15 +107,16 @@ func runBuild(cmd *cobra.Command, args []string) error {
 	r := globals.NewRunner()
 
 	builder := ctrBuilder.NewBuilder(ctrBuilder.BuildOptions{
-		ServerBuildDir: serverBuildDir,
-		ImageName:      cfg.Container.ImageName,
-		Tag:            tag,
-		ServerPort:     cfg.Container.ServerPort,
-		NoCache:        noCache,
-		ProjectName:    cfg.Game.ProjectName,
-		ServerTarget:   cfg.Game.ResolvedServerTarget(),
-		Arch:           cfg.Game.ResolvedArch(),
-		Backend:        resolvedBackend,
+		ServerBuildDir:  serverBuildDir,
+		ImageName:       cfg.Container.ImageName,
+		Tag:             tag,
+		ServerPort:      cfg.Container.ServerPort,
+		NoCache:         noCache,
+		ProjectName:     cfg.Game.ProjectName,
+		PackagedDirName: cfg.Game.ResolvedPackagedDirName(),
+		ServerTarget:    cfg.Game.ResolvedServerTarget(),
+		Arch:            cfg.Game.ResolvedArch(),
+		Backend:         resolvedBackend,
 	}, r)
 
 	fmt.Println("Building container image...")

--- a/cmd/globals/resolve.go
+++ b/cmd/globals/resolve.go
@@ -146,17 +146,18 @@ func resolveAnywhere(ctx context.Context, cfg *config.Config) (deploy.Target, er
 	r := NewRunner()
 
 	deployer := anywhere.NewDeployer(anywhere.DeployOptions{
-		Region:         cfg.AWS.Region,
-		FleetName:      cfg.GameLift.FleetName,
-		LocationName:   cfg.Anywhere.LocationName,
-		IPAddress:      cfg.Anywhere.IPAddress,
-		ServerPort:     cfg.Container.ServerPort,
-		Tags:           tags.Build(cfg),
-		ServerBuildDir: serverBuildDir,
-		ProjectName:    cfg.Game.ProjectName,
-		ServerTarget:   cfg.Game.ResolvedServerTarget(),
-		ServerMap:      cfg.Game.ServerMap,
-		AWSProfile:     cfg.Anywhere.AWSProfile,
+		Region:          cfg.AWS.Region,
+		FleetName:       cfg.GameLift.FleetName,
+		LocationName:    cfg.Anywhere.LocationName,
+		IPAddress:       cfg.Anywhere.IPAddress,
+		ServerPort:      cfg.Container.ServerPort,
+		Tags:            tags.Build(cfg),
+		ServerBuildDir:  serverBuildDir,
+		ProjectName:     cfg.Game.ProjectName,
+		PackagedDirName: cfg.Game.ResolvedPackagedDirName(),
+		ServerTarget:    cfg.Game.ResolvedServerTarget(),
+		ServerMap:       cfg.Game.ServerMap,
+		AWSProfile:      cfg.Anywhere.AWSProfile,
 	}, awsCfg, r)
 
 	return anywhere.NewTargetAdapter(deployer), nil
@@ -178,16 +179,17 @@ func resolveEC2Fleet(ctx context.Context, cfg *config.Config) (deploy.Target, er
 	r := NewRunner()
 
 	deployer := ec2fleet.NewDeployer(ec2fleet.DeployOptions{
-		Region:       cfg.AWS.Region,
-		FleetName:    cfg.GameLift.FleetName,
-		InstanceType: cfg.GameLift.InstanceType,
-		ServerPort:   cfg.Container.ServerPort,
-		S3Bucket:     cfg.EC2Fleet.S3Bucket,
-		ProjectName:  cfg.Game.ProjectName,
-		ServerTarget: cfg.Game.ResolvedServerTarget(),
-		ServerMap:    cfg.Game.ServerMap,
-		Arch:         cfg.Game.ResolvedArch(),
-		Tags:         tags.Build(cfg),
+		Region:          cfg.AWS.Region,
+		FleetName:       cfg.GameLift.FleetName,
+		InstanceType:    cfg.GameLift.InstanceType,
+		ServerPort:      cfg.Container.ServerPort,
+		S3Bucket:        cfg.EC2Fleet.S3Bucket,
+		ProjectName:     cfg.Game.ProjectName,
+		PackagedDirName: cfg.Game.ResolvedPackagedDirName(),
+		ServerTarget:    cfg.Game.ResolvedServerTarget(),
+		ServerMap:       cfg.Game.ServerMap,
+		Arch:            cfg.Game.ResolvedArch(),
+		Tags:            tags.Build(cfg),
 	}, awsCfg, r)
 
 	return ec2fleet.NewTargetAdapter(deployer), nil

--- a/cmd/mcp/tools_container.go
+++ b/cmd/mcp/tools_container.go
@@ -58,15 +58,16 @@ func handleContainerBuild(ctx context.Context, _ *mcp.CallToolRequest, input con
 	serverBuildDir := config.ResolveServerBuildDir(&cfg)
 
 	b := container.NewBuilder(container.BuildOptions{
-		ServerBuildDir: serverBuildDir,
-		ImageName:      cfg.Container.ImageName,
-		Tag:            tag,
-		ServerPort:     cfg.Container.ServerPort,
-		NoCache:        input.NoCache,
-		ProjectName:    cfg.Game.ProjectName,
-		ServerTarget:   cfg.Game.ResolvedServerTarget(),
-		Arch:           cfg.Game.ResolvedArch(),
-		Backend:        globals.ResolveContainerBackend(input.Backend),
+		ServerBuildDir:  serverBuildDir,
+		ImageName:       cfg.Container.ImageName,
+		Tag:             tag,
+		ServerPort:      cfg.Container.ServerPort,
+		NoCache:         input.NoCache,
+		ProjectName:     cfg.Game.ProjectName,
+		PackagedDirName: cfg.Game.ResolvedPackagedDirName(),
+		ServerTarget:    cfg.Game.ResolvedServerTarget(),
+		Arch:            cfg.Game.ResolvedArch(),
+		Backend:         globals.ResolveContainerBackend(input.Backend),
 	}, r)
 
 	var result containerResult

--- a/internal/anywhere/deployer.go
+++ b/internal/anywhere/deployer.go
@@ -29,9 +29,21 @@ type DeployOptions struct {
 	Tags           map[string]string
 	ServerBuildDir string
 	ProjectName    string
-	ServerTarget   string
-	ServerMap      string
-	AWSProfile     string
+	// PackagedDirName is the packaged content directory name (the .uproject
+	// name, e.g. "LyraStarterGame6"). When empty, falls back to ProjectName.
+	PackagedDirName string
+	ServerTarget    string
+	ServerMap       string
+	AWSProfile      string
+}
+
+// packagedDirName returns the packaged content directory name, falling back to
+// ProjectName when not explicitly set.
+func (o DeployOptions) packagedDirName() string {
+	if o.PackagedDirName != "" {
+		return o.PackagedDirName
+	}
+	return o.ProjectName
 }
 
 // Deployer handles GameLift Anywhere fleet operations.
@@ -180,7 +192,7 @@ func serverBinaryPath(buildDir, projectName, serverTarget string) string {
 // GenerateWrapperConfig produces the config.yaml for the GameLift Game Server Wrapper
 // in Anywhere mode.
 func (d *Deployer) GenerateWrapperConfig(fleetARN, locationARN, wrapperBinary, ipAddress string) string {
-	serverBinary := serverBinaryPath(d.opts.ServerBuildDir, d.opts.ProjectName, d.opts.ServerTarget)
+	serverBinary := serverBinaryPath(d.opts.ServerBuildDir, d.opts.packagedDirName(), d.opts.ServerTarget)
 
 	return fmt.Sprintf(`log-config:
   wrapper-log-level: info

--- a/internal/anywhere/deployer_test.go
+++ b/internal/anywhere/deployer_test.go
@@ -75,6 +75,51 @@ func TestGenerateWrapperConfig(t *testing.T) {
 	}
 }
 
+func TestPackagedDirName(t *testing.T) {
+	tests := []struct {
+		name            string
+		projectName     string
+		packagedDirName string
+		want            string
+	}{
+		{"explicit packaged dir wins", "Lyra", "LyraStarterGame6", "LyraStarterGame6"},
+		{"fallback to project name", "Lyra", "", "Lyra"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := DeployOptions{ProjectName: tt.projectName, PackagedDirName: tt.packagedDirName}
+			if got := o.packagedDirName(); got != tt.want {
+				t.Errorf("packagedDirName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGenerateWrapperConfig_PackagedDirDiffersFromProject(t *testing.T) {
+	// The wrapper exec path must use the packaged content dir (the .uproject
+	// name), not ProjectName, when they differ.
+	d := &Deployer{
+		opts: DeployOptions{
+			ServerBuildDir:  "/opt/builds/LinuxServer",
+			ProjectName:     "Lyra",
+			PackagedDirName: "LyraStarterGame6",
+			ServerTarget:    "LyraServer",
+			ServerMap:       "L_Expanse",
+			ServerPort:      7777,
+			AWSProfile:      "default",
+		},
+	}
+	config := d.GenerateWrapperConfig("fleet-arn", "loc-arn", "/usr/local/bin/wrapper", "10.0.0.1")
+
+	want := serverBinaryPath("/opt/builds/LinuxServer", "LyraStarterGame6", "LyraServer")
+	if !strings.Contains(config, want) {
+		t.Errorf("wrapper config should reference packaged dir path %q\ngot:\n%s", want, config)
+	}
+	if strings.Contains(config, "/Lyra/Binaries") {
+		t.Errorf("wrapper config must not use ProjectName 'Lyra' for the content dir\ngot:\n%s", config)
+	}
+}
+
 func TestServerBinaryPath(t *testing.T) {
 	got := serverBinaryPath("/opt/builds/LinuxServer", "Lyra", "LyraServer")
 

--- a/internal/config/config_game.go
+++ b/internal/config/config_game.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // ResolveProjectPath fills in ProjectPath if empty by checking known locations.
@@ -18,6 +19,25 @@ func (g *GameConfig) ResolveProjectPath(engineSourcePath string) {
 			g.ProjectPath = candidate
 		}
 	}
+}
+
+// ResolvedPackagedDirName returns the name of the packaged content directory
+// that UE creates inside the staged build (e.g. .../LinuxServer/<dir>/Binaries).
+// Unreal names this directory after the .uproject filename, NOT after the build
+// target or any configured project name — so a project shipping
+// LyraStarterGame6.uproject with a LyraServer target packages content under
+// "LyraStarterGame6/". Derive it from ProjectPath when set; fall back to
+// ProjectName for in-engine projects (e.g. the Lyra sample) that have no
+// explicit projectPath.
+func (g *GameConfig) ResolvedPackagedDirName() string {
+	if g.ProjectPath != "" {
+		base := filepath.Base(g.ProjectPath)
+		return strings.TrimSuffix(base, filepath.Ext(base))
+	}
+	if g.ProjectName != "" {
+		return g.ProjectName
+	}
+	return "Lyra"
 }
 
 // ResolvedServerTarget returns the server target name, defaulting to ProjectName + "Server".

--- a/internal/config/config_game_test.go
+++ b/internal/config/config_game_test.go
@@ -29,6 +29,35 @@ func TestGameConfig_ResolvedServerTarget(t *testing.T) {
 	}
 }
 
+func TestGameConfig_ResolvedPackagedDirName(t *testing.T) {
+	tests := []struct {
+		name        string
+		projectPath string
+		projectName string
+		want        string
+	}{
+		// The packaged content dir is named after the .uproject filename, NOT
+		// projectName or the server target. This is the case that broke the
+		// container build: projectName=Lyra but the .uproject is LyraStarterGame6.
+		{"uproject basename wins over projectName", filepath.Join("/home/u/LyraStarterGame6", "LyraStarterGame6.uproject"), "Lyra", "LyraStarterGame6"},
+		{"differs from projectName", filepath.Join("/proj/MyGame", "MyGame.uproject"), "Other", "MyGame"},
+		{"matching names", filepath.Join("/x/Lyra", "Lyra.uproject"), "Lyra", "Lyra"},
+		// No projectPath (in-engine project): fall back to projectName.
+		{"fallback to projectName", "", "Lyra", "Lyra"},
+		{"fallback default", "", "", "Lyra"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			g := &GameConfig{ProjectPath: tt.projectPath, ProjectName: tt.projectName}
+			got := g.ResolvedPackagedDirName()
+			if got != tt.want {
+				t.Errorf("got %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestGameConfig_ResolvedClientTarget(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/internal/config/config_types.go
+++ b/internal/config/config_types.go
@@ -76,10 +76,20 @@ type EngineConfig struct {
 
 // GameConfig holds UE5 game project build settings.
 type GameConfig struct {
-	// ProjectPath is the path to the .uproject file.
-	// For Lyra, if empty, defaults to <engine>/Samples/Games/Lyra/Lyra.uproject.
+	// ProjectPath is the path to the .uproject file (e.g.
+	// ".../LyraStarterGame6/LyraStarterGame6.uproject"). This is the source of
+	// truth: Unreal names the packaged content directory after the .uproject
+	// filename, so the packaged/staged/container paths are derived from it — NOT
+	// from ProjectName. For Lyra, if empty, defaults to
+	// <engine>/Samples/Games/Lyra/Lyra.uproject.
 	ProjectPath string `yaml:"projectPath"`
-	// ProjectName is the name of the UE5 project (e.g. "Lyra", "MyGame").
+	// ProjectName is a convenience label used only to DEFAULT the build target
+	// names (serverTarget = ProjectName+"Server", etc.). It does NOT need to
+	// match the .uproject filename and is not used for any packaged path. For
+	// projects where the .uproject name, the project label, and the target name
+	// all differ (e.g. uproject "LyraStarterGame6", target "LyraServer"), set
+	// projectPath and serverTarget explicitly and ProjectName is irrelevant to
+	// path resolution.
 	ProjectName string `yaml:"projectName"`
 	// ContentSourcePath is the path to the downloaded game content that needs to
 	// be overlaid onto the engine source tree. For Lyra, this is the path to the

--- a/internal/container/builder.go
+++ b/internal/container/builder.go
@@ -29,8 +29,13 @@ type BuildOptions struct {
 	ServerPort int
 	// NoCache disables Docker build cache.
 	NoCache bool
-	// ProjectName is the UE5 project name (e.g. "Lyra").
+	// ProjectName is the UE5 project name (e.g. "Lyra"). Used only to default
+	// the server target name; it does NOT name the packaged content directory.
 	ProjectName string
+	// PackagedDirName is the name of the packaged content directory inside the
+	// staged build (UE names it after the .uproject filename, e.g.
+	// "LyraStarterGame6"). When empty, falls back to ProjectName.
+	PackagedDirName string
 	// ServerTarget is the server binary name (e.g. "LyraServer").
 	ServerTarget string
 	// Arch is the target CPU architecture: "amd64" or "arm64".
@@ -72,6 +77,16 @@ func (b *Builder) resolveProjectName() string {
 	return "Lyra"
 }
 
+// resolvePackagedDirName returns the packaged content directory name (the dir
+// UE creates inside the staged build, named after the .uproject filename, e.g.
+// "LyraStarterGame6"). Falls back to the project name when not explicitly set.
+func (b *Builder) resolvePackagedDirName() string {
+	if b.opts.PackagedDirName != "" {
+		return b.opts.PackagedDirName
+	}
+	return b.resolveProjectName()
+}
+
 // resolveCLI returns the container CLI binary name: "podman" if backend is podman, otherwise "docker".
 func (b *Builder) resolveCLI() string {
 	if b.opts.Backend == "podman" {
@@ -107,7 +122,7 @@ func (b *Builder) resolveServerBinaryName() string {
 	}
 	arch := b.resolveArch()
 	binPlatform := config.BinariesPlatformDir(arch)
-	binDir := filepath.Join(b.opts.ServerBuildDir, b.resolveProjectName(), "Binaries", binPlatform)
+	binDir := filepath.Join(b.opts.ServerBuildDir, b.resolvePackagedDirName(), "Binaries", binPlatform)
 	entries, err := os.ReadDir(binDir)
 	if err != nil {
 		return serverTarget
@@ -130,7 +145,10 @@ func (b *Builder) ensureWrapper(ctx context.Context) (string, error) {
 // GenerateWrapperConfig produces the config.yaml for the GameLift Game Server Wrapper.
 // The wrapper uses this to know how to launch the game server process.
 func (b *Builder) GenerateWrapperConfig() string {
-	projectName := b.resolveProjectName()
+	// The packaged content dir AND the project argument the server binary
+	// expects are both the .uproject name (e.g. "LyraStarterGame6"), per UE's
+	// generated <Target>.sh launcher — not the (possibly different) project name.
+	packagedDir := b.resolvePackagedDirName()
 	serverBinary := b.resolveServerBinaryName()
 	binDir := config.BinariesPlatformDir(b.resolveArch())
 
@@ -152,7 +170,7 @@ game-server-details:
     - arg: "-log"
       val: ""
       pos: 2
-`, b.opts.ServerPort, projectName, binDir, serverBinary, projectName)
+`, b.opts.ServerPort, packagedDir, binDir, serverBinary, packagedDir)
 }
 
 // copyFile copies a file from src to dst, preserving permissions.
@@ -199,7 +217,7 @@ func copyFile(src, dst string) (retErr error) {
 //
 // Based on the GameLift Containers Starter Kit pattern.
 func (b *Builder) GenerateDockerfile() string {
-	projectName := b.resolveProjectName()
+	packagedDir := b.resolvePackagedDirName()
 	serverBinary := b.resolveServerBinaryName()
 	binDir := config.BinariesPlatformDir(b.resolveArch())
 
@@ -235,7 +253,7 @@ WORKDIR /opt/server
 
 # Wrapper is PID 1 — handles GameLift SDK, launches game server as child process
 ENTRYPOINT ["./amazon-gamelift-servers-game-server-wrapper"]
-`, projectName, binDir, serverBinary, b.opts.ServerPort)
+`, packagedDir, binDir, serverBinary, b.opts.ServerPort)
 }
 
 // GenerateDockerignore creates a .dockerignore to exclude debug symbols

--- a/internal/container/builder_test.go
+++ b/internal/container/builder_test.go
@@ -89,12 +89,37 @@ func TestGenerateDockerfile(t *testing.T) {
 				"EXPOSE 9999/udp",
 			},
 		},
+		{
+			// Real-world case that broke the live build: the .uproject name
+			// (packaged content dir), the project name, and the server target
+			// are all different. The Dockerfile must chmod the binary under the
+			// PACKAGED DIR name, not ProjectName.
+			name: "packaged dir differs from project name and target",
+			opts: BuildOptions{
+				ServerPort:      7777,
+				ProjectName:     "Lyra",
+				PackagedDirName: "LyraStarterGame6",
+				ServerTarget:    "LyraServer",
+			},
+			wantContain: []string{
+				"LyraStarterGame6/Binaries/Linux/LyraServer",
+			},
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			b := NewBuilder(tt.opts, nil)
 			dockerfile := b.GenerateDockerfile()
+			// Guard: when a distinct packaged dir is set, the bare project name
+			// must NOT appear as a content-dir path segment.
+			if tt.opts.PackagedDirName != "" && tt.opts.PackagedDirName != tt.opts.ProjectName {
+				if strings.Contains(dockerfile, "/"+tt.opts.ProjectName+"/Binaries") ||
+					strings.Contains(dockerfile, " "+tt.opts.ProjectName+"/Binaries") {
+					t.Errorf("Dockerfile used ProjectName %q for content dir instead of PackagedDirName %q\ngot:\n%s",
+						tt.opts.ProjectName, tt.opts.PackagedDirName, dockerfile)
+				}
+			}
 
 			for _, want := range tt.wantContain {
 				if !strings.Contains(dockerfile, want) {
@@ -135,6 +160,22 @@ func TestGenerateWrapperConfig(t *testing.T) {
 				"gamePort: 8888",
 				"./FPS/Binaries/LinuxArm64/FPSServer",
 				"\"FPS\"",
+			},
+		},
+		{
+			// Wrapper config must use the packaged dir name for BOTH the exec
+			// path and the project argument passed to the server binary (UE's
+			// generated <Target>.sh passes the .uproject name, not ProjectName).
+			name: "packaged dir differs from project name",
+			opts: BuildOptions{
+				ServerPort:      7777,
+				ProjectName:     "Lyra",
+				PackagedDirName: "LyraStarterGame6",
+				ServerTarget:    "LyraServer",
+			},
+			wantContain: []string{
+				"./LyraStarterGame6/Binaries/Linux/LyraServer",
+				"arg: \"LyraStarterGame6\"",
 			},
 		},
 	}

--- a/internal/ddc/ddc.go
+++ b/internal/ddc/ddc.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io/fs"
 	"os"
+	"os/user"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -63,11 +65,30 @@ func EnvOverride(path string) string {
 // mounting a host directory here persists the cook DDC across --rm container runs.
 const ZenContainerPath = "/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data"
 
+// resolveHome returns the user's home directory. It prefers os.UserHomeDir()
+// ($HOME / %USERPROFILE%), but that fails when the environment is stripped of
+// HOME — which happens under SSM Run Command, some CI runners, and bare service
+// contexts. In that case it falls back to the os/user database, then to /root
+// for the common root-in-container case, so DDC path resolution doesn't hard-fail.
+func resolveHome() (string, error) {
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return home, nil
+	}
+	if u, err := user.Current(); err == nil && u.HomeDir != "" {
+		return u.HomeDir, nil
+	}
+	if runtime.GOOS != "windows" {
+		// Last-resort default for HOME-less *nix contexts (e.g. SSM as root).
+		return "/root", nil
+	}
+	return "", fmt.Errorf("resolving home directory: HOME is unset and no fallback is available; set HOME or configure ddc.zenPath/ddc.localPath explicitly")
+}
+
 // DefaultZenPath returns the default ZenStore host directory: ~/.ludus/zen
 func DefaultZenPath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := resolveHome()
 	if err != nil {
-		return "", fmt.Errorf("resolving home directory: %w", err)
+		return "", err
 	}
 	return filepath.Join(home, ".ludus", "zen"), nil
 }
@@ -85,9 +106,9 @@ func ResolveZenPath(override string) (string, error) {
 
 // DefaultPath returns the default DDC directory path: ~/.ludus/ddc
 func DefaultPath() (string, error) {
-	home, err := os.UserHomeDir()
+	home, err := resolveHome()
 	if err != nil {
-		return "", fmt.Errorf("resolving home directory: %w", err)
+		return "", err
 	}
 	return filepath.Join(home, ".ludus", "ddc"), nil
 }

--- a/internal/ddc/ddc_path_test.go
+++ b/internal/ddc/ddc_path_test.go
@@ -50,6 +50,44 @@ func TestDefaultPath(t *testing.T) {
 	}
 }
 
+func TestDefaultPath_HomeUnset(t *testing.T) {
+	// SSM Run Command / some CI contexts run with HOME stripped. DefaultPath must
+	// still resolve via a fallback rather than hard-failing.
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME-unset fallback is a *nix concern")
+	}
+	t.Setenv("HOME", "")
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath() with HOME unset should not error, got: %v", err)
+	}
+	if got == "" || !filepath.IsAbs(got) {
+		t.Errorf("DefaultPath() = %q, want a non-empty absolute path", got)
+	}
+	if filepath.Base(got) != "ddc" {
+		t.Errorf("DefaultPath() = %q, want it to end in .../ddc", got)
+	}
+}
+
+func TestDefaultZenPath_HomeUnset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("HOME-unset fallback is a *nix concern")
+	}
+	t.Setenv("HOME", "")
+
+	got, err := DefaultZenPath()
+	if err != nil {
+		t.Fatalf("DefaultZenPath() with HOME unset should not error, got: %v", err)
+	}
+	if got == "" || !filepath.IsAbs(got) {
+		t.Errorf("DefaultZenPath() = %q, want a non-empty absolute path", got)
+	}
+	if filepath.Base(got) != "zen" {
+		t.Errorf("DefaultZenPath() = %q, want it to end in .../zen", got)
+	}
+}
+
 func TestResolvePath_Override(t *testing.T) {
 	path := "/custom/ddc"
 	if runtime.GOOS == "windows" {

--- a/internal/ec2fleet/build.go
+++ b/internal/ec2fleet/build.go
@@ -59,7 +59,7 @@ func (d *Deployer) ZipAndUpload(ctx context.Context, serverBuildDir string) (buc
 func (d *Deployer) resolveServerBinaryPath(serverBuildDir, arch string) string {
 	binPlatform := config.BinariesPlatformDir(arch)
 	serverBinaryName := d.opts.ServerTarget
-	binDir := filepath.Join(serverBuildDir, d.opts.ProjectName, "Binaries", binPlatform)
+	binDir := filepath.Join(serverBuildDir, d.opts.packagedDirName(), "Binaries", binPlatform)
 	if entries, err := os.ReadDir(binDir); err == nil {
 		for _, e := range entries {
 			name := e.Name()
@@ -69,7 +69,7 @@ func (d *Deployer) resolveServerBinaryPath(serverBuildDir, arch string) string {
 			}
 		}
 	}
-	return fmt.Sprintf("./%s/Binaries/%s/%s", d.opts.ProjectName, binPlatform, serverBinaryName)
+	return fmt.Sprintf("./%s/Binaries/%s/%s", d.opts.packagedDirName(), binPlatform, serverBinaryName)
 }
 
 func (d *Deployer) uploadToS3(ctx context.Context, bucket, key, zipPath string) error {

--- a/internal/ec2fleet/deployer.go
+++ b/internal/ec2fleet/deployer.go
@@ -24,10 +24,22 @@ type DeployOptions struct {
 	ServerPort   int
 	S3Bucket     string // auto-create "ludus-builds-<account-id>" if empty
 	ProjectName  string
-	ServerTarget string
-	ServerMap    string
-	Arch         string // "amd64" (default) or "arm64"
-	Tags         map[string]string
+	// PackagedDirName is the packaged content directory name (the .uproject
+	// name, e.g. "LyraStarterGame6"). When empty, falls back to ProjectName.
+	PackagedDirName string
+	ServerTarget    string
+	ServerMap       string
+	Arch            string // "amd64" (default) or "arm64"
+	Tags            map[string]string
+}
+
+// packagedDirName returns the packaged content directory name, falling back to
+// ProjectName when not explicitly set.
+func (o DeployOptions) packagedDirName() string {
+	if o.PackagedDirName != "" {
+		return o.PackagedDirName
+	}
+	return o.ProjectName
 }
 
 // FleetStatus represents the current state of a GameLift EC2 fleet.

--- a/internal/ec2fleet/deployer_test.go
+++ b/internal/ec2fleet/deployer_test.go
@@ -1,0 +1,25 @@
+package ec2fleet
+
+import "testing"
+
+func TestPackagedDirName(t *testing.T) {
+	tests := []struct {
+		name            string
+		projectName     string
+		packagedDirName string
+		want            string
+	}{
+		// The packaged content dir is the .uproject name; ProjectName may differ.
+		{"explicit packaged dir wins", "Lyra", "LyraStarterGame6", "LyraStarterGame6"},
+		{"fallback to project name", "Lyra", "", "Lyra"},
+		{"both empty", "", "", ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			o := DeployOptions{ProjectName: tt.projectName, PackagedDirName: tt.packagedDirName}
+			if got := o.packagedDirName(); got != tt.want {
+				t.Errorf("packagedDirName() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/ludus.example.yaml
+++ b/ludus.example.yaml
@@ -21,13 +21,21 @@ engine:
   # dockerBaseImage: "ubuntu:22.04"
 
 game:
-  # Project name (used to derive target names and paths)
+  # projectName is ONLY a convenience label to default the target names below
+  # (serverTarget = <projectName>Server, etc.). It does NOT need to match your
+  # .uproject filename and is not used for packaged/container paths.
   projectName: "Lyra"
   # Path to the .uproject file — must include the filename, not just the directory.
   # Example: "/home/user/MyGame/MyGame.uproject"
-  # Leave empty to auto-detect for Lyra from the engine Samples/ directory.
+  # This is the source of truth for paths: Unreal names the packaged content
+  # directory after the .uproject filename (e.g. a LyraStarterGame6.uproject
+  # packages under "LyraStarterGame6/"), and ludus derives the staged/container
+  # paths from it — not from projectName. Set this for any non-Lyra project.
+  # Leave empty to auto-detect for the Lyra sample from the engine Samples/ dir.
   projectPath: ""
-  # Server build target name (default: <projectName>Server, e.g. "LyraServer")
+  # Server build target name (default: <projectName>Server, e.g. "LyraServer").
+  # Set this explicitly when your target name differs from <projectName>Server
+  # (common for real projects, e.g. uproject "LyraStarterGame6" + target "LyraServer").
   serverTarget: ""
   # Client build target name (default: <projectName>Game, e.g. "LyraGame")
   clientTarget: ""


### PR DESCRIPTION
Two fixes surfaced during the live Lyra (UE 5.7.4) container validation, plus documentation.

## 1. Packaged content dir derived from the `.uproject` name (not `projectName`)

UE names the staged content directory after the `.uproject` filename (e.g. `LyraStarterGame6/`), **not** after `game.projectName` or the build target. The container build and the anywhere/ec2 deployers derived that path from `projectName`, so a project whose `projectName` (`Lyra`) differed from its `.uproject` name (`LyraStarterGame6`) failed at:

```
chmod: cannot access '/opt/server/Lyra/Binaries/Linux/LyraServer': No such file or directory
```

**Fix:** add `GameConfig.ResolvedPackagedDirName()` (from the `.uproject` basename, falling back to `projectName` for in-engine projects like the Lyra sample) and thread a `PackagedDirName` option through the container builder, the anywhere deployer, and the ec2fleet deployer. `projectName` is now only a default for target names.

This was decided as the cleanest model: `projectPath` (the `.uproject`) is the source of truth for paths; `projectName` is just a label that defaults `serverTarget`/`clientTarget`/`gameTarget`. No required config change for existing users (the Lyra sample still works via fallback).

## 2. DDC path resolution no longer hard-fails when `$HOME` is unset

`DefaultPath`/`DefaultZenPath` called `os.UserHomeDir()`, which errors when `HOME` is stripped from the environment (SSM Run Command, some CI runners). That broke `ludus ddc status` and game builds in those contexts. Added `resolveHome()` with a fallback chain: `os.UserHomeDir()` → `os/user` database → `/root` on \*nix.

## 3. Documentation

Clarified `game.projectPath` vs `game.projectName` vs `game.serverTarget` in the README, `ludus.example.yaml`, and config struct comments.

## Tests

- `ResolvedPackagedDirName`: uproject-basename-wins, differs-from-projectName, matching, and fallback cases.
- Container Dockerfile + wrapper config: assert the packaged dir name is used (and `projectName` is NOT used as the content-dir segment) when they differ.
- Anywhere + ec2fleet `packagedDirName()` fallback; anywhere wrapper config with a differing packaged dir.
- DDC `DefaultPath`/`DefaultZenPath` with `HOME` unset (\*nix).
- `go build`, `go test ./...`, `golangci-lint run ./...` all clean.