### PR TITLE
refactor: centralize AWS ECR URI and account/region resolution into awsenv (#367)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,160 +1,103 @@
-# Coding Guidelines
+# Ludus Development Guide
 
-For contributors and AI coding agents working in this repository.
-See also [ARCHITECTURE.md](ARCHITECTURE.md) for the high-level design and module map.
+This guide provides essential context for AI agents working with Ludus, a CLI tool that automates the end-to-end pipeline for deploying Unreal Engine 5 dedicated servers to AWS GameLift.
 
-## Build / Lint / Test
-
-Go `1.25.10` is required (see `go.mod`).
+## Build, Test & Lint
 
 ```bash
-# Build
-go build -o ludus -v .            # Linux/macOS
-go build -o ludus.exe -v .        # Windows
+# Build (Windows)
+go build -o ludus.exe -v .
+
+# Build (Linux/macOS)
+go build -o ludus -v .
 
 # Lint (golangci-lint v2 required)
 golangci-lint run ./...
 
-# Test
-go test ./...                          # All tests
-go test -race ./...                    # Race detector (Linux/macOS; requires CGO)
-go test -v ./internal/toolchain        # Single package
-go test -v -run TestParseBuildVersion ./internal/toolchain  # Single test
+# Test (all packages)
+go test ./...
 
-# Other
-go vet ./...                      # Static analysis
-go mod tidy                       # Clean up module dependencies
+# Test (single package)
+go test -v ./internal/toolchain
+
+# Test (single test)
+go test -v -run TestParseBuildVersion ./internal/toolchain
+
+# Static analysis
+go vet ./...
+
+# Module cleanup
+go mod tidy
+
+# Pre-commit hooks check
+.git/hooks/pre-commit
 ```
 
-Pre-commit hooks (`.hooks/pre-commit`) run build, lint, and test.
-Activate with `git config core.hooksPath .hooks`.
+## Key Project Structure
 
-CI runs build and tests on Linux, Windows, and macOS, plus lint on Linux and
-Windows. Linux tests also collect coverage; Linux and macOS tests use `-race`.
+- `main.go` → `cmd/root/root.go` → subcommand packages in `cmd/`
+- `cmd/globals/globals.go` — shared mutable state (`Cfg`, `Verbose`, `DryRun`, `JSONOutput`, `Profile`)
+- `cmd/mcp/` — MCP server with 26 tools for AI orchestration  
+- `internal/` — all business logic (unexported), one primary type per file
+- Platform-specific files: `_windows.go` / `_unix.go` with `//go:build` tags
 
-## Project Structure
+## Critical Features to Understand
 
-- `main.go` — Entry point; calls `root.Execute()`.
-- `cmd/` — Cobra command packages. Each exports `var Cmd = &cobra.Command{...}`,
-  registered in `cmd/root/root.go`. Handler functions are named `run<Command>`.
-  - `cmd/globals/` exports mutable global state (`Cfg`, `Verbose`, `JSONOutput`,
-    `DryRun`, `Profile`, `DDCMode`) and deployment target resolution
-    (`resolve.go`). It is not a command package. The `init` command lives in
-    `cmd/root/init.go`.
-  - `cmd/mcp/` — MCP server for AI agent orchestration (26 tools, stdio JSON-RPC).
-  - `cmd/resources/` — AWS resource inventory for resources managed by Ludus.
-- `internal/` — All business logic (unexported). One primary type per file.
-  See [ARCHITECTURE.md](ARCHITECTURE.md) for the full package layout.
-- Shared infrastructure includes `runner/` (subprocesses), `retry/` (network
-  retries), `awsutil/` (AWS config/errors/polling), `state/` and `cache/`
-  (persistent pipeline data), `inventory/` (AWS discovery), and `wsl/` (WSL2
-  detection, paths, commands, and source synchronization).
-- Config is loaded via Viper from `ludus.yaml`; `--profile <name>` prefers
-  `ludus-<name>.yaml` and isolates persisted state.
-- Platform-specific files use `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
+### Deployment & Build Backends
+- `--backend native` (default, builds on host)
+- `--backend docker` (builds engine container images, needs Docker)
+- `--backend podman` (Docker alternative, on Windows or Linux)
+- `--backend wsl2` (native Linux I/O on Windows)
 
-### Execution and External Services
+### Architecture Support
+- `--arch amd64` (default)
+- `--arch arm64` (Graviton instances for AWS)
+- Cross-compilation from Windows to Linux binaries
 
-- Run external processes through `runner.Runner`; do not call `exec.Command`
-  directly. This preserves `--verbose`, `--dry-run`, environment overrides,
-  output routing, and consistent error handling.
-- Use `internal/retry` for retryable Docker/AWS operations. Use
-  `retry.Default()` unless the operation needs explicit timing or attempt limits.
-- Use `awsutil.Poll` / `PollWithOptions` for AWS wait loops and
-  `awsutil.IsNotFound` / `IsConflict` for idempotent AWS error handling.
-- Deploy backends implement `deploy.Target`; session-capable targets also
-  implement `deploy.SessionManager`. Wire new targets through
-  `cmd/globals/resolve.go` and expose them consistently in CLI, MCP, and status.
+### DDC (Derived Data Cache) Modes
+- `--ddc zen` (default, persistent UE Zen Store cache) 
+- `--ddc local` (legacy FileSystem cache)
+- `--ddc none` (disabled)
 
-## Code Style
+## Development Environment
 
-### Formatting and Imports
+- Go 1.25.10 required (see `go.mod`)
+- Linux or Windows with Docker/Podman for container builds
+- AWS CLI v2 configured with credentials
+- UE5 source with Lyra game assets (must be downloaded manually)
+- 16+ GB RAM recommended (UE5 compilation is memory-hungry)
+- 300+ GB disk space for engine builds
 
-Enforced by `gofmt`. Two import groups separated by a blank line: (1) stdlib,
-(2) everything else (third-party and project imports together, sorted alphabetically).
+## Important Operational Details
 
-```go
-import (
-    "context"
-    "fmt"
+- Run external processes through `runner.Runner` (not raw `exec.Command`)
+- Use `internal/retry` for AWS/Docker operations (default retry strategy)
+- Use `awsutil.Poll` for AWS wait loops  
+- All CLI commands support `--verbose`, `--dry-run`, JSON output
+- Commands support `--profile` (creates `ludus-<name>.yaml`)
+- Config loaded from `ludus.yaml` via Viper (override via `--config`)
+- Build logs go to `.ludus/logs/` (project-local)
+- Cache in `.ludus/cache.json` (skip unchanged stages automatically)
+- State in `.ludus/state.json` (fleet IDs, ECR URIs, session data)
 
-    "github.com/jpvelasco/ludus/internal/runner"
-    "github.com/spf13/cobra"
-)
-```
+## Communication Model
 
-Aliases only to resolve naming conflicts. Common patterns: AWS type packages
-(`gltypes`, `cftypes`), cmd-vs-internal disambiguation (`engBuilder`, `gameBuilder`).
+Ludus uses the [Model Context Protocol](https://modelcontextprotocol.io/). 
+The MCP server is started with `ludus mcp` and exposes 26 tools for AI orchestration.
 
-### Naming
+## Command Execution Patterns
 
-- **Packages**: lowercase, single word. Multi-word concatenated (`dockerbuild`).
-- **Files**: `snake_case.go`. Build-tagged: `checker_unix.go`, `process_windows.go`.
-- **Acronyms**: Fully uppercase: `ID`, `URI`, `ARN`, `ECR`, `IAM`, `AWS`.
-- **Structs**: PascalCase nouns — `Builder`, `Deployer`, `TargetAdapter`.
-- **Options/Results**: `BuildOptions`, `BuildResult`, `DeployOptions`, `FleetStatus`.
-- **Constants**: Unexported camelCase (`iamRoleName`), exported PascalCase (`WrapperRepo`).
-- **Variables**: camelCase. Short for narrow scope (`r`, `b`, `cfg`, `ctx`),
-  descriptive for broader scope (`serverBuildDir`, `engineVersion`).
+- Commands produce output via `fmt.Printf` (status) and `fmt.Fprintln(os.Stderr)` (warnings)
+- All test commands expect the working directory to be the project root
+- Commands with long-running operations provide `*_start` variants for async operations 
+- Environment variables and CLI flags are merged with config precedence:
+  `config.yaml` → `--flag` → `mcp-parameter`
 
-### Constructors and Methods
+## Testing Constraints
 
-Constructors use `New*` and return a pointer:
-```go
-func NewBuilder(opts BuildOptions, r *runner.Runner) *Builder
-```
-
-Method receivers are single-letter pointer receivers matching the type initial:
-`b` for `*Builder`, `d` for `*Deployer`, `r` for `*Runner`.
-
-`context.Context` is the first parameter for all I/O or long-running methods.
-
-### Error Handling
-
-- Wrap with `fmt.Errorf("brief context: %w", err)`. Lowercase, no trailing punctuation.
-- No sentinel errors (`var Err*`) and no custom error types.
-- Non-fatal issues: `fmt.Printf("Warning: ...")`.
-- AWS errors: use `smithy.APIError` via `errors.As()` for structured error matching.
-
-### Output
-
-No logging library. All output via `fmt`:
-- `fmt.Println` / `fmt.Printf` for status; `fmt.Fprintln(os.Stderr, ...)` for warnings.
-- Stage messages indented 2 spaces. Verbose echoing via `runner.Runner` (`+ command`).
-- JSON output conditional on `globals.JSONOutput`.
-
-## Test Conventions
-
-- **stdlib only** — no testify or assertion libraries.
-- **Same-package tests** (access to unexported symbols).
-- **Table-driven tests** using anonymous struct slices. Loop variable is `tt`:
-  ```go
-  tests := []struct{ name string; input string; want int }{ ... }
-  for _, tt := range tests {
-      t.Run(tt.name, func(t *testing.T) { ... })
-  }
-  ```
-- **Assertions** via `if got != want` with `t.Errorf` / `t.Fatalf`.
-- **Temp dirs** via `t.TempDir()`, **env overrides** via `t.Setenv()`.
-- Use `t.Chdir()` for tests that depend on the working directory.
-- Test files co-located: `builder_test.go` alongside `builder.go`.
-
-## Lint Configuration
-
-`.golangci.yml` (v2 format). Enabled: errcheck, govet, ineffassign, staticcheck,
-unused, gocritic, misspell, unconvert, gosec, dupl.
-
-Key gosec exclusions: G104 (unhandled errors in cleanup), G204/G702 (subprocess
-with variable), G304/G703 (file inclusion via variable), G115 (integer overflow),
-G301/G306 (dir/file perms). ST1005 suppressed — error messages may start with
-proper nouns like `Setup.sh`.
-
-## UE Source Patches
-
-Ludus patches UE source files at init/build time. See [UE_SOURCE_PATCHES.md](UE_SOURCE_PATCHES.md)
-for full details on each patch and testing procedures.
-
-## Feature Work
-
-Approved feature designs and implementation plans are kept locally (not in the
-public repo). Check local copies before implementing non-trivial features.
+- All tests use Go standard library only
+- `t.TempDir()` for temporary directories  
+- `t.Setenv()` for environment variable overrides
+- `t.Chdir()` for working directory changes
+- All internal packages with tests (except deploy and version)
+- Unit test files co-located with source files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -107,6 +107,12 @@ Integration points (`internal/dockerbuild/game.go`): for `zen`, the host Zen dir
 
 `internal/wsl/` handles distro detection, path translation, and the source sync. Use `--wsl-distro` to override the auto-detected distro.
 
+### AWS Environment Resolution
+
+`internal/awsenv` centralizes AWS account-ID and region resolution and ECR URI construction. Use `awsenv.NewResolver(DryRun).Resolve(ctx, cfg, awsenv.Requirements{...})` to resolve account/region (auto-detects via STS/IMDS when not configured, respects dry-run). Use `awsenv.ImageURI(env, repo, tag)`, `awsenv.RepositoryURI(env, repo)`, or `awsenv.RegistryURI(env)` for ECR URIs — these validate that account ID and region are present. Never construct `dkr.ecr` strings directly in command code.
+
+Thin wrappers in `cmd/globals/aws.go` (`ResolveAWSAccountID`, `ResolveAWSRegion`) delegate to `awsenv` for backward compatibility; prefer calling `awsenv` directly for new code.
+
 ### AWS Polling
 
 `internal/awsutil/poll.go` provides a generic `Poll()` helper used across deployers for waiting on fleet activation, stack events, etc. Prefer it over hand-rolled polling loops when adding new AWS wait conditions.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,11 +69,11 @@ Network-facing operations (Docker, AWS) wrap calls with `internal/retry/`: expon
 
 ### DDC (Derived Data Cache)
 
-`internal/ddc/` manages UE5's Derived Data Cache — persistent shader/asset cache that survives Docker container lifecycles. Two modes: `local` (default, persists to `~/.ludus/ddc`) and `none` (disabled).
+`internal/ddc/` manages UE5's Derived Data Cache — persistent shader/asset cache that survives Docker container lifecycles. Three modes (`internal/ddc/ddc.go`): `zen` (default since v0.7.0 — the Unreal Zen Store, UE's default local backend since 5.4, applies to UE 5.4–5.7), `local` (legacy FileSystem cache, **deprecated** — delete-only in UE since 5.4; `doctor`/`ddc status`/config load warn and recommend `zen`), and `none` (disabled). `NormalizeMode` maps the empty string to `zen`.
 
-Integration points: `internal/dockerbuild/` mounts the host DDC directory as a Docker volume and passes `UE-LocalDataCachePath=<path>` as an env override to redirect UE5's local DDC backend (no ini patching needed — `BaseEngine.ini` already configures `EnvPathOverride=UE-LocalDataCachePath`).
+Integration points (`internal/dockerbuild/game.go`): for `zen`, the host Zen directory (`ddc.zenPath`, default `~/.ludus/zen`) is bind-mounted to the container's fixed ZenStore data path (`ddc.ZenContainerPath` = `/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data`); the game-build preamble recursively chowns `/home/ue/.config` so `zenserver` (running as `ue`) can write it. For legacy `local`, the host DDC dir is mounted at `/ddc` and passed via `UE-LocalDataCachePath`.
 
-`ludus ddc` subcommands: `status`, `clean`, `prune`, `warmup`. Config in `ludus.yaml` under `ddc.mode` / `ddc.localPath`, overridable via `--ddc` flag.
+`ludus ddc` subcommands: `status`, `clean`, `prune`, `warmup`. Config in `ludus.yaml` under `ddc.mode` / `ddc.zenPath` / `ddc.localPath`, overridable via `--ddc` flag.
 
 ### Build Observability
 
@@ -81,13 +81,15 @@ Integration points: `internal/dockerbuild/` mounts the host DDC directory as a D
 
 `internal/tracing/` adds optional OpenTelemetry (OTLP) trace export — one span per pipeline stage under a `ludus.run` root span, wired in `cmd/pipeline/executeStages`. No-op with zero overhead unless `observability.otlp.enabled` (or standard `OTEL_*` env vars) is set. Initialized in root `PersistentPreRunE`, flushed in `Execute()`.
 
+`internal/dflint/` lints Dockerfiles (hadolint) and scans the built image for vulnerabilities (trivy), surfaced via `ludus status`. Both tools degrade gracefully when not installed.
+
 ### BuildGraph
 
 `cmd/buildgraph/` generates UE5 BuildGraph XML describing engine and game build stages as a DAG. Used with Horde, UET, or other external orchestrators. Exposed as `ludus_buildgraph` MCP tool.
 
 ### MCP Server
 
-`cmd/mcp/` exposes 26 tools via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout). Long-running builds have async variants returning build IDs.
+`cmd/mcp/` exposes 25 tools via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout). Long-running builds have async variants returning build IDs.
 
 ### GameLift Wrapper
 
@@ -128,7 +130,7 @@ Full style guide in [AGENTS.md](AGENTS.md). Key points for quick reference:
 - **Errors**: `fmt.Errorf("context: %w", err)`. No sentinel errors, no custom types. AWS errors via `smithy.APIError` + `errors.As()`. `internal/diagnose/` matches error patterns to user-facing hints — add new patterns there rather than embedding hint strings in command code.
 - **Output**: `fmt.Println`/`fmt.Printf` for status. No logging library. JSON conditional on `globals.JSONOutput`. Human-readable stdout is filtered through `internal/output` (account-ID masking) when `privacy.maskAccountId` is on and `--show-account-id` is not set — installed once in root `PersistentPreRunE`, skipped for `--json` and `mcp`. Mask new sensitive identifiers by adding a pattern to `internal/output/sanitize.go`, not at call sites.
 - **Shell execution**: Always through `runner.Runner`, never raw `exec.Command`.
-- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. 32/36 internal packages have tests. AWS-heavy packages (ec2fleet) and interface-only packages (deploy, version) rely on E2E or integration coverage.
+- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. 34/37 internal packages have tests. AWS-heavy packages (ec2fleet) and interface-only packages (deploy, version) rely on E2E or integration coverage.
 - **Platform code**: `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
 - **Imports**: Two groups separated by a blank line — stdlib first, then third-party and project imports together (alphabetically sorted). Aliases only to resolve conflicts (e.g. `gltypes`, `cftypes`).
 - **Naming**: Acronyms fully uppercase (`ID`, `URI`, `ARN`, `ECR`). Constructors `New*` returning a pointer. Single-letter pointer receivers matching type initial (`b *Builder`, `d *Deployer`). `context.Context` is the first parameter for all I/O or long-running methods.

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -159,7 +159,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 		ServerPort: cfg.Container.ServerPort,
 	}, r)
 
