### PR TITLE
Release v0.7.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.7.3] - 2026-06-23
+
+Fixes container/deploy path resolution for projects whose name differs from the `.uproject`, and DDC path resolution when `$HOME` is unset.
+
 ### Fixed
 - Derive the packaged content directory name from the `.uproject` filename instead of `game.projectName`. UE names the staged content dir after the `.uproject` (e.g. `LyraStarterGame6/`), so container builds and the anywhere/ec2 deployers failed to find the server binary when `projectName` differed from the `.uproject` name. `projectName` is now only a default for target names.
 - `ludus ddc status` (and DDC path resolution generally) no longer errors with "resolving home directory" when `$HOME` is unset (e.g. under SSM Run Command / some CI). Falls back to the user database, then `/root` on \*nix.
@@ -417,7 +421,8 @@ Initial public release.
 [0.1.4]: https://github.com/jpvelasco/ludus/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/jpvelasco/ludus/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/jpvelasco/ludus/releases/tag/v0.1.2
-[Unreleased]: https://github.com/jpvelasco/ludus/compare/v0.7.2...HEAD
+[Unreleased]: https://github.com/jpvelasco/ludus/compare/v0.7.3...HEAD
+[0.7.3]: https://github.com/jpvelasco/ludus/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/jpvelasco/ludus/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/jpvelasco/ludus/compare/v0.7.0...v0.7.1
 [0.7.0]: https://github.com/jpvelasco/ludus/compare/v0.6.0...v0.7.0


### PR DESCRIPTION
## [0.7.3] - 2026-06-23

Fixes container/deploy path resolution for projects whose name differs from the `.uproject`, and DDC path resolution when `$HOME` is unset.

### Fixed
- Derive the packaged content directory name from the `.uproject` filename instead of `game.projectName` (container builds + anywhere/ec2 deployers). `projectName` is now only a default for target names.
- `ludus ddc status` / DDC path resolution no longer errors when `$HOME` is unset (SSM / some CI); falls back to the user database, then `/root` on *nix.

### Documentation
- Clarified `game.projectPath` vs `game.projectName` vs `game.serverTarget` in README, `ludus.example.yaml`, and config docs.