### PR TITLE
fix: clear issue backlog — prebuilt-image prereq, macOS RAM, ECR error, docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - **`ludus engine build --jobs 0` now actually auto-detects compile parallelism** from the host (CPU cores and RAM), instead of silently using a hardcoded `MAX_JOBS=4`. The flag's help has always advertised auto-detection; now it's real. Auto-detect uses `min(NumCPU, RAM_GB / 2)` so large build hosts use their cores while RAM still bounds parallelism to avoid OOM on memory-heavy UE translation units. An explicit `--jobs N` / `engine.maxJobs` is still honored as-is; detection falls back to the previous default of 4 when host resources can't be read (#350).
+- Container game builds against a **prebuilt engine image** (`engine.dockerImage`) no longer fail the "Engine Source" prerequisite. The build runs inside the image and doesn't read the host engine source tree, so that check is skipped when a prebuilt image is configured (#361).
+- Compile-job auto-detection now works on **macOS**, reading total RAM via `sysctl hw.memsize` instead of the Linux-only `/proc/meminfo` (which returned 0 on macOS, defeating detection) (#364).
+- `ludus container push` now returns an **actionable error** when the AWS identity lacks `ecr:CreateRepository` (e.g. `AmazonEC2ContainerRegistryPowerUser`), pointing to pre-creating the repository or granting the action, instead of a raw `AccessDenied` (#362).
+
+### Documentation
+- Documented the npm `allow-scripts` install warning as benign (the binary self-heals on first run) and how to silence it, in the npm package README (#358).
+- Noted that `ludus container push` auto-create needs `ecr:CreateRepository`, with guidance for least-privilege/CI roles (#362).
 
 ## [0.8.0] - 2026-06-23
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Epic does not include Lyra game assets in the GitHub source. The `Content/` fold
 
 - An AWS account with permissions for GameLift, ECR, IAM, and STS
 - Configure authentication: `aws configure sso` or set `AWS_PROFILE`
-- An ECR repository (Ludus will push container images here)
+- An ECR repository (Ludus will push container images here). `ludus container push` auto-creates the repository if it's missing, which needs the `ecr:CreateRepository` action (not included in `AmazonEC2ContainerRegistryPowerUser`). For least-privilege/CI roles that only push, pre-create the repository (`aws ecr create-repository --repository-name <repo>`) and grant push/pull only.
 
 ## Installation
 

--- a/cmd/game/game.go
+++ b/cmd/game/game.go
@@ -152,6 +152,10 @@ func resolvedBuildConfig() config.Config {
 func runBuild(cmd *cobra.Command, args []string) error {
 	cfg := resolvedBuildConfig()
 	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
+	// A prebuilt engine image (engine.dockerImage) is self-contained; the build
+	// runs inside it and does not read the host engine source tree, so skip the
+	// Engine Source prerequisite.
+	checker.PrebuiltImage = cfg.Engine.DockerImage != ""
 	if err := prereq.Validate(checker.CheckGameReady()); err != nil {
 		return err
 	}

--- a/internal/dockerbuild/jobs_darwin.go
+++ b/internal/dockerbuild/jobs_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package dockerbuild
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// totalRAMGB returns total physical memory in GB, or 0 if detection fails.
+// macOS has no /proc/meminfo, so read total physical memory via sysctl.
+func totalRAMGB() int {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "sysctl", "-n", "hw.memsize").Output()
+	if err != nil {
+		return 0
+	}
+	bytes, err := strconv.ParseUint(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil || bytes == 0 {
+		return 0
+	}
+	return int(bytes / (1024 * 1024 * 1024))
+}

--- a/internal/dockerbuild/jobs_linux.go
+++ b/internal/dockerbuild/jobs_linux.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package dockerbuild
 

--- a/internal/ecr/push.go
+++ b/internal/ecr/push.go
@@ -50,17 +50,35 @@ func Push(ctx context.Context, r *runner.Runner, localTag string, opts PushOptio
 func ensureECRRepository(ctx context.Context, r *runner.Runner, opts PushOptions) error {
 	if err := r.RunQuiet(ctx, "aws", "ecr", "describe-repositories",
 		"--repository-names", opts.ECRRepository,
-		"--region", opts.AWSRegion); err != nil {
-		fmt.Printf("  ECR repository %q not found, creating...\n", opts.ECRRepository)
-		if err := r.RunQuiet(ctx, "aws", "ecr", "create-repository",
-			"--repository-name", opts.ECRRepository,
-			"--region", opts.AWSRegion,
-			"--image-scanning-configuration", "scanOnPush=true",
-			"--tags", "Key=ManagedBy,Value=ludus"); err != nil {
-			return fmt.Errorf("creating ECR repository: %w", err)
+		"--region", opts.AWSRegion); err == nil {
+		return nil
+	}
+
+	fmt.Printf("  ECR repository %q not found, creating...\n", opts.ECRRepository)
+	if err := r.RunQuiet(ctx, "aws", "ecr", "create-repository",
+		"--repository-name", opts.ECRRepository,
+		"--region", opts.AWSRegion,
+		"--image-scanning-configuration", "scanOnPush=true",
+		"--tags", "Key=ManagedBy,Value=ludus"); err != nil {
+		// CreateRepository requires the ecr:CreateRepository action, which is not
+		// in AmazonEC2ContainerRegistryPowerUser. Callers with push/pull-only
+		// rights can still push to an existing repo — surface an actionable hint
+		// instead of a raw AccessDenied.
+		if isAccessDenied(err) {
+			return fmt.Errorf("cannot create ECR repository %q: the current AWS identity lacks ecr:CreateRepository. "+
+				"Either pre-create it (aws ecr create-repository --repository-name %s --region %s) "+
+				"or grant ecr:CreateRepository to the role, then re-run: %w",
+				opts.ECRRepository, opts.ECRRepository, opts.AWSRegion, err)
 		}
+		return fmt.Errorf("creating ECR repository: %w", err)
 	}
 	return nil
+}
+
+// isAccessDenied reports whether err looks like an AWS authorization failure.
+func isAccessDenied(err error) bool {
+	msg := err.Error()
+	return strings.Contains(msg, "AccessDenied") || strings.Contains(msg, "not authorized")
 }
 
 // authenticateECR retrieves an ECR auth token and logs Docker in.

--- a/internal/ecr/push_test.go
+++ b/internal/ecr/push_test.go
@@ -3,6 +3,7 @@ package ecr
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -108,5 +109,25 @@ func TestPush_DryRun(t *testing.T) {
 	}
 	if !strings.Contains(output, "docker push") {
 		t.Error("dry-run output should contain docker push command")
+	}
+}
+
+func TestIsAccessDenied(t *testing.T) {
+	tests := []struct {
+		name string
+		msg  string
+		want bool
+	}{
+		{"AccessDeniedException", "operation error ECR: CreateRepository, AccessDeniedException: ...", true},
+		{"not authorized", "User ... is not authorized to perform: ecr:CreateRepository", true},
+		{"unrelated error", "RepositoryAlreadyExists", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isAccessDenied(fmt.Errorf("%s", tt.msg)); got != tt.want {
+				t.Errorf("isAccessDenied(%q) = %v, want %v", tt.msg, got, tt.want)
+			}
+		})
 	}
 }

--- a/internal/game/jobs_darwin.go
+++ b/internal/game/jobs_darwin.go
@@ -1,0 +1,28 @@
+//go:build darwin
+
+package game
+
+import (
+	"context"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// totalRAMGB returns total physical memory in GB, or 0 if detection fails.
+// macOS has no /proc/meminfo, so read total physical memory via sysctl.
+func totalRAMGB() int {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "sysctl", "-n", "hw.memsize").Output()
+	if err != nil {
+		return 0
+	}
+	bytes, err := strconv.ParseUint(strings.TrimSpace(string(out)), 10, 64)
+	if err != nil || bytes == 0 {
+		return 0
+	}
+	return int(bytes / (1024 * 1024 * 1024))
+}

--- a/internal/game/jobs_linux.go
+++ b/internal/game/jobs_linux.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package game
 

--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -71,6 +71,11 @@ type Checker struct {
 	// Backend is the configured container backend ("docker", "podman", or "").
 	// When set, non-selected runtimes produce warnings instead of failures.
 	Backend string
+	// PrebuiltImage indicates a prebuilt engine container image is configured
+	// (engine.dockerImage). A container game build against a prebuilt image does
+	// not read the host engine source tree, so the Engine Source prerequisite is
+	// not applicable and is skipped.
+	PrebuiltImage bool
 }
 
 // NewChecker creates a new prerequisite checker.
@@ -132,8 +137,14 @@ func (c *Checker) CheckEngineReady() []CheckResult {
 	return []CheckResult{c.checkEngineSource()}
 }
 
-// CheckGameReady validates prerequisites for game build commands.
+// CheckGameReady validates prerequisites for game build commands. When a
+// prebuilt engine image is configured (engine.dockerImage), the build runs
+// inside that image and does not read the host engine source tree, so the
+// Engine Source check is skipped — only game content is validated.
 func (c *Checker) CheckGameReady() []CheckResult {
+	if c.PrebuiltImage {
+		return []CheckResult{c.checkGameContent()}
+	}
 	return []CheckResult{c.checkEngineSource(), c.checkGameContent()}
 }
 

--- a/internal/prereq/checker_stages_test.go
+++ b/internal/prereq/checker_stages_test.go
@@ -24,7 +24,27 @@ func TestCheckGameReady(t *testing.T) {
 	}
 	results := c.CheckGameReady()
 	if len(results) != 2 {
-		t.Fatalf("expected 2 checks, got %d", len(results))
+		t.Fatalf("expected 2 checks (engine source + game content), got %d", len(results))
+	}
+}
+
+func TestCheckGameReady_PrebuiltImageSkipsEngineSource(t *testing.T) {
+	// With a prebuilt engine image, the build runs inside the image and does not
+	// read the host engine source tree, so the Engine Source check is skipped —
+	// only game content is validated.
+	c := &Checker{
+		EngineSourcePath: "/nonexistent",
+		GameConfig:       &config.GameConfig{ProjectPath: "/some/MyGame.uproject"},
+		PrebuiltImage:    true,
+	}
+	results := c.CheckGameReady()
+	if len(results) != 1 {
+		t.Fatalf("expected 1 check (game content only) with prebuilt image, got %d", len(results))
+	}
+	for _, r := range results {
+		if r.Name == "Engine Source" {
+			t.Errorf("Engine Source check should be skipped when a prebuilt image is configured")
+		}
 	}
 }
 

--- a/npm/README.md
+++ b/npm/README.md
@@ -28,6 +28,20 @@ fetches the matching binary on first run instead — no extra steps. To manage t
 binary yourself (air-gapped setups), set `LUDUS_SKIP_AUTO_DOWNLOAD=1` and place
 the `ludus` binary under the package's `bin/` directory.
 
+### "allow-scripts" warning during install
+
+If npm's `allow-scripts` policy is enabled in your environment, you may see:
+
+```
+npm warn allow-scripts   ludus-cli@x.y.z (postinstall: node install.js)
+```
+
+This is **harmless** — the install still succeeds. `postinstall` is only the
+binary downloader, and `ludus` self-heals by fetching the binary on first run if
+the script was blocked. So you can ignore the warning and just run `ludus`. To
+silence it and let the download run at install time, allow-list the package with
+the command npm prints (e.g. `npm config set allow-scripts=ludus-cli --location=user`).
+
 ## What it does
 
 ```


### PR DESCRIPTION
Batch of small fixes closing the remaining open-issue backlog ahead of a release.

## Closes #361 — prebuilt-image game build prereq
Container game builds against a prebuilt engine image (`engine.dockerImage`) failed the "Engine Source" prerequisite even though the build runs inside the image and never reads the host engine source tree. Added `Checker.PrebuiltImage`; `CheckGameReady()` skips `checkEngineSource()` when it's set (game content is still validated). Wired in `cmd/game/game.go` from `engine.dockerImage != ""`.

## Closes #364 — macOS compile-job auto-detection
`totalRAMGB()` read `/proc/meminfo` under a `!windows` build tag, returning 0 on macOS and defeating the `--jobs` auto-detect added in #350. Split into `jobs_linux.go` (`/proc/meminfo`) and `jobs_darwin.go` (`sysctl hw.memsize`) for both `internal/dockerbuild` and `internal/game`. Cross-builds verified for linux/darwin/windows.

## Closes #362 — ECR CreateRepository permission
`ludus container push` auto-creates a missing ECR repo, which needs `ecr:CreateRepository` (absent from `AmazonEC2ContainerRegistryPowerUser`). On denial it now returns an actionable error (pre-create the repo, or grant the action) instead of a raw `AccessDenied`. Documented the required IAM action in the README.

## Closes #358 — npm allow-scripts warning
Documented in `npm/README.md` that the `allow-scripts` install warning is benign (binary self-heals on first run) and how to silence it.

## Also
- #346 verified resolved and closed separately — the Zen mount path was already correct (`.../Common/Zen/Data`) and DDC persistence was proven live (warm cook 92% hit rate, ~44% faster).

## Test plan
- [x] `TestCheckGameReady_PrebuiltImageSkipsEngineSource` (engine source skipped, content kept)
- [x] `TestIsAccessDenied` (AccessDenied / not-authorized / unrelated / empty)
- [x] existing `--jobs` auto-detect tests still pass with the linux/darwin split
- [x] cross-build linux + darwin + windows all clean
- [x] `go build`, `go test ./...`, `golangci-lint run ./...` clean