### PR TITLE
feat: redesign 'deploy destroy' flags — safe default, --all-targets, --purge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed (breaking)
+- **`ludus deploy destroy` no longer deletes ECR repositories or S3 build buckets by default.** The default now removes only the active target's *ephemeral* resources (fleet, container group definition, IAM role, EC2 build + its S3 object) and preserves durable build artifacts. The old `--all` flag is removed and replaced by two independent flags: `--all-targets` (tear down every target type) and `--purge` (also delete durable artifacts — ECR repos + S3 build buckets, with a `[y/N]` confirmation unless `--yes`). The CLI and the `ludus_deploy_destroy` MCP tool now behave consistently. Previously the default `destroy` silently deleted the ECR repository for container targets, which could wipe expensive build images (#357).
+
 ## [0.7.3] - 2026-06-23
 
 Fixes container/deploy path resolution for projects whose name differs from the `.uproject`, and DDC path resolution when `$HOME` is unset.

--- a/README.md
+++ b/README.md
@@ -664,7 +664,33 @@ The `Project` tag is auto-derived from `game.projectName` if not explicitly set.
 - `ludus deploy stack` — declarative CloudFormation stack (atomic, with automatic rollback on failure)
 - `ludus deploy anywhere` — local development via GameLift Anywhere (see below)
 
-Use `ludus deploy destroy` to tear down all Ludus-managed resources. For `fleet`, resources are deleted in reverse order. For `stack`, the entire CloudFormation stack is deleted atomically. For `anywhere`, the server process is stopped and fleet/location resources are cleaned up.
+#### Tearing down: `ludus deploy destroy`
+
+By default, `ludus deploy destroy` is **scoped and safe** — it removes only the **ephemeral** resources for the active target and **preserves your durable build artifacts** (ECR repositories and S3 build buckets), which are expensive to recreate:
+
+- `fleet` — fleet, container group definition, IAM role (reverse order)
+- `stack` — the entire CloudFormation stack, atomically
+- `ec2` — fleet, GameLift build, the uploaded S3 build **object**, IAM role
+- `anywhere` — stops the server, deregisters compute, deletes fleet and location
+- `binary` — the output directory
+
+Two independent flags widen the scope:
+
+| Flag | Effect |
+| --- | --- |
+| `--all-targets` | Tear down **every** target type, not just the active one. Still preserves durable artifacts. |
+| `--purge` | **Also delete durable artifacts** — ECR repositories and S3 build buckets. Lists what will be deleted and prompts `[y/N]` first. |
+| `--yes` / `-y` | Skip the `--purge` confirmation prompt (for CI/automation). |
+
+```bash
+./ludus deploy destroy                              # active target's fleet/group/IAM — ECR/S3 kept
+./ludus deploy destroy --target anywhere            # a specific target
+./ludus deploy destroy --all-targets                # sweep every target, artifacts kept
+./ludus deploy destroy --purge                      # active target + ECR/S3 (prompts to confirm)
+./ludus deploy destroy --all-targets --purge --yes  # full wipe, no prompt
+```
+
+> **Note:** `--purge` is irreversible — it deletes ECR images (your built engine/server containers) and S3 build buckets. The default `destroy` never touches them, so iterating on fleets is safe.
 
 ### GameLift Anywhere (local development)
 
@@ -843,7 +869,7 @@ Add to `.vscode/mcp.json` in your workspace:
 | | `ludus_deploy_anywhere` | Deploy locally via GameLift Anywhere |
 | | `ludus_deploy_ec2` | Deploy via GameLift Managed EC2 (no Docker) |
 | | `ludus_deploy_session` | Create a game session, returns connection details |