-	accountID, err := globals.ResolveAWSAccountID(cmd.Context(), cfg.AWS.AccountID)
+	accountID, err := globals.ResolveAWSAccountID(cmd.Context(), cfg.AWS.AccountID, cfg.AWS.Region)
 	if err != nil {
 		return err
 	}

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -163,7 +163,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	awsRegion, err := globals.ResolveAWSRegion(cfg.AWS.Region)
+	awsRegion, err := globals.ResolveAWSRegion(cmd.Context(), cfg.AWS.Region)
 	if err != nil {
 		return err
 	}

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
-	"github.com/jpvelasco/ludus/internal/awsutil"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/deploy"
 	"github.com/jpvelasco/ludus/internal/gamelift"
 	"github.com/jpvelasco/ludus/internal/prereq"
@@ -65,11 +65,10 @@ func init() {
 // makeDeployer creates a GameLift deployer with flag overrides applied.
 // Used by GameLift-specific commands (fleet, session) that need direct Deployer access.
 func makeDeployer(cmd *cobra.Command) (*gamelift.Deployer, error) {
-	cfg := globals.Cfg
+	cfg := globals.Cfg.Clone()
 
-	r := region
-	if r == "" {
-		r = cfg.AWS.Region
+	if region != "" {
+		cfg.AWS.Region = region
 	}
 	it := instanceType
 	if it == "" {
@@ -86,23 +85,24 @@ func makeDeployer(cmd *cobra.Command) (*gamelift.Deployer, error) {
 		it = resolved
 	}
 
-	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		cfg.AWS.AccountID, r, cfg.AWS.ECRRepository, cfg.Container.Tag)
-
-	awsCfg, err := awsutil.LoadAWSConfig(cmd.Context(), r)
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(cmd.Context(), &cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
-		return nil, fmt.Errorf("loading AWS config: %w", err)
+		return nil, err
+	}
+	imageURI, err := awsenv.ImageURI(env, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	if err != nil {
+		return nil, err
 	}
 
 	return gamelift.NewDeployer(gamelift.DeployOptions{
-		Region:             r,
+		Region:             env.Region,
 		ImageURI:           imageURI,
 		FleetName:          fn,
 		InstanceType:       it,
 		ContainerGroupName: cfg.GameLift.ContainerGroupName,
 		ServerPort:         cfg.Container.ServerPort,
-		Tags:               tags.Build(cfg),
-	}, awsCfg), nil
+		Tags:               tags.Build(&cfg),
+	}, env.AWSConfig), nil
 }
 
 // resolveTarget resolves a deploy.Target, applying --target flag override and

--- a/cmd/deploy/deploy_destroy.go
+++ b/cmd/deploy/deploy_destroy.go
@@ -213,6 +213,9 @@ func resolveAccountID(ctx context.Context, awsCfg aws.Config, configured string)
 		return configured
 	}
 	stsClient := sts.NewFromConfig(awsCfg)
