### PR TITLE
Release v0.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2026-06-23
+
+Build-host ergonomics and a batch of backlog fixes.
+
 ### Fixed
 - **`ludus engine build --jobs 0` now actually auto-detects compile parallelism** from the host (CPU cores and RAM), instead of silently using a hardcoded `MAX_JOBS=4`. The flag's help has always advertised auto-detection; now it's real. Auto-detect uses `min(NumCPU, RAM_GB / 2)` so large build hosts use their cores while RAM still bounds parallelism to avoid OOM on memory-heavy UE translation units. An explicit `--jobs N` / `engine.maxJobs` is still honored as-is; detection falls back to the previous default of 4 when host resources can't be read (#350).
 - Container game builds against a **prebuilt engine image** (`engine.dockerImage`) no longer fail the "Engine Source" prerequisite. The build runs inside the image and doesn't read the host engine source tree, so that check is skipped when a prebuilt image is configured (#361).
@@ -438,7 +442,8 @@ Initial public release.
 [0.1.4]: https://github.com/jpvelasco/ludus/compare/v0.1.3...v0.1.4
 [0.1.3]: https://github.com/jpvelasco/ludus/compare/v0.1.2...v0.1.3
 [0.1.2]: https://github.com/jpvelasco/ludus/releases/tag/v0.1.2
-[Unreleased]: https://github.com/jpvelasco/ludus/compare/v0.8.0...HEAD
+[Unreleased]: https://github.com/jpvelasco/ludus/compare/v0.8.1...HEAD
+[0.8.1]: https://github.com/jpvelasco/ludus/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/jpvelasco/ludus/compare/v0.7.3...v0.8.0
 [0.7.3]: https://github.com/jpvelasco/ludus/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/jpvelasco/ludus/compare/v0.7.1...v0.7.2


### PR DESCRIPTION
## [0.8.1] - 2026-06-23

Build-host ergonomics and a batch of backlog fixes.

### Fixed
- `ludus engine build --jobs 0` actually auto-detects parallelism from host CPU/RAM (was hardcoded to 4) (#350).
- Container game build against a prebuilt engine image no longer fails the Engine Source prerequisite (#361).
- Compile-job auto-detection works on macOS via `sysctl hw.memsize` (#364).
- `ludus container push` gives an actionable error when the role lacks `ecr:CreateRepository` (#362).

### Documentation
- npm `allow-scripts` install warning documented as benign (#358).
- Required IAM action for ECR auto-create documented (#362).