-| | `ludus_deploy_destroy` | Tear down all deployed resources |
+| | `ludus_deploy_destroy` | Tear down the active target's ephemeral resources (durable ECR/S3 artifacts preserved). `all_targets` sweeps every target; `purge` also deletes durable artifacts |
 | Connect | `ludus_connect_info` | Get connection info for current session and client build |
 | BuildGraph | `ludus_buildgraph` | Generate BuildGraph XML for Horde/UET |
 | DDC | `ludus_ddc_status` | Show DDC mode, path, and cache size on disk |

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -24,7 +24,10 @@ var (
 	anywhereIP   string
 	ec2Arch      string
 	withSession  bool
-	destroyAll   bool
+	// destroy flags
+	destroyAllTgts bool // sweep ephemeral teardown across every target
+	destroyPurge   bool // also delete durable artifacts (ECR repos, S3 build buckets)
+	destroyYes     bool // skip the --purge confirmation prompt
 )
 
 // Cmd is the top-level deploy command group.

--- a/cmd/deploy/deploy_destroy.go
+++ b/cmd/deploy/deploy_destroy.go
@@ -1,8 +1,11 @@
 package deploy
 
 import (
+	"bufio"
 	"context"
 	"fmt"
+	"io"
+	"strings"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
@@ -15,61 +18,129 @@ import (
 
 var destroyCmd = &cobra.Command{
 	Use:   "destroy",
-	Short: "Tear down all deployed resources",
-	Long: `Destroys all resources created by Ludus for the active deployment target.
+	Short: "Tear down deployed resources for the active target",
+	Long: `Destroys the resources created by Ludus for the active deployment target.
 
-For GameLift: deletes fleet, container group definition, and IAM role.
-For stack: deletes the CloudFormation stack (all resources removed atomically).
-For binary: removes the output directory.
-For anywhere: stops server, deregisters compute, deletes fleet and location.
-For ec2: deletes fleet, build, S3 object, and IAM role.
+By default this is scoped and safe — it removes only the EPHEMERAL deployment
+resources and leaves your durable build artifacts (ECR repositories, S3 build
+buckets) intact:
+
+  GameLift: fleet, container group definition, IAM role
+  stack:    the CloudFormation stack (all resources removed atomically)
+  ec2:      fleet, GameLift build, the uploaded S3 build object, IAM role
+  anywhere: stops the server, deregisters compute, deletes fleet and location
+  binary:   the output directory
 
 Resources that don't exist are skipped gracefully.
 
-Use --all to destroy resources across all target types.`,
+Flags (two independent axes):
+  --all-targets   widen the teardown to every target type, not just the active one
+  --purge         ALSO delete durable artifacts (ECR repositories + S3 build
+                  buckets). Prompts for confirmation unless --yes is given.
+  --yes / -y      skip the --purge confirmation prompt (for CI/automation)
+
+Examples:
+  ludus deploy destroy                       # this target's fleet/group/IAM only
+  ludus deploy destroy --all-targets         # sweep every target, artifacts kept
+  ludus deploy destroy --purge               # this target + ECR/S3 (prompts)
+  ludus deploy destroy --all-targets --purge --yes  # full wipe, no prompt`,
 	RunE: runDestroy,
 }
 
 func init() {
-	destroyCmd.Flags().BoolVar(&destroyAll, "all", false, "destroy resources across all target types")
+	destroyCmd.Flags().BoolVar(&destroyAllTgts, "all-targets", false, "tear down every deploy target, not just the active one")
+	destroyCmd.Flags().BoolVar(&destroyPurge, "purge", false, "also delete durable artifacts (ECR repositories + S3 build buckets)")
+	destroyCmd.Flags().BoolVarP(&destroyYes, "yes", "y", false, "skip the --purge confirmation prompt")
 	Cmd.AddCommand(destroyCmd)
 }
 
-func runDestroy(cmd *cobra.Command, args []string) error {
-	if destroyAll {
-		return runDestroyAll(cmd)
-	}
-
-	target, err := resolveTarget(cmd)
-	if err != nil {
-		return err
-	}
-
-	fmt.Printf("Destroying %s resources...\n", target.Name())
-	if err := target.Destroy(cmd.Context()); err != nil {
-		return err
-	}
-
-	if target.Capabilities().NeedsContainerPush {
-		cfg := globals.Cfg.Clone()
-		if region != "" {
-			cfg.AWS.Region = region
-		}
-		cleanupECR(cmd.Context(), &cfg)
-	}
-
-	fmt.Printf("\nAll %s resources destroyed.\n", target.Name())
-	return nil
+// destroyScope is the resolved teardown plan: how wide (sweep) and how deep
+// (durable). It is pure data so runDestroy can stay a thin dispatcher.
+type destroyScope struct {
+	sweep   bool // tear down all targets, not just the active one
+	durable bool // also delete durable artifacts (ECR repos, S3 build buckets)
 }
 
-func runDestroyAll(cmd *cobra.Command) error {
+func resolveDestroyScope(allTargets, purge bool) destroyScope {
+	return destroyScope{sweep: allTargets, durable: purge}
+}
+
+func runDestroy(cmd *cobra.Command, args []string) error {
+	scope := resolveDestroyScope(destroyAllTgts, destroyPurge)
 	cfg := globals.Cfg.Clone()
 	if region != "" {
 		cfg.AWS.Region = region
 	}
 
-	destroyAllTargets(cmd.Context(), &cfg)
-	return cleanupSharedResources(cmd.Context(), &cfg)
+	if scope.durable && !confirmPurge(cmd.OutOrStdout(), cmd.InOrStdin(), purgeItems(&cfg), destroyYes) {
+		fmt.Fprintln(cmd.OutOrStdout(), "Aborted; no resources were deleted.")
+		return nil
+	}
+
+	if scope.sweep {
+		destroyAllTargets(cmd.Context(), &cfg)
+	} else if err := destroyActiveTarget(cmd); err != nil {
+		return err
+	}
+
+	if scope.durable {
+		return cleanupSharedResources(cmd.Context(), &cfg)
+	}
+	return nil
+}
+
+// destroyActiveTarget tears down only the ephemeral resources of the configured
+// target. Durable artifacts are never touched here (see --purge).
+func destroyActiveTarget(cmd *cobra.Command) error {
+	target, err := resolveTarget(cmd)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("Destroying %s resources...\n", target.Name())
+	if err := target.Destroy(cmd.Context()); err != nil {
+		return err
+	}
+	fmt.Printf("\n%s resources destroyed.\n", target.Name())
+	return nil
+}
+
+// purgeItems lists the durable artifacts that --purge would delete, for the
+// confirmation prompt.
+func purgeItems(cfg *config.Config) []string {
+	ecrRepo := cfg.AWS.ECRRepository
+	if ecrRepo == "" {
+		ecrRepo = "ludus-server"
+	}
+	return []string{
+		fmt.Sprintf("ECR repository: %s (and all images)", ecrRepo),
+		fmt.Sprintf("S3 build bucket: ludus-builds-%s", accountIDLabel(cfg.AWS.AccountID)),
+	}
+}
+
+func accountIDLabel(id string) string {
+	if id == "" {
+		return "<account-id>"
+	}
+	return id
+}
+
+// confirmPurge prints the durable items that will be deleted and reads a y/N
+// answer. Returns true when the user confirms or skip (--yes) is set.
+func confirmPurge(w io.Writer, in io.Reader, items []string, skip bool) bool {
+	fmt.Fprintln(w, "--purge will permanently delete these durable artifacts:")
+	for _, it := range items {
+		fmt.Fprintf(w, "  - %s\n", it)
+	}
+	if skip {
+		return true
+	}
+	fmt.Fprint(w, "Continue? [y/N]: ")
+	answer, err := bufio.NewReader(in).ReadString('\n')
+	if err != nil {
+		return false
+	}
+	answer = strings.ToLower(strings.TrimSpace(answer))
+	return answer == "y" || answer == "yes"
 }
 
 func destroyAllTargets(ctx context.Context, cfg *config.Config) {
@@ -113,17 +184,6 @@ func cleanupSharedResources(ctx context.Context, cfg *config.Config) error {
 	cleanupECRRepos(ctx, cleaner, cfg)
 	cleanupS3Bucket(ctx, cleaner, awsCfg, cfg)
 	return nil
-}
-
-func cleanupECR(ctx context.Context, cfg *config.Config) {
-	fmt.Println("\nCleaning up ECR repositories...")
-	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)
-	if err != nil {
-		fmt.Printf("  Warning: could not load AWS config for ECR cleanup: %v\n", err)
-		return
-	}
-	cleaner := cleanup.NewCleaner(awsCfg)
-	cleanupECRRepos(ctx, cleaner, cfg)
 }
 
 func cleanupECRRepos(ctx context.Context, cleaner *cleanup.Cleaner, cfg *config.Config) {

--- a/cmd/deploy/deploy_destroy_test.go
+++ b/cmd/deploy/deploy_destroy_test.go
@@ -1,0 +1,93 @@
+package deploy
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestResolveDestroyScope(t *testing.T) {
+	tests := []struct {
+		name        string
+		allTargets  bool
+		purge       bool
+		wantSweep   bool
+		wantDurable bool
+	}{
+		{"default: ephemeral, active target only", false, false, false, false},
+		{"all-targets: sweep, no durable", true, false, true, false},
+		{"purge: durable, active target only", false, true, false, true},
+		{"all-targets + purge: full wipe", true, true, true, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := resolveDestroyScope(tt.allTargets, tt.purge)
+			if got.sweep != tt.wantSweep || got.durable != tt.wantDurable {
+				t.Errorf("resolveDestroyScope(%v,%v) = {sweep:%v durable:%v}, want {sweep:%v durable:%v}",
+					tt.allTargets, tt.purge, got.sweep, got.durable, tt.wantSweep, tt.wantDurable)
+			}
+		})
+	}
+}
+
+func TestConfirmPurge(t *testing.T) {
+	items := []string{"ECR repository: lyra-server-x86 (and all images)"}
+
+	tests := []struct {
+		name  string
+		input string
+		skip  bool
+		want  bool
+	}{
+		{"skip via --yes (no prompt read)", "", true, true},
+		{"explicit y", "y\n", false, true},
+		{"explicit yes", "yes\n", false, true},
+		{"uppercase Y", "Y\n", false, true},
+		{"explicit n", "n\n", false, false},
+		{"empty defaults to no", "\n", false, false},
+		{"garbage is no", "maybe\n", false, false},
+		{"EOF is no", "", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var out bytes.Buffer
+			got := confirmPurge(&out, strings.NewReader(tt.input), items, tt.skip)
+			if got != tt.want {
+				t.Errorf("confirmPurge(input=%q, skip=%v) = %v, want %v", tt.input, tt.skip, got, tt.want)
+			}
+			// The destructive items must always be shown to the user, even when skipping.
+			if !strings.Contains(out.String(), items[0]) {
+				t.Errorf("confirmPurge should list the durable items; output:\n%s", out.String())
+			}
+		})
+	}
+}
+
+func TestPurgeItems(t *testing.T) {
+	t.Run("uses configured ECR repo and account", func(t *testing.T) {
+		cfg := &config.Config{}
+		cfg.AWS.ECRRepository = "lyra-server-x86"
+		cfg.AWS.AccountID = "575108928122"
+		items := purgeItems(cfg)
+		joined := strings.Join(items, "\n")
+		if !strings.Contains(joined, "lyra-server-x86") {
+			t.Errorf("purgeItems should name the ECR repo; got %v", items)
+		}
+		if !strings.Contains(joined, "ludus-builds-575108928122") {
+			t.Errorf("purgeItems should name the S3 build bucket; got %v", items)
+		}
+	})
+
+	t.Run("falls back when unset", func(t *testing.T) {
+		items := purgeItems(&config.Config{})
+		joined := strings.Join(items, "\n")
+		if !strings.Contains(joined, "ludus-server") {
+			t.Errorf("purgeItems should fall back to default ECR repo; got %v", items)
+		}
+		if !strings.Contains(joined, "<account-id>") {
+			t.Errorf("purgeItems should show an account-id placeholder when unset; got %v", items)
+		}
+	})
+}

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -58,8 +58,9 @@ type deployEC2Input struct {
 }
 
 type deployDestroyInput struct {
-	Target string `json:"target,omitempty" jsonschema:"Deployment target to destroy: gamelift, stack, binary, anywhere, or ec2"`
-	All    bool   `json:"all,omitempty" jsonschema:"Destroy all resources including ECR repositories and S3 buckets"`
+	Target     string `json:"target,omitempty" jsonschema:"Deployment target to destroy: gamelift, stack, binary, anywhere, or ec2"`
+	AllTargets bool   `json:"all_targets,omitempty" jsonschema:"Tear down every deploy target, not just the active/specified one. Still preserves durable artifacts unless purge is also set."`
+	Purge      bool   `json:"purge,omitempty" jsonschema:"Also delete durable build artifacts (ECR repositories and S3 build buckets). Irreversible; runs without a confirmation prompt in MCP, so set deliberately."`
 }
 
 type deployFleetResult struct {
@@ -163,7 +164,7 @@ func registerDeployTools(s *mcp.Server) {
 
 	mcp.AddTool(s, &mcp.Tool{
 		Name:        "ludus_deploy_destroy",
-		Description: "Tear down deployed resources. Destroys fleet, container group definition, and IAM role. Use all=true to also destroy ECR repositories and S3 buckets.",
+		Description: "Tear down deployed resources for the active target (fleet, container group definition, IAM role, EC2 build + its S3 object). Durable artifacts (ECR repositories, S3 build buckets) are preserved by default. Set all_targets=true to sweep every target; set purge=true to also delete the durable artifacts (irreversible).",
 	}, handleDeployDestroy)
 }
 
@@ -415,20 +416,10 @@ func handleDeploySession(ctx context.Context, _ *mcp.CallToolRequest, input depl
 
 func handleDeployDestroy(ctx context.Context, _ *mcp.CallToolRequest, input deployDestroyInput) (*mcp.CallToolResult, any, error) {
 	cfg := globals.Cfg
-
-	if input.All {
-		return handleDeployDestroyAll(ctx, cfg)
-	}
-
-	target, err := globals.ResolveTarget(ctx, cfg, input.Target)
-	if err != nil {
-		return toolError(fmt.Sprintf("could not resolve deploy target: %v", err))
-	}
-
 	var result deployDestroyResult
 
 	captured, err := withCapture(func() error {
-		return target.Destroy(ctx)
+		return runDestroyForMCP(ctx, cfg, input)
 	})
 	result.Output = mergeOutput(captured)
 
@@ -437,31 +428,32 @@ func handleDeployDestroy(ctx context.Context, _ *mcp.CallToolRequest, input depl
 		return resultErr(result)
 	}
 
-	// Clear fleet state
 	_ = state.ClearFleet()
-
 	result.Success = true
 	return resultOK(result)
 }
 
-func handleDeployDestroyAll(ctx context.Context, cfg *config.Config) (*mcp.CallToolResult, any, error) {
-	var result deployDestroyResult
-
-	captured, err := withCapture(func() error {
+// runDestroyForMCP mirrors the CLI destroy scoping: default tears down only the
+// active target's ephemeral resources; all_targets sweeps every target; purge
+// also deletes durable artifacts (ECR repos + S3 build buckets). MCP is
+// non-interactive, so purge runs without a confirmation prompt.
+func runDestroyForMCP(ctx context.Context, cfg *config.Config, input deployDestroyInput) error {
+	if input.AllTargets {
 		destroyAllTargets(ctx, cfg)
-		return cleanupSharedResources(ctx, cfg)
-	})
-	result.Output = mergeOutput(captured)
-
-	if err != nil {
-		result.Error = fmt.Sprintf("destroy all failed: %v", err)
-		return resultErr(result)
+	} else {
+		target, err := globals.ResolveTarget(ctx, cfg, input.Target)
+		if err != nil {
+			return fmt.Errorf("could not resolve deploy target: %w", err)
+		}
+		if err := target.Destroy(ctx); err != nil {
+			return err
+		}
 	}
 
-	_ = state.ClearFleet()
-
-	result.Success = true
-	return resultOK(result)
+	if input.Purge {
+		return cleanupSharedResources(ctx, cfg)
+	}
+	return nil
 }
 
 // destroyAllTargets attempts to destroy every known deploy target, continuing on errors.


### PR DESCRIPTION
## Summary

Fixes #357 (default `destroy` deletes ECR images) and removes the overloaded legacy `--all` flag.

Previously `ludus deploy destroy` (no flags) deleted the **ECR repository and all its images** for container targets — silently wiping expensive build artifacts during a routine fleet teardown. The `--all` flag also bundled two unrelated concerns (sweep-all-targets **and** delete-shared-artifacts), and the CLI default deleted ECR while the **MCP** default did not — inconsistent and unpredictable.

## New design

Two **orthogonal, explicit** axes; `--all` removed:

| Command | Scope |
| --- | --- |
| `ludus deploy destroy` | **Ephemeral only**, active target: fleet, container group def, IAM role, EC2 build + its S3 *object*. **ECR repos + S3 build buckets preserved.** |
| `--all-targets` | Widen the ephemeral teardown to every target type. |
| `--purge` | **Also** delete durable artifacts (ECR repos + S3 build buckets). Lists them and prompts `[y/N]` unless `--yes`. |
| `--yes`/`-y` | Skip the `--purge` confirmation. |

`--all-targets` = how wide, `--purge` = how deep — composable, neither implies the other. CLI and the `ludus_deploy_destroy` MCP tool now behave identically (MCP `purge` runs without a prompt since it's non-interactive).

The ephemeral/durable split already existed in the code: each target's `Destroy()` only removes ephemeral resources; `cleanupECRRepos`/`cleanupS3Bucket` handle the durable side. The fix routes the durable cleanup behind `--purge` only.

## Code quality

`runDestroy` is a thin dispatcher over a pure `resolveDestroyScope()`, with small single-purpose helpers (`destroyActiveTarget`, `confirmPurge`, `purgeItems`). Lizard: new functions avg **CCN ~3.2**, all well under the 8 threshold — no new Codacy/complexity warnings.

## Behavior verified

```
$ ludus deploy destroy --purge   # answered 'n'
--purge will permanently delete these durable artifacts:
  - ECR repository: lyra-server-x86 (and all images)
  - S3 build bucket: ludus-builds-<account>
Continue? [y/N]: Aborted; no resources were deleted.
```

## Test plan

- [x] `resolveDestroyScope` table test (default / all-targets / purge / both)
- [x] `confirmPurge` (y, yes, Y, n, empty→no, garbage→no, EOF→no, --yes skip; always lists items)
- [x] `purgeItems` (configured + fallback)
- [x] `go build`, `go test ./...`, `golangci-lint run ./...` clean
- [x] `git grep` confirms no `--all` / `destroyAll` flag references remain
- [x] `destroy --help` shows the new flags + examples; `--purge` prompt aborts on `n`

## Breaking change

`--all` is removed (pre-1.0). CHANGELOG documents the migration to `--all-targets` + `--purge`.