-	id, _ := awsenv.AccountID(ctx, stsClient)
+	id, err := awsenv.AccountID(ctx, stsClient)
+	if err != nil {
+		fmt.Printf("  Warning: could not resolve account ID: %v\n", err)
+	}
 	return id
 }

--- a/cmd/deploy/deploy_destroy.go
+++ b/cmd/deploy/deploy_destroy.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/awsutil"
 	"github.com/jpvelasco/ludus/internal/cleanup"
 	"github.com/jpvelasco/ludus/internal/config"
@@ -212,9 +213,6 @@ func resolveAccountID(ctx context.Context, awsCfg aws.Config, configured string)
 		return configured
 	}
 	stsClient := sts.NewFromConfig(awsCfg)
-	identity, err := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-	if err != nil {
-		return ""
-	}
-	return aws.ToString(identity.Account)
+	id, _ := awsenv.AccountID(ctx, stsClient)
+	return id
 }

--- a/cmd/deploy/deploy_stack.go
+++ b/cmd/deploy/deploy_stack.go
@@ -37,7 +37,7 @@ func init() {
 	Cmd.AddCommand(stackCmd)
 }
 
-func applyStackFlags(cfg *config.Config) (imageURI, sn, fn string) {
+func applyStackFlags(cfg *config.Config) (imageURI, sn, fn string, err error) {
 	if region != "" {
 		cfg.AWS.Region = region
 	}
@@ -63,13 +63,13 @@ func applyStackFlags(cfg *config.Config) (imageURI, sn, fn string) {
 
 	env, err := awsenv.NewResolver(globals.DryRun).Resolve(context.Background(), cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
-		return "", "", ""
+		return "", "", "", err
 	}
 	imageURI, err = awsenv.ImageURI(env, cfg.AWS.ECRRepository, cfg.Container.Tag)
 	if err != nil {
-		return "", "", ""
+		return "", "", "", err
 	}
-	return imageURI, sn, fn
+	return imageURI, sn, fn, nil
 }
 
 func saveStackState(result *stack.StackResult) {
@@ -94,7 +94,10 @@ func saveStackState(result *stack.StackResult) {
 
 func runStack(cmd *cobra.Command, args []string) error {
 	cfg := globals.Cfg.Clone()
-	imageURI, sn, fn := applyStackFlags(&cfg)
+	imageURI, sn, fn, err := applyStackFlags(&cfg)
+	if err != nil {
+		return err
+	}
 
 	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
 	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {

--- a/cmd/deploy/deploy_stack.go
+++ b/cmd/deploy/deploy_stack.go
@@ -37,7 +37,7 @@ func init() {
 	Cmd.AddCommand(stackCmd)
 }
 
-func applyStackFlags(cfg *config.Config) (imageURI, sn, fn string, err error) {
+func applyStackFlags(ctx context.Context, cfg *config.Config) (env awsenv.Env, imageURI, sn, fn string, err error) {
 	if region != "" {
 		cfg.AWS.Region = region
 	}
@@ -61,15 +61,15 @@ func applyStackFlags(cfg *config.Config) (imageURI, sn, fn string, err error) {
 		sn = fmt.Sprintf("ludus-%s", fn)
 	}
 
-	env, err := awsenv.NewResolver(globals.DryRun).Resolve(context.Background(), cfg, awsenv.Requirements{Account: true, Region: true})
+	env, err = awsenv.NewResolver(globals.DryRun).Resolve(ctx, cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
-		return "", "", "", err
+		return awsenv.Env{}, "", "", "", err
 	}
 	imageURI, err = awsenv.ImageURI(env, cfg.AWS.ECRRepository, cfg.Container.Tag)
 	if err != nil {
-		return "", "", "", err
+		return awsenv.Env{}, "", "", "", err
 	}
-	return imageURI, sn, fn, nil
+	return env, imageURI, sn, fn, nil
 }
 
 func saveStackState(result *stack.StackResult) {
@@ -94,7 +94,7 @@ func saveStackState(result *stack.StackResult) {
 
 func runStack(cmd *cobra.Command, args []string) error {
 	cfg := globals.Cfg.Clone()
-	imageURI, sn, fn, err := applyStackFlags(&cfg)
+	env, imageURI, sn, fn, err := applyStackFlags(cmd.Context(), &cfg)
 	if err != nil {
 		return err
 	}
@@ -104,11 +104,6 @@ func runStack(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	printPricingHints(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch())
-
-	env, err := awsenv.NewResolver(globals.DryRun).Resolve(cmd.Context(), &cfg, awsenv.Requirements{Account: true, Region: true})
-	if err != nil {
-		return err
-	}
 
 	start := time.Now()
 	deployer := stack.NewStackDeployer(stack.StackOptions{

--- a/cmd/deploy/deploy_stack.go
+++ b/cmd/deploy/deploy_stack.go
@@ -1,11 +1,12 @@
 package deploy
 
 import (
+	"context"
 	"fmt"
 	"time"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
-	"github.com/jpvelasco/ludus/internal/awsutil"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/diagnose"
 	"github.com/jpvelasco/ludus/internal/prereq"
@@ -60,9 +61,14 @@ func applyStackFlags(cfg *config.Config) (imageURI, sn, fn string) {
 		sn = fmt.Sprintf("ludus-%s", fn)
 	}
 
-	r := cfg.AWS.Region
-	imageURI = fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		cfg.AWS.AccountID, r, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(context.Background(), cfg, awsenv.Requirements{Account: true, Region: true})
+	if err != nil {
+		return "", "", ""
+	}
+	imageURI, err = awsenv.ImageURI(env, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	if err != nil {
+		return "", "", ""
+	}
 	return imageURI, sn, fn
 }
 
@@ -96,15 +102,15 @@ func runStack(cmd *cobra.Command, args []string) error {
 	}
 	printPricingHints(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch())
 
-	awsCfg, err := awsutil.LoadAWSConfig(cmd.Context(), cfg.AWS.Region)
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(cmd.Context(), &cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
-		return fmt.Errorf("loading AWS config: %w", err)
+		return err
 	}
 
 	start := time.Now()
 	deployer := stack.NewStackDeployer(stack.StackOptions{
 		StackName:          sn,
-		Region:             cfg.AWS.Region,
+		Region:             env.Region,
 		ImageURI:           imageURI,
 		FleetName:          fn,
 		InstanceType:       cfg.GameLift.InstanceType,
@@ -112,7 +118,7 @@ func runStack(cmd *cobra.Command, args []string) error {
 		ServerPort:         cfg.Container.ServerPort,
 		ServerSDKVersion:   "5.4.0",
 		Tags:               tags.Build(&cfg),
-	}, awsCfg)
+	}, env.AWSConfig)
 
 	result, err := deployer.Deploy(cmd.Context())
 	if err != nil {

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -2,12 +2,52 @@ package deploy
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/prereq"
 )
+
+func TestApplyStackFlagsErrorPaths(t *testing.T) {
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+
+	prev := globals.DryRun
+	globals.DryRun = true
+	defer func() { globals.DryRun = prev }()
+
+	t.Run("empty ECR repository returns error", func(t *testing.T) {
+		globals.Cfg = &config.Config{
+			AWS:       config.AWSConfig{Region: "us-east-1", AccountID: "123456789012"},
+			Container: config.ContainerConfig{Tag: "latest"},
+		}
+		cfg := globals.Cfg.Clone()
+		_, _, _, _, err := applyStackFlags(context.Background(), &cfg)
+		if err == nil {
+			t.Fatal("expected error for empty ECR repository")
+		}
+		if !strings.Contains(err.Error(), "repository") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+
+	t.Run("empty image tag returns error", func(t *testing.T) {
+		globals.Cfg = &config.Config{
+			AWS:       config.AWSConfig{Region: "us-east-1", AccountID: "123456789012", ECRRepository: "ludus"},
+			Container: config.ContainerConfig{},
+		}
+		cfg := globals.Cfg.Clone()
+		_, _, _, _, err := applyStackFlags(context.Background(), &cfg)
+		if err == nil {
+			t.Fatal("expected error for empty image tag")
+		}
+		if !strings.Contains(err.Error(), "tag") {
+			t.Errorf("unexpected error: %v", err)
+		}
+	})
+}
 
 func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 	origCfg := globals.Cfg

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -13,9 +13,9 @@ func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 	t.Cleanup(func() { globals.Cfg = origCfg })
 
 	globals.Cfg = &config.Config{
-		AWS:      config.AWSConfig{Region: "us-east-1", AccountID: "123456789012", ECRRepository: "ludus"},
-		GameLift: config.GameLiftConfig{InstanceType: "c6i.large", FleetName: "original"},
-		Game:     config.GameConfig{Arch: "amd64"},
+		AWS:       config.AWSConfig{Region: "us-east-1", AccountID: "123456789012", ECRRepository: "ludus"},
+		GameLift:  config.GameLiftConfig{InstanceType: "c6i.large", FleetName: "original"},
+		Game:      config.GameConfig{Arch: "amd64"},
 		Container: config.ContainerConfig{Tag: "latest"},
 		Anywhere:  config.AnywhereConfig{IPAddress: "10.0.0.1"},
 	}

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -13,10 +13,11 @@ func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 	t.Cleanup(func() { globals.Cfg = origCfg })
 
 	globals.Cfg = &config.Config{
-		AWS:      config.AWSConfig{Region: "us-east-1"},
+		AWS:      config.AWSConfig{Region: "us-east-1", AccountID: "123456789012", ECRRepository: "ludus"},
 		GameLift: config.GameLiftConfig{InstanceType: "c6i.large", FleetName: "original"},
 		Game:     config.GameConfig{Arch: "amd64"},
-		Anywhere: config.AnywhereConfig{IPAddress: "10.0.0.1"},
+		Container: config.ContainerConfig{Tag: "latest"},
+		Anywhere:  config.AnywhereConfig{IPAddress: "10.0.0.1"},
 	}
 
 	t.Run("applyEC2Flags isolates mutations", func(t *testing.T) {
@@ -68,11 +69,18 @@ func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 		origRegion, origInstance := region, instanceType
 		t.Cleanup(func() { region, instanceType = origRegion, origInstance })
 
+		prev := globals.DryRun
+		globals.DryRun = true
+		defer func() { globals.DryRun = prev }()
+
 		region = "us-west-2"
 		instanceType = "m5.xlarge"
 
 		cfg := globals.Cfg.Clone()
-		applyStackFlags(&cfg)
+		_, _, _, err := applyStackFlags(&cfg)
+		if err != nil {
+			t.Fatalf("applyStackFlags failed: %v", err)
+		}
 
 		if cfg.AWS.Region != "us-west-2" {
 			t.Errorf("local Region = %q, want %q", cfg.AWS.Region, "us-west-2")

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"context"
 	"testing"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
@@ -77,7 +78,7 @@ func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 		instanceType = "m5.xlarge"
 
 		cfg := globals.Cfg.Clone()
-		_, _, _, err := applyStackFlags(&cfg)
+		_, _, _, _, err := applyStackFlags(context.Background(), &cfg)
 		if err != nil {
 			t.Fatalf("applyStackFlags failed: %v", err)
 		}

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -323,7 +323,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 		repoName = "ludus-engine"
 	}
 
-	accountID, err := globals.ResolveAWSAccountID(cmd.Context(), cfg.AWS.AccountID)
+	accountID, err := globals.ResolveAWSAccountID(cmd.Context(), cfg.AWS.AccountID, cfg.AWS.Region)
 	if err != nil {
 		return err
 	}

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -327,7 +327,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
-	awsRegion, err := globals.ResolveAWSRegion(cfg.AWS.Region)
+	awsRegion, err := globals.ResolveAWSRegion(cmd.Context(), cfg.AWS.Region)
 	if err != nil {
 		return err
 	}

--- a/cmd/globals/aws.go
+++ b/cmd/globals/aws.go
@@ -20,8 +20,8 @@ func ResolveAWSAccountID(ctx context.Context, accountID, region string) (string,
 
 // ResolveAWSRegion returns the region from the given value, or resolves it via
 // the AWS SDK chain / IMDS when empty. Delegates to internal/awsenv.
-func ResolveAWSRegion(region string) (string, error) {
+func ResolveAWSRegion(ctx context.Context, region string) (string, error) {
 	cfg := &config.Config{}
 	cfg.AWS.Region = region
-	return awsenv.NewResolver(DryRun).ResolveRegion(context.Background(), cfg)
+	return awsenv.NewResolver(DryRun).ResolveRegion(ctx, cfg)
 }

--- a/cmd/globals/aws.go
+++ b/cmd/globals/aws.go
@@ -2,51 +2,23 @@ package globals
 
 import (
 	"context"
-	"encoding/json"
-	"fmt"
-	"os"
-	"os/exec"
-	"strings"
+
+	"github.com/jpvelasco/ludus/internal/awsenv"
+	"github.com/jpvelasco/ludus/internal/config"
 )
 
-// dryRunAccountID is the placeholder account ID returned under --dry-run so the
-// command can print a representative ECR URI without invoking AWS.
-const dryRunAccountID = "000000000000"
-
-// ResolveAWSAccountID returns the AWS account ID from cfg, or auto-detects it
-// via aws sts get-caller-identity if the config value is empty.
+// ResolveAWSAccountID returns the AWS account ID from the given value, or
+// auto-detects it via STS when empty. Delegates to internal/awsenv.
 func ResolveAWSAccountID(ctx context.Context, accountID string) (string, error) {
-	if accountID != "" {
-		return accountID, nil
-	}
-	// Under --dry-run, stay side-effect-free: skip the aws sts call (which would
-	// fail without credentials) and return a placeholder account ID.
-	if DryRun {
-		return dryRunAccountID, nil
-	}
-	out, err := exec.CommandContext(ctx, "aws", "sts", "get-caller-identity", "--output", "json").Output()
-	if err != nil {
-		return "", fmt.Errorf("aws.accountId not configured and auto-detection failed: %w\n  Set aws.accountId in ludus.yaml or ensure AWS credentials are valid", err)
-	}
-	var identity struct {
-		Account string `json:"Account"`
-	}
-	if err := json.Unmarshal(out, &identity); err != nil || strings.TrimSpace(identity.Account) == "" {
-		return "", fmt.Errorf("aws.accountId not configured and could not be parsed from aws sts get-caller-identity output")
-	}
-	return strings.TrimSpace(identity.Account), nil
+	cfg := &config.Config{}
+	cfg.AWS.AccountID = accountID
+	return awsenv.NewResolver(DryRun).ResolveAccountID(ctx, cfg)
 }
 
-// ResolveAWSRegion returns the AWS region from cfg, or falls back to
-// AWS_DEFAULT_REGION / AWS_REGION environment variables.
+// ResolveAWSRegion returns the region from the given value, or resolves it via
+// the AWS SDK chain / IMDS when empty. Delegates to internal/awsenv.
 func ResolveAWSRegion(region string) (string, error) {
-	if region != "" {
-		return region, nil
-	}
-	for _, env := range []string{"AWS_DEFAULT_REGION", "AWS_REGION"} {
-		if v := os.Getenv(env); v != "" {
-			return v, nil
-		}
-	}
-	return "", fmt.Errorf("aws.region not configured (set aws.region in ludus.yaml, or AWS_DEFAULT_REGION / AWS_REGION env var)")
+	cfg := &config.Config{}
+	cfg.AWS.Region = region
+	return awsenv.NewResolver(DryRun).ResolveRegion(context.Background(), cfg)
 }

--- a/cmd/globals/aws.go
+++ b/cmd/globals/aws.go
@@ -9,9 +9,12 @@ import (
 
 // ResolveAWSAccountID returns the AWS account ID from the given value, or
 // auto-detects it via STS when empty. Delegates to internal/awsenv.
-func ResolveAWSAccountID(ctx context.Context, accountID string) (string, error) {
+// The region parameter is used when auto-detecting the account ID via STS,
+// since the AWS SDK requires a region to make the call.
+func ResolveAWSAccountID(ctx context.Context, accountID, region string) (string, error) {
 	cfg := &config.Config{}
 	cfg.AWS.AccountID = accountID
+	cfg.AWS.Region = region
 	return awsenv.NewResolver(DryRun).ResolveAccountID(ctx, cfg)
 }
 

--- a/cmd/globals/aws_test.go
+++ b/cmd/globals/aws_test.go
@@ -36,7 +36,7 @@ func TestResolveAWSAccountID(t *testing.T) {
 
 func TestResolveAWSRegion(t *testing.T) {
 	t.Run("returns configured value", func(t *testing.T) {
-		got, err := ResolveAWSRegion("us-west-2")
+		got, err := ResolveAWSRegion(context.Background(), "us-west-2")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -48,7 +48,7 @@ func TestResolveAWSRegion(t *testing.T) {
 	t.Run("falls back to env var", func(t *testing.T) {
 		t.Setenv("AWS_REGION", "eu-central-1")
 		t.Setenv("AWS_DEFAULT_REGION", "")
-		got, err := ResolveAWSRegion("")
+		got, err := ResolveAWSRegion(context.Background(), "")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}

--- a/cmd/globals/aws_test.go
+++ b/cmd/globals/aws_test.go
@@ -9,6 +9,7 @@ import (
 
 func TestResolveAWSAccountID(t *testing.T) {
 	t.Run("returns configured value without invoking aws", func(t *testing.T) {
+		t.Setenv("AWS_REGION", "us-west-2")
 		got, err := ResolveAWSAccountID(context.Background(), "123456789012")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)

--- a/cmd/globals/aws_test.go
+++ b/cmd/globals/aws_test.go
@@ -10,7 +10,7 @@ import (
 func TestResolveAWSAccountID(t *testing.T) {
 	t.Run("returns configured value without invoking aws", func(t *testing.T) {
 		t.Setenv("AWS_REGION", "us-west-2")
-		got, err := ResolveAWSAccountID(context.Background(), "123456789012")
+		got, err := ResolveAWSAccountID(context.Background(), "123456789012", "us-west-2")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -24,7 +24,7 @@ func TestResolveAWSAccountID(t *testing.T) {
 		DryRun = true
 		defer func() { DryRun = prev }()
 
-		got, err := ResolveAWSAccountID(context.Background(), "")
+		got, err := ResolveAWSAccountID(context.Background(), "", "us-west-2")
 		if err != nil {
 			t.Fatalf("dry-run should not error, got: %v", err)
 		}

--- a/cmd/globals/aws_test.go
+++ b/cmd/globals/aws_test.go
@@ -3,6 +3,8 @@ package globals
 import (
 	"context"
 	"testing"
+
+	"github.com/jpvelasco/ludus/internal/awsenv"
 )
 
 func TestResolveAWSAccountID(t *testing.T) {
@@ -25,8 +27,8 @@ func TestResolveAWSAccountID(t *testing.T) {
 		if err != nil {
 			t.Fatalf("dry-run should not error, got: %v", err)
 		}
-		if got != dryRunAccountID {
-			t.Errorf("got %q, want placeholder %q", got, dryRunAccountID)
+		if got != awsenv.PlaceholderAccountID {
+			t.Errorf("got %q, want placeholder %q", got, awsenv.PlaceholderAccountID)
 		}
 	})
 }

--- a/cmd/globals/resolve.go
+++ b/cmd/globals/resolve.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jpvelasco/ludus/internal/anywhere"
-	"github.com/jpvelasco/ludus/internal/awsutil"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/binary"
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/deploy"
@@ -71,23 +71,24 @@ func resolveGameLift(ctx context.Context, cfg *config.Config) (deploy.Target, er
 		cfg.GameLift.InstanceType = resolved
 	}
 
-	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)
+	env, err := awsenv.NewResolver(DryRun).Resolve(ctx, cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
-		return nil, fmt.Errorf("loading AWS config: %w", err)
+		return nil, err
+	}
+	imageURI, err := awsenv.ImageURI(env, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	if err != nil {
+		return nil, err
 	}
 
-	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		cfg.AWS.AccountID, cfg.AWS.Region, cfg.AWS.ECRRepository, cfg.Container.Tag)
-
 	deployer := gamelift.NewDeployer(gamelift.DeployOptions{
-		Region:             cfg.AWS.Region,
+		Region:             env.Region,
 		ImageURI:           imageURI,
 		FleetName:          cfg.GameLift.FleetName,
 		InstanceType:       cfg.GameLift.InstanceType,
 		ContainerGroupName: cfg.GameLift.ContainerGroupName,
 		ServerPort:         cfg.Container.ServerPort,
 		Tags:               tags.Build(cfg),
-	}, awsCfg)
+	}, env.AWSConfig)
 
 	return gamelift.NewTargetAdapter(deployer), nil
 }
@@ -100,17 +101,18 @@ func resolveStack(ctx context.Context, cfg *config.Config) (deploy.Target, error
 		cfg.GameLift.InstanceType = resolved
 	}
 
-	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)
+	env, err := awsenv.NewResolver(DryRun).Resolve(ctx, cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
-		return nil, fmt.Errorf("loading AWS config: %w", err)
+		return nil, err
 	}
-
-	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		cfg.AWS.AccountID, cfg.AWS.Region, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	imageURI, err := awsenv.ImageURI(env, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	if err != nil {
+		return nil, err
+	}
 
 	deployer := stack.NewStackDeployer(stack.StackOptions{
 		StackName:          fmt.Sprintf("ludus-%s", cfg.GameLift.FleetName),
-		Region:             cfg.AWS.Region,
+		Region:             env.Region,
 		ImageURI:           imageURI,
 		FleetName:          cfg.GameLift.FleetName,
 		InstanceType:       cfg.GameLift.InstanceType,
@@ -118,7 +120,7 @@ func resolveStack(ctx context.Context, cfg *config.Config) (deploy.Target, error
 		ServerPort:         cfg.Container.ServerPort,
 		ServerSDKVersion:   "5.4.0",
 		Tags:               tags.Build(cfg),
-	}, awsCfg)
+	}, env.AWSConfig)
 
 	return stack.NewTargetAdapter(deployer), nil
 }
@@ -132,10 +134,11 @@ func resolveBinary(cfg *config.Config) (deploy.Target, error) {
 }
 
 func resolveAnywhere(ctx context.Context, cfg *config.Config) (deploy.Target, error) {
-	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)
+	env, err := awsenv.NewResolver(DryRun).Resolve(ctx, cfg, awsenv.Requirements{Region: true})
 	if err != nil {
-		return nil, fmt.Errorf("loading AWS config: %w", err)
+		return nil, err
 	}
+	awsCfg := env.AWSConfig
 
 	// Resolve server build directory
 	serverBuildDir := config.ResolveServerBuildDir(cfg)
@@ -146,7 +149,7 @@ func resolveAnywhere(ctx context.Context, cfg *config.Config) (deploy.Target, er
 	r := NewRunner()
 
 	deployer := anywhere.NewDeployer(anywhere.DeployOptions{
-		Region:          cfg.AWS.Region,
+		Region:          env.Region,
 		FleetName:       cfg.GameLift.FleetName,
 		LocationName:    cfg.Anywhere.LocationName,
 		IPAddress:       cfg.Anywhere.IPAddress,
@@ -171,15 +174,16 @@ func resolveEC2Fleet(ctx context.Context, cfg *config.Config) (deploy.Target, er
 		cfg.GameLift.InstanceType = resolved
 	}
 
-	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)
+	env, err := awsenv.NewResolver(DryRun).Resolve(ctx, cfg, awsenv.Requirements{Region: true})
 	if err != nil {
-		return nil, fmt.Errorf("loading AWS config: %w", err)
+		return nil, err
 	}
+	awsCfg := env.AWSConfig
 
 	r := NewRunner()
 
 	deployer := ec2fleet.NewDeployer(ec2fleet.DeployOptions{
-		Region:          cfg.AWS.Region,
+		Region:          env.Region,
 		FleetName:       cfg.GameLift.FleetName,
 		InstanceType:    cfg.GameLift.InstanceType,
 		ServerPort:      cfg.Container.ServerPort,

--- a/cmd/mcp/tools_container.go
+++ b/cmd/mcp/tools_container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/container"
 	"github.com/jpvelasco/ludus/internal/ecr"
@@ -116,10 +117,14 @@ func handleContainerPush(ctx context.Context, _ *mcp.CallToolRequest, input cont
 	result.ImageTag = fmt.Sprintf("%s:%s", cfg.Container.ImageName, tag)
 
 	captured, err := withCapture(func() error {
+		env, resolveErr := awsenv.NewResolver(globals.DryRun).Resolve(ctx, cfg, awsenv.Requirements{Account: true, Region: true})
+		if resolveErr != nil {
+			return resolveErr
+		}
 		return b.Push(ctx, ecr.PushOptions{
 			ECRRepository: cfg.AWS.ECRRepository,
-			AWSRegion:     cfg.AWS.Region,
-			AWSAccountID:  cfg.AWS.AccountID,
+			AWSRegion:     env.Region,
+			AWSAccountID:  env.AccountID,
 			ImageTag:      tag,
 		})
 	})

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -507,9 +507,9 @@ func cleanupS3Bucket(ctx context.Context, cleaner *cleanup.Cleaner, awsCfg aws.C
 	accountID := cfg.AWS.AccountID
 	if accountID == "" {
 		stsClient := sts.NewFromConfig(awsCfg)
-		identity, stsErr := stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
-		if stsErr == nil {
-			accountID = aws.ToString(identity.Account)
+		id, err := awsenv.AccountID(ctx, stsClient)
+		if err == nil {
+			accountID = id
 		}
 	}
 	if accountID != "" {

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -508,7 +508,9 @@ func cleanupS3Bucket(ctx context.Context, cleaner *cleanup.Cleaner, awsCfg aws.C
 	if accountID == "" {
 		stsClient := sts.NewFromConfig(awsCfg)
 		id, err := awsenv.AccountID(ctx, stsClient)
-		if err == nil {
+		if err != nil {
+			fmt.Printf("  Warning: could not resolve account ID: %v\n", err)
+		} else {
 			accountID = id
 		}
 	}

--- a/cmd/mcp/tools_deploy.go
+++ b/cmd/mcp/tools_deploy.go
@@ -8,6 +8,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/awsutil"
 	"github.com/jpvelasco/ludus/internal/cleanup"
 	"github.com/jpvelasco/ludus/internal/config"
@@ -178,8 +179,14 @@ func handleDeployFleet(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 	}
 
 	serverBuildDir := config.ResolveServerBuildDir(&cfg)
-	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		cfg.AWS.AccountID, cfg.AWS.Region, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(ctx, &cfg, awsenv.Requirements{Account: true, Region: true})
+	if err != nil {
+		return toolError(fmt.Sprintf("could not resolve AWS environment: %v", err))
+	}
+	imageURI, err := awsenv.ImageURI(env, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	if err != nil {
+		return toolError(fmt.Sprintf("could not build ECR image URI: %v", err))
+	}
 
 	var result deployFleetResult
 
@@ -233,17 +240,18 @@ func handleDeployStack(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 		sn = fmt.Sprintf("ludus-%s", cfg.GameLift.FleetName)
 	}
 
-	imageURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		cfg.AWS.AccountID, cfg.AWS.Region, cfg.AWS.ECRRepository, cfg.Container.Tag)
-
-	awsCfg, err := awsutil.LoadAWSConfig(ctx, cfg.AWS.Region)
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(ctx, &cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
-		return toolError(fmt.Sprintf("could not load AWS config: %v", err))
+		return toolError(fmt.Sprintf("could not resolve AWS environment: %v", err))
+	}
+	imageURI, err := awsenv.ImageURI(env, cfg.AWS.ECRRepository, cfg.Container.Tag)
+	if err != nil {
+		return toolError(fmt.Sprintf("could not build ECR image URI: %v", err))
 	}
 
 	deployer := stack.NewStackDeployer(stack.StackOptions{
 		StackName:          sn,
-		Region:             cfg.AWS.Region,
+		Region:             env.Region,
 		ImageURI:           imageURI,
 		FleetName:          cfg.GameLift.FleetName,
 		InstanceType:       cfg.GameLift.InstanceType,
@@ -251,7 +259,7 @@ func handleDeployStack(ctx context.Context, _ *mcp.CallToolRequest, input deploy
 		ServerPort:         cfg.Container.ServerPort,
 		ServerSDKVersion:   "5.4.0",
 		Tags:               tags.Build(&cfg),
-	}, awsCfg)
+	}, env.AWSConfig)
 
 	var result deployStackResult
 	result.StackName = sn

--- a/cmd/mcp/tools_engine.go
+++ b/cmd/mcp/tools_engine.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/cache"
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/dockerbuild"
@@ -328,10 +329,14 @@ func handleEnginePush(ctx context.Context, _ *mcp.CallToolRequest, input engineP
 	}
 
 	captured, err := withCapture(func() error {
+		env, resolveErr := awsenv.NewResolver(globals.DryRun).Resolve(ctx, cfg, awsenv.Requirements{Account: true, Region: true})
+		if resolveErr != nil {
+			return resolveErr
+		}
 		return b.Push(ctx, ecr.PushOptions{
 			ECRRepository: repoName,
-			AWSRegion:     cfg.AWS.Region,
-			AWSAccountID:  cfg.AWS.AccountID,
+			AWSRegion:     env.Region,
+			AWSAccountID:  env.AccountID,
 			ImageTag:      imageTag,
 		})
 	})

--- a/cmd/pipeline/stages_deploy.go
+++ b/cmd/pipeline/stages_deploy.go
@@ -48,6 +48,11 @@ func (p *pipelineCtx) stageContainerBuild(ctx context.Context) error {
 }
 
 func (p *pipelineCtx) stageContainerPush(ctx context.Context) error {
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(ctx, p.cfg, awsenv.Requirements{Account: true, Region: true})
+	if err != nil {
+		return err
+	}
+
 	builder := ctrBuilder.NewBuilder(ctrBuilder.BuildOptions{
 		ImageName:    p.cfg.Container.ImageName,
 		Tag:          p.cfg.Container.Tag,
@@ -58,8 +63,8 @@ func (p *pipelineCtx) stageContainerPush(ctx context.Context) error {
 	}, p.r)
 	return builder.Push(ctx, ecr.PushOptions{
 		ECRRepository: p.cfg.AWS.ECRRepository,
-		AWSRegion:     p.cfg.AWS.Region,
-		AWSAccountID:  p.cfg.AWS.AccountID,
+		AWSRegion:     env.Region,
+		AWSAccountID:  env.AccountID,
 		ImageTag:      p.cfg.Container.Tag,
 	})
 }

--- a/cmd/pipeline/stages_deploy.go
+++ b/cmd/pipeline/stages_deploy.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/cache"
 	ctrBuilder "github.com/jpvelasco/ludus/internal/container"
 	"github.com/jpvelasco/ludus/internal/deploy"
@@ -70,8 +72,12 @@ func (p *pipelineCtx) stageDeploy(ctx context.Context) error {
 		fmt.Printf("    %s\n", sug)
 	}
 
+	imageURI, err := p.buildImageURI(ctx)
+	if err != nil {
+		return err
+	}
 	result, err := p.target.Deploy(ctx, deploy.DeployInput{
-		ImageURI:       p.buildImageURI(),
+		ImageURI:       imageURI,
 		ServerBuildDir: p.serverBuildDir,
 		ServerPort:     p.cfg.Container.ServerPort,
 	})
@@ -105,9 +111,12 @@ func (p *pipelineCtx) stageSession(ctx context.Context) error {
 	return nil
 }
 
-func (p *pipelineCtx) buildImageURI() string {
-	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		p.cfg.AWS.AccountID, p.cfg.AWS.Region, p.cfg.AWS.ECRRepository, p.cfg.Container.Tag)
+func (p *pipelineCtx) buildImageURI(ctx context.Context) (string, error) {
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(ctx, p.cfg, awsenv.Requirements{Account: true, Region: true})
+	if err != nil {
+		return "", err
+	}
+	return awsenv.ImageURI(env, p.cfg.AWS.ECRRepository, p.cfg.Container.Tag)
 }
 
 func (p *pipelineCtx) saveDeployState(result *deploy.DeployResult) {

--- a/cmd/pipeline/stages_test.go
+++ b/cmd/pipeline/stages_test.go
@@ -91,7 +91,11 @@ func TestBuildImageURI(t *testing.T) {
 					Container: config.ContainerConfig{Tag: tt.tag},
 				},
 			}
-			if got := p.buildImageURI(); got != tt.want {
+			got, err := p.buildImageURI(context.Background())
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tt.want {
 				t.Errorf("buildImageURI() = %q, want %q", got, tt.want)
 			}
 		})

--- a/cmd/pipeline/stages_test.go
+++ b/cmd/pipeline/stages_test.go
@@ -2,6 +2,7 @@ package pipeline
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/config"
@@ -97,6 +98,55 @@ func TestBuildImageURI(t *testing.T) {
 			}
 			if got != tt.want {
 				t.Errorf("buildImageURI() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildImageURIErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		account string
+		region  string
+		repo    string
+		tag     string
+		wantErr string
+	}{
+		{
+			name:    "empty repository",
+			account: "123456789012",
+			region:  "us-east-1",
+			repo:    "",
+			tag:     "latest",
+			wantErr: "repository",
+		},
+		{
+			name:    "empty tag",
+			account: "123456789012",
+			region:  "us-east-1",
+			repo:    "my-game",
+			tag:     "",
+			wantErr: "tag",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := &pipelineCtx{
+				cfg: &config.Config{
+					AWS: config.AWSConfig{
+						AccountID:     tt.account,
+						Region:        tt.region,
+						ECRRepository: tt.repo,
+					},
+					Container: config.ContainerConfig{Tag: tt.tag},
+				},
+			}
+			_, err := p.buildImageURI(context.Background())
+			if err == nil {
+				t.Fatal("expected error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want substring %q", err.Error(), tt.wantErr)
 			}
 		})
 	}

--- a/internal/awsenv/resolve.go
+++ b/internal/awsenv/resolve.go
@@ -1,0 +1,153 @@
+package awsenv
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awsconfig "github.com/aws/aws-sdk-go-v2/config"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+// PlaceholderAccountID is returned under dry-run when no account ID is
+// configured, so a representative URI can be printed without calling AWS.
+const PlaceholderAccountID = "000000000000"
+
+// placeholderRegion is used under dry-run when no region is configured, keeping
+// dry-run network-free (no IMDS lookup).
+const placeholderRegion = "us-east-1"
+
+// IdentityAPI is the subset of the STS client used to resolve the account ID.
+// The real *sts.Client satisfies it; tests inject a fake.
+type IdentityAPI interface {
+	GetCallerIdentity(context.Context, *sts.GetCallerIdentityInput, ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error)
+}
+
+// Requirements declares which fields a caller needs resolved. A target that
+// needs no account (e.g. anywhere) leaves Account false so no STS call is made.
+type Requirements struct {
+	Account bool
+	Region  bool
+}
+
+// Resolver resolves the AWS account ID and region from config, the SDK chain,
+// STS, and IMDS. Construct with NewResolver.
+type Resolver struct {
+	dryRun bool
+
+	// loadConfig loads the AWS SDK config for region; useIMDS enables EC2 IMDS
+	// region resolution when region is empty. Overridable in tests.
+	loadConfig func(ctx context.Context, region string, useIMDS bool) (aws.Config, error)
+	// newIdentityClient builds an STS client from config. Overridable in tests.
+	newIdentityClient func(aws.Config) IdentityAPI
+
+	cached *Env
+}
+
+// NewResolver returns a Resolver wired to the real AWS SDK. Pass the process
+// dry-run flag so resolution stays side-effect-free under --dry-run.
+func NewResolver(dryRun bool) *Resolver {
+	return &Resolver{
+		dryRun:            dryRun,
+		loadConfig:        defaultLoadConfig,
+		newIdentityClient: func(c aws.Config) IdentityAPI { return sts.NewFromConfig(c) },
+	}
+}
+
+func defaultLoadConfig(ctx context.Context, region string, useIMDS bool) (aws.Config, error) {
+	opts := []func(*awsconfig.LoadOptions) error{}
+	switch {
+	case region != "":
+		opts = append(opts, awsconfig.WithRegion(region))
+	case useIMDS:
+		opts = append(opts, awsconfig.WithEC2IMDSRegion())
+	}
+	return awsconfig.LoadDefaultConfig(ctx, opts...)
+}
+
+// Resolve resolves the requested fields and returns them plus the loaded SDK
+// config. Results are memoized for the resolver's lifetime.
+func (r *Resolver) Resolve(ctx context.Context, cfg *config.Config, req Requirements) (Env, error) {
+	if r.cached != nil {
+		return *r.cached, nil
+	}
+
+	region, awsCfg, err := r.resolveRegion(ctx, cfg)
+	if err != nil {
+		return Env{}, err
+	}
+
+	env := Env{Region: region, AWSConfig: awsCfg}
+
+	if req.Account {
+		account, err := r.resolveAccountID(ctx, cfg, awsCfg)
+		if err != nil {
+			return Env{}, err
+		}
+		env.AccountID = account
+	}
+
+	r.cached = &env
+	return env, nil
+}
+
+// ResolveRegion resolves only the region.
+func (r *Resolver) ResolveRegion(ctx context.Context, cfg *config.Config) (string, error) {
+	env, err := r.Resolve(ctx, cfg, Requirements{Region: true})
+	return env.Region, err
+}
+
+// ResolveAccountID resolves only the account ID.
+func (r *Resolver) ResolveAccountID(ctx context.Context, cfg *config.Config) (string, error) {
+	env, err := r.Resolve(ctx, cfg, Requirements{Account: true, Region: true})
+	return env.AccountID, err
+}
+
+func (r *Resolver) resolveRegion(ctx context.Context, cfg *config.Config) (string, aws.Config, error) {
+	useIMDS := !r.dryRun
+	awsCfg, err := r.loadConfig(ctx, cfg.AWS.Region, useIMDS)
+	if err != nil {
+		return "", aws.Config{}, fmt.Errorf("loading AWS config: %w", err)
+	}
+	region := awsCfg.Region
+	if strings.TrimSpace(region) == "" {
+		if r.dryRun {
+			region = placeholderRegion
+			awsCfg.Region = region
+		} else {
+			return "", aws.Config{}, fmt.Errorf("aws.region is required or could not be resolved (set aws.region in ludus.yaml, or AWS_REGION / AWS_DEFAULT_REGION)")
+		}
+	}
+	return region, awsCfg, nil
+}
+
+func (r *Resolver) resolveAccountID(ctx context.Context, cfg *config.Config, awsCfg aws.Config) (string, error) {
+	if id := strings.TrimSpace(cfg.AWS.AccountID); id != "" {
+		return id, nil
+	}
+	if r.dryRun {
+		return PlaceholderAccountID, nil
+	}
+	id, err := AccountID(ctx, r.newIdentityClient(awsCfg))
+	if err != nil {
+		return "", fmt.Errorf("aws.accountId is required or could not be resolved: %w", err)
+	}
+	return id, nil
+}
+
+// AccountID calls STS GetCallerIdentity and returns the account ID. It is the
+// single STS consolidation point used by the resolver and by deployers that
+// already hold an STS client.
+func AccountID(ctx context.Context, client IdentityAPI) (string, error) {
+	out, err := client.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	if err != nil {
+		return "", fmt.Errorf("calling sts get-caller-identity: %w", err)
+	}
+	id := strings.TrimSpace(aws.ToString(out.Account))
+	if id == "" {
+		return "", fmt.Errorf("sts get-caller-identity returned an empty account ID")
+	}
+	return id, nil
+}

--- a/internal/awsenv/resolve.go
+++ b/internal/awsenv/resolve.go
@@ -99,16 +99,8 @@ func (r *Resolver) ResolveRegion(ctx context.Context, cfg *config.Config) (strin
 	return env.Region, err
 }
 
-// ResolveAccountID resolves only the account ID. If the account ID is already
-// configured, it is returned directly without requiring region resolution or
-// an STS call.
+// ResolveAccountID resolves only the account ID.
 func (r *Resolver) ResolveAccountID(ctx context.Context, cfg *config.Config) (string, error) {
-	if id := strings.TrimSpace(cfg.AWS.AccountID); id != "" {
-		return id, nil
-	}
-	if r.dryRun {
-		return PlaceholderAccountID, nil
-	}
 	env, err := r.Resolve(ctx, cfg, Requirements{Account: true, Region: true})
 	return env.AccountID, err
 }

--- a/internal/awsenv/resolve.go
+++ b/internal/awsenv/resolve.go
@@ -99,8 +99,16 @@ func (r *Resolver) ResolveRegion(ctx context.Context, cfg *config.Config) (strin
 	return env.Region, err
 }
 
-// ResolveAccountID resolves only the account ID.
+// ResolveAccountID resolves only the account ID. If the account ID is already
+// configured, it is returned directly without requiring region resolution or
+// an STS call.
 func (r *Resolver) ResolveAccountID(ctx context.Context, cfg *config.Config) (string, error) {
+	if id := strings.TrimSpace(cfg.AWS.AccountID); id != "" {
+		return id, nil
+	}
+	if r.dryRun {
+		return PlaceholderAccountID, nil
+	}
 	env, err := r.Resolve(ctx, cfg, Requirements{Account: true, Region: true})
 	return env.AccountID, err
 }

--- a/internal/awsenv/resolve_test.go
+++ b/internal/awsenv/resolve_test.go
@@ -1,0 +1,139 @@
+package awsenv
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+type fakeIdentity struct {
+	account string
+	err     error
+	calls   int
+}
+
+func (f *fakeIdentity) GetCallerIdentity(_ context.Context, _ *sts.GetCallerIdentityInput, _ ...func(*sts.Options)) (*sts.GetCallerIdentityOutput, error) {
+	f.calls++
+	if f.err != nil {
+		return nil, f.err
+	}
+	return &sts.GetCallerIdentityOutput{Account: aws.String(f.account)}, nil
+}
+
+// newTestResolver builds a resolver with injected, network-free seams.
+func newTestResolver(dryRun bool, region string, id *fakeIdentity) *Resolver {
+	r := NewResolver(dryRun)
+	r.loadConfig = func(_ context.Context, reg string, _ bool) (aws.Config, error) {
+		if reg == "" {
+			reg = region // simulate SDK/IMDS-resolved region
+		}
+		return aws.Config{Region: reg}, nil
+	}
+	r.newIdentityClient = func(aws.Config) IdentityAPI { return id }
+	return r
+}
+
+func TestResolve(t *testing.T) {
+	t.Run("explicit config wins, no STS", func(t *testing.T) {
+		id := &fakeIdentity{account: "999999999999"}
+		r := newTestResolver(false, "", id)
+		cfg := &config.Config{}
+		cfg.AWS.AccountID = "123456789012"
+		cfg.AWS.Region = "us-west-2"
+
+		env, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if env.AccountID != "123456789012" || env.Region != "us-west-2" {
+			t.Errorf("got %+v", env)
+		}
+		if id.calls != 0 {
+			t.Errorf("STS called %d times, want 0", id.calls)
+		}
+	})
+
+	t.Run("account falls back to STS", func(t *testing.T) {
+		id := &fakeIdentity{account: "555555555555"}
+		r := newTestResolver(false, "eu-west-1", id)
+		cfg := &config.Config{}
+
+		env, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if env.AccountID != "555555555555" {
+			t.Errorf("got account %q", env.AccountID)
+		}
+		if env.Region != "eu-west-1" {
+			t.Errorf("got region %q", env.Region)
+		}
+	})
+
+	t.Run("region-only requirement skips STS", func(t *testing.T) {
+		id := &fakeIdentity{account: "x"}
+		r := newTestResolver(false, "us-east-2", id)
+		cfg := &config.Config{}
+
+		env, err := r.Resolve(context.Background(), cfg, Requirements{Region: true})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if env.Region != "us-east-2" {
+			t.Errorf("got region %q", env.Region)
+		}
+		if id.calls != 0 {
+			t.Errorf("STS called %d times, want 0", id.calls)
+		}
+	})
+
+	t.Run("dry-run returns placeholders without STS", func(t *testing.T) {
+		id := &fakeIdentity{err: errors.New("no creds")}
+		r := newTestResolver(true, "", id)
+		cfg := &config.Config{}
+
+		env, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true})
+		if err != nil {
+			t.Fatalf("dry-run must not error: %v", err)
+		}
+		if env.AccountID != PlaceholderAccountID {
+			t.Errorf("got account %q, want placeholder", env.AccountID)
+		}
+		if env.Region != placeholderRegion {
+			t.Errorf("got region %q, want placeholder", env.Region)
+		}
+		if id.calls != 0 {
+			t.Errorf("STS called %d times in dry-run, want 0", id.calls)
+		}
+	})
+
+	t.Run("memoizes — STS called at most once", func(t *testing.T) {
+		id := &fakeIdentity{account: "111111111111"}
+		r := newTestResolver(false, "us-west-2", id)
+		cfg := &config.Config{}
+
+		for i := 0; i < 3; i++ {
+			if _, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true}); err != nil {
+				t.Fatalf("call %d: %v", i, err)
+			}
+		}
+		if id.calls != 1 {
+			t.Errorf("STS called %d times, want 1", id.calls)
+		}
+	})
+
+	t.Run("account unresolved yields field error", func(t *testing.T) {
+		id := &fakeIdentity{err: errors.New("no creds")}
+		r := newTestResolver(false, "us-west-2", id)
+		cfg := &config.Config{}
+
+		_, err := r.Resolve(context.Background(), cfg, Requirements{Account: true})
+		if err == nil {
+			t.Fatal("expected error, got nil")
+		}
+	})
+}

--- a/internal/awsenv/uri.go
+++ b/internal/awsenv/uri.go
@@ -1,0 +1,63 @@
+// Package awsenv centralizes resolution of the AWS account ID and region and
+// construction of ECR URIs, so no command duplicates this logic (issue #367).
+package awsenv
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+// Env holds a resolved AWS environment: account ID, region, and the loaded SDK
+// config (so callers reuse one config instead of re-loading).
+type Env struct {
+	AccountID string
+	Region    string
+	AWSConfig aws.Config
+}
+
+// RegistryURI returns the ECR registry endpoint:
+// <account>.dkr.ecr.<region>.amazonaws.com.
+func RegistryURI(env Env) (string, error) {
+	if err := requireEnv(env); err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", env.AccountID, env.Region), nil
+}
+
+// RepositoryURI returns the registry endpoint plus repository, without a tag.
+func RepositoryURI(env Env, repo string) (string, error) {
+	reg, err := RegistryURI(env)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(repo) == "" {
+		return "", fmt.Errorf("cannot build ECR repository URI: repository name is empty (set aws.ecrRepository in ludus.yaml)")
+	}
+	return reg + "/" + repo, nil
+}
+
+// ImageURI returns the fully qualified, tagged ECR image URI.
+func ImageURI(env Env, repo, tag string) (string, error) {
+	repoURI, err := RepositoryURI(env, repo)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(tag) == "" {
+		return "", fmt.Errorf("cannot build ECR image URI: image tag is empty")
+	}
+	return repoURI + ":" + tag, nil
+}
+
+// requireEnv validates the account ID and region are present (not blank), so no
+// URI builder can emit a string with an empty segment.
+func requireEnv(env Env) error {
+	if strings.TrimSpace(env.AccountID) == "" {
+		return fmt.Errorf("aws.accountId is required or could not be resolved (set aws.accountId in ludus.yaml or ensure AWS credentials are valid)")
+	}
+	if strings.TrimSpace(env.Region) == "" {
+		return fmt.Errorf("aws.region is required or could not be resolved (set aws.region in ludus.yaml, or AWS_REGION / AWS_DEFAULT_REGION)")
+	}
+	return nil
+}

--- a/internal/awsenv/uri_test.go
+++ b/internal/awsenv/uri_test.go
@@ -37,9 +37,9 @@ func TestURIBuilders(t *testing.T) {
 
 	// No builder may ever emit a blank segment.
 	bad := []struct {
-		name       string
-		env        Env
-		repo, tag  string
+		name      string
+		env       Env
+		repo, tag string
 	}{
 		{"empty account", Env{Region: "us-west-2"}, "r", "t"},
 		{"empty region", Env{AccountID: "123456789012"}, "r", "t"},

--- a/internal/awsenv/uri_test.go
+++ b/internal/awsenv/uri_test.go
@@ -1,0 +1,58 @@
+package awsenv
+
+import "testing"
+
+func TestURIBuilders(t *testing.T) {
+	ok := Env{AccountID: "123456789012", Region: "us-west-2"}
+
+	t.Run("registry", func(t *testing.T) {
+		got, err := RegistryURI(ok)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "123456789012.dkr.ecr.us-west-2.amazonaws.com"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("repository", func(t *testing.T) {
+		got, err := RepositoryURI(ok, "ludus-server")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "123456789012.dkr.ecr.us-west-2.amazonaws.com/ludus-server"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	t.Run("image", func(t *testing.T) {
+		got, err := ImageURI(ok, "ludus-server", "latest")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if want := "123456789012.dkr.ecr.us-west-2.amazonaws.com/ludus-server:latest"; got != want {
+			t.Errorf("got %q, want %q", got, want)
+		}
+	})
+
+	// No builder may ever emit a blank segment.
+	bad := []struct {
+		name       string
+		env        Env
+		repo, tag  string
+	}{
+		{"empty account", Env{Region: "us-west-2"}, "r", "t"},
+		{"empty region", Env{AccountID: "123456789012"}, "r", "t"},
+		{"whitespace account", Env{AccountID: "  ", Region: "us-west-2"}, "r", "t"},
+		{"whitespace region", Env{AccountID: "123456789012", Region: " "}, "r", "t"},
+		{"empty repo", ok, "", "t"},
+		{"empty tag", ok, "r", ""},
+	}
+	for _, tt := range bad {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := ImageURI(tt.env, tt.repo, tt.tag); err == nil {
+				t.Errorf("expected error for %s, got nil", tt.name)
+			}
+		})
+	}
+}

--- a/internal/dockerbuild/engine.go
+++ b/internal/dockerbuild/engine.go
@@ -10,6 +10,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/ecr"
 	"github.com/jpvelasco/ludus/internal/runner"
 )
@@ -242,8 +243,12 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts ecr.PushOptions) err
 	if err := ecr.Push(ctx, b.Runner, localTag, opts); err != nil {
 		return err
 	}
-	remoteTag := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s:%s",
-		opts.AWSAccountID, opts.AWSRegion, opts.ECRRepository, opts.ImageTag)
+	remoteTag, err := awsenv.ImageURI(
+		awsenv.Env{AccountID: opts.AWSAccountID, Region: opts.AWSRegion},
+		opts.ECRRepository, opts.ImageTag)
+	if err != nil {
+		return err
+	}
 	fmt.Printf("  Pushed engine image: %s\n", remoteTag)
 	return nil
 }

--- a/internal/ec2fleet/deployer_s3.go
+++ b/internal/ec2fleet/deployer_s3.go
@@ -7,7 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	s3types "github.com/aws/aws-sdk-go-v2/service/s3/types"
-	"github.com/aws/aws-sdk-go-v2/service/sts"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/tags"
 )
 
@@ -19,11 +19,10 @@ func (d *Deployer) resolveBucket(ctx context.Context) (string, error) {
 	}
 
 	// Auto-derive bucket name from AWS account ID
-	identity, err := d.stsClient.GetCallerIdentity(ctx, &sts.GetCallerIdentityInput{})
+	accountID, err := awsenv.AccountID(ctx, d.stsClient)
 	if err != nil {
-		return "", fmt.Errorf("getting AWS account ID: %w", err)
+		return "", err
 	}
-	accountID := aws.ToString(identity.Account)
 	bucket = fmt.Sprintf("ludus-builds-%s", accountID)
 
 	// Create bucket if it doesn't exist

--- a/internal/ecr/push.go
+++ b/internal/ecr/push.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/retry"
 	"github.com/jpvelasco/ludus/internal/runner"
 )
@@ -34,8 +35,11 @@ func Push(ctx context.Context, r *runner.Runner, localTag string, opts PushOptio
 		opts.ImageTag = "latest"
 	}
 
-	ecrURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com/%s",
-		opts.AWSAccountID, opts.AWSRegion, opts.ECRRepository)
+	env := awsenv.Env{AccountID: opts.AWSAccountID, Region: opts.AWSRegion}
+	ecrURI, err := awsenv.RepositoryURI(env, opts.ECRRepository)
+	if err != nil {
+		return err
+	}
 
 	if err := ensureECRRepository(ctx, r, opts); err != nil {
 		return err
@@ -86,7 +90,10 @@ func isAccessDenied(err error) bool {
 // operations are Docker-only (images are small, ~3-5 GB, unaffected by lease
 // timeouts). Podman ECR support is planned for a future release.
 func authenticateECR(ctx context.Context, r *runner.Runner, opts PushOptions) error {
-	loginURI := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", opts.AWSAccountID, opts.AWSRegion)
+	loginURI, err := awsenv.RegistryURI(awsenv.Env{AccountID: opts.AWSAccountID, Region: opts.AWSRegion})
+	if err != nil {
+		return err
+	}
 	retryCfg := retry.Default()
 
 	var password []byte


### PR DESCRIPTION
## Summary

Centralizes AWS account-ID / region resolution and ECR URI construction into a new `internal/awsenv` package, eliminating per-command duplication across the codebase (issue #367).

## What Changed

### New: `internal/awsenv` package
- **URI builders** — `RegistryURI`, `RepositoryURI`, `ImageURI` with empty-segment validation (no builder can emit a blank segment)
- **Requirement-based resolver** — `Resolver.Resolve(ctx, cfg, Requirements{Account, Region})` resolves account/region via config → SDK chain → STS/IMDS, returns loaded `aws.Config` (no double-load)
- **STS consolidation** — `AccountID(ctx, IdentityAPI)` is the single STS `GetCallerIdentity` call point

### Migration
All 9 raw `fmt.Sprintf` ECR URI constructions and scattered `awsutil.LoadAWSConfig` calls replaced:
- `cmd/globals/aws.go` — thin wrapper delegating to `awsenv`
- `cmd/globals/resolve.go` — all 5 deploy targets
- `internal/ecr/push.go` — push + authenticate
- `internal/dockerbuild/engine.go` — engine push
- `cmd/deploy/deploy.go` — `makeDeployer`
- `cmd/deploy/deploy_stack.go` — stack flags
- `cmd/mcp/tools_deploy.go` — fleet/stack deploy
- `cmd/mcp/tools_container.go` — container push
- `cmd/mcp/tools_engine.go` — engine push
- `cmd/pipeline/stages_deploy.go` — `buildImageURI` now returns `(string, error)`
- `internal/ec2fleet/deployer_s3.go` — consolidated STS call
- `cmd/deploy/deploy_destroy.go` — consolidated STS call

### Acceptance Criteria
- `dkr.ecr` only in `internal/awsenv` ✓
- `GetCallerIdentity` only in `internal/awsenv` ✓
- `000000000000` only in `internal/awsenv` (constant definition) ✓
- Build, vet, lint, all tests pass ✓

## Commits

1. `feat: add awsenv ECR URI builders with empty-segment validation (#367)`
2. `feat: add awsenv requirement-based resolver (SDK/STS/IMDS) (#367)`
3. `refactor: cmd/globals AWS resolvers delegate to awsenv (#367)`
4. `refactor: centralize AWS ECR URI and account/region resolution into awsenv package` (Tasks 5-8)
5. `refactor: consolidate duplicate STS account lookups into awsenv.AccountID (#367)`

## Follow-ups (out of scope)
- Dry-run actually-dry deployers (follow-up A)
- Container-group idempotency (follow-up B)
- Purge prompt
- Setup/prereq CLI
