### PR TITLE
fix: address remaining loose ties after awsenv centralization (#367)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -72,7 +72,8 @@ go mod tidy
 
 - Run external processes through `runner.Runner` (not raw `exec.Command`)
 - Use `internal/retry` for AWS/Docker operations (default retry strategy)
-- Use `awsutil.Poll` for AWS wait loops  
+- Use `awsutil.Poll` for AWS wait loops
+- Use `internal/awsenv` (NewResolver + Requirements + ImageURI/RegistryURI) for all account/region resolution and ECR URI building; centralized to address per-command duplication (see #367)
 - All CLI commands support `--verbose`, `--dry-run`, JSON output
 - Commands support `--profile` (creates `ludus-<name>.yaml`)
 - Config loaded from `ludus.yaml` via Viper (override via `--config`)

--- a/cmd/container/container.go
+++ b/cmd/container/container.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/cache"
 	"github.com/jpvelasco/ludus/internal/config"
 	ctrBuilder "github.com/jpvelasco/ludus/internal/container"
@@ -159,11 +160,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 		ServerPort: cfg.Container.ServerPort,
 	}, r)
 
-	accountID, err := globals.ResolveAWSAccountID(cmd.Context(), cfg.AWS.AccountID, cfg.AWS.Region)
-	if err != nil {
-		return err
-	}
-	awsRegion, err := globals.ResolveAWSRegion(cmd.Context(), cfg.AWS.Region)
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(cmd.Context(), &cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
 		return err
 	}
@@ -171,8 +168,8 @@ func runPush(cmd *cobra.Command, args []string) error {
 	fmt.Println("Pushing container image to ECR...")
 	if err := builder.Push(cmd.Context(), ecr.PushOptions{
 		ECRRepository: cfg.AWS.ECRRepository,
-		AWSRegion:     awsRegion,
-		AWSAccountID:  accountID,
+		AWSRegion:     env.Region,
+		AWSAccountID:  env.AccountID,
 		ImageTag:      imageTag,
 	}); err != nil {
 		return diagnose.ContainerError(err, "container push")

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -30,6 +30,16 @@ var (
 	destroyYes     bool // skip the --purge confirmation prompt
 )
 
+// dryRun prints the message and returns true under --dry-run to short-circuit
+// before making AWS calls. Used to deduplicate the pattern across deploy paths.
+func dryRun(msg string) bool {
+	if globals.DryRun {
+		fmt.Println(msg)
+		return true
+	}
+	return false
+}
+
 // Cmd is the top-level deploy command group.
 var Cmd = &cobra.Command{
 	Use:   "deploy",

--- a/cmd/deploy/deploy_anywhere.go
+++ b/cmd/deploy/deploy_anywhere.go
@@ -56,6 +56,11 @@ func runAnywhere(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if globals.DryRun {
+		fmt.Println("Dry run — would deploy to Anywhere (no AWS calls made).")
+		return nil
+	}
+
 	result, err := target.Deploy(cmd.Context(), deploy.DeployInput{
 		ServerPort: cfg.Container.ServerPort,
 	})

--- a/cmd/deploy/deploy_anywhere.go
+++ b/cmd/deploy/deploy_anywhere.go
@@ -56,8 +56,7 @@ func runAnywhere(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	if globals.DryRun {
-		fmt.Println("Dry run — would deploy to Anywhere (no AWS calls made).")
+	if dryRun("Dry run — would deploy to Anywhere (no AWS calls made).") {
 		return nil
 	}
 

--- a/cmd/deploy/deploy_ec2.go
+++ b/cmd/deploy/deploy_ec2.go
@@ -64,8 +64,7 @@ func runEC2(cmd *cobra.Command, args []string) error {
 
 	printPricingHints(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch())
 
-	if globals.DryRun {
-		fmt.Println("Dry run — would deploy to EC2 (no AWS calls made).")
+	if dryRun("Dry run — would deploy to EC2 (no AWS calls made).") {
 		return nil
 	}
 

--- a/cmd/deploy/deploy_ec2.go
+++ b/cmd/deploy/deploy_ec2.go
@@ -64,6 +64,11 @@ func runEC2(cmd *cobra.Command, args []string) error {
 
 	printPricingHints(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch())
 
+	if globals.DryRun {
+		fmt.Println("Dry run — would deploy to EC2 (no AWS calls made).")
+		return nil
+	}
+
 	serverBuildDir := config.ResolveServerBuildDir(&cfg)
 	if serverBuildDir == "" {
 		return fmt.Errorf("could not determine server build directory; set game.projectPath in ludus.yaml")

--- a/cmd/deploy/deploy_fleet.go
+++ b/cmd/deploy/deploy_fleet.go
@@ -46,8 +46,7 @@ func runFleet(cmd *cobra.Command, args []string) error {
 	}
 	printPricingHints(it, globals.Cfg.Game.ResolvedArch())
 
-	if globals.DryRun {
-		fmt.Println("Dry run — would create container group definition and fleet (no AWS calls made).")
+	if dryRun("Dry run — would create container group definition and fleet (no AWS calls made).") {
 		return nil
 	}
 

--- a/cmd/deploy/deploy_fleet.go
+++ b/cmd/deploy/deploy_fleet.go
@@ -46,6 +46,11 @@ func runFleet(cmd *cobra.Command, args []string) error {
 	}
 	printPricingHints(it, globals.Cfg.Game.ResolvedArch())
 
+	if globals.DryRun {
+		fmt.Println("Dry run — would create container group definition and fleet (no AWS calls made).")
+		return nil
+	}
+
 	fmt.Println("Creating container group definition...")
 	cgdARN, err := deployer.CreateContainerGroupDefinition(cmd.Context())
 	if err != nil {

--- a/cmd/deploy/deploy_stack.go
+++ b/cmd/deploy/deploy_stack.go
@@ -105,6 +105,11 @@ func runStack(cmd *cobra.Command, args []string) error {
 	}
 	printPricingHints(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch())
 
+	if globals.DryRun {
+		fmt.Println("Dry run — would deploy CloudFormation stack (no AWS calls made).")
+		return nil
+	}
+
 	start := time.Now()
 	deployer := stack.NewStackDeployer(stack.StackOptions{
 		StackName:          sn,

--- a/cmd/deploy/deploy_stack.go
+++ b/cmd/deploy/deploy_stack.go
@@ -105,8 +105,7 @@ func runStack(cmd *cobra.Command, args []string) error {
 	}
 	printPricingHints(cfg.GameLift.InstanceType, cfg.Game.ResolvedArch())
 
-	if globals.DryRun {
-		fmt.Println("Dry run — would deploy CloudFormation stack (no AWS calls made).")
+	if dryRun("Dry run — would deploy CloudFormation stack (no AWS calls made).") {
 		return nil
 	}
 

--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/cache"
 	"github.com/jpvelasco/ludus/internal/dockerbuild"
 	"github.com/jpvelasco/ludus/internal/ecr"
@@ -323,11 +324,7 @@ func runPush(cmd *cobra.Command, args []string) error {
 		repoName = "ludus-engine"
 	}
 
-	accountID, err := globals.ResolveAWSAccountID(cmd.Context(), cfg.AWS.AccountID, cfg.AWS.Region)
-	if err != nil {
-		return err
-	}
-	awsRegion, err := globals.ResolveAWSRegion(cmd.Context(), cfg.AWS.Region)
+	env, err := awsenv.NewResolver(globals.DryRun).Resolve(cmd.Context(), cfg, awsenv.Requirements{Account: true, Region: true})
 	if err != nil {
 		return err
 	}
@@ -335,8 +332,8 @@ func runPush(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Pushing engine image %s to ECR...\n", builder.FullImageTag())
 	if err := builder.Push(cmd.Context(), ecr.PushOptions{
 		ECRRepository: repoName,
-		AWSRegion:     awsRegion,
-		AWSAccountID:  accountID,
+		AWSRegion:     env.Region,
+		AWSAccountID:  env.AccountID,
 		ImageTag:      imageTag,
 	}); err != nil {
 		return err

--- a/cmd/pipeline/stages_deploy.go
+++ b/cmd/pipeline/stages_deploy.go
@@ -81,6 +81,10 @@ func (p *pipelineCtx) stageDeploy(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
+	if globals.DryRun {
+		fmt.Printf("    (dry run) would deploy image %s\n", imageURI)
+		return nil
+	}
 	result, err := p.target.Deploy(ctx, deploy.DeployInput{
 		ImageURI:       imageURI,
 		ServerBuildDir: p.serverBuildDir,
@@ -99,6 +103,10 @@ func (p *pipelineCtx) stageSession(ctx context.Context) error {
 	sm, ok := p.target.(deploy.SessionManager)
 	if !ok {
 		return fmt.Errorf("target %q does not support game sessions", p.target.Name())
+	}
+	if globals.DryRun {
+		fmt.Println("    (dry run) would create game session")
+		return nil
 	}
 	info, err := sm.CreateSession(ctx, 8)
 	if err != nil {

--- a/internal/dockerbuild/engine.go
+++ b/internal/dockerbuild/engine.go
@@ -243,6 +243,7 @@ func (b *EngineImageBuilder) Push(ctx context.Context, opts ecr.PushOptions) err
 	if err := ecr.Push(ctx, b.Runner, localTag, opts); err != nil {
 		return err
 	}
+	// Post-success reconstruction for display only (Push already validated via awsenv).
 	remoteTag, err := awsenv.ImageURI(
 		awsenv.Env{AccountID: opts.AWSAccountID, Region: opts.AWSRegion},
 		opts.ECRRepository, opts.ImageTag)

--- a/internal/ecr/push.go
+++ b/internal/ecr/push.go
@@ -28,13 +28,11 @@ type PushOptions struct {
 //
 // localTag is the existing Docker image tag (e.g. "ludus-server:latest").
 func Push(ctx context.Context, r *runner.Runner, localTag string, opts PushOptions) error {
-	if opts.AWSAccountID == "" || opts.AWSRegion == "" || opts.ECRRepository == "" {
-		return fmt.Errorf("AWS account ID, region, and ECR repository must be configured")
-	}
 	if opts.ImageTag == "" {
 		opts.ImageTag = "latest"
 	}
 
+	// Bridge for legacy PushOptions (callers now pre-resolve via awsenv in most paths).
 	env := awsenv.Env{AccountID: opts.AWSAccountID, Region: opts.AWSRegion}
 	ecrURI, err := awsenv.RepositoryURI(env, opts.ECRRepository)
 	if err != nil {
@@ -90,6 +88,7 @@ func isAccessDenied(err error) bool {
 // operations are Docker-only (images are small, ~3-5 GB, unaffected by lease
 // timeouts). Podman ECR support is planned for a future release.
 func authenticateECR(ctx context.Context, r *runner.Runner, opts PushOptions) error {
+	// Bridge for legacy PushOptions (validated upstream).
 	loginURI, err := awsenv.RegistryURI(awsenv.Env{AccountID: opts.AWSAccountID, Region: opts.AWSRegion})
 	if err != nil {
 		return err

--- a/internal/ecr/push.go
+++ b/internal/ecr/push.go
@@ -33,6 +33,10 @@ func Push(ctx context.Context, r *runner.Runner, localTag string, opts PushOptio
 	}
 
 	// Bridge for legacy PushOptions (callers now pre-resolve via awsenv in most paths).
+	// Validation is performed here via RepositoryURI (which calls requireEnv for account/region,
+	// then checks repo). All current callers (cmd/container, cmd/engine, cmd/pipeline, internal/dockerbuild)
+	// flow through this early validation before calling Push, so downstream reconstruction of Env in
+	// ensureECRRepository/authenticateECR is safe. Future callers must do the same.
 	env := awsenv.Env{AccountID: opts.AWSAccountID, Region: opts.AWSRegion}
 	ecrURI, err := awsenv.RepositoryURI(env, opts.ECRRepository)
 	if err != nil {
@@ -50,6 +54,7 @@ func Push(ctx context.Context, r *runner.Runner, localTag string, opts PushOptio
 
 // ensureECRRepository creates the ECR repository if it does not already exist.
 func ensureECRRepository(ctx context.Context, r *runner.Runner, opts PushOptions) error {
+	// Assumes opts validated upstream (account/region/repo non-empty) by caller via awsenv.
 	if err := r.RunQuiet(ctx, "aws", "ecr", "describe-repositories",
 		"--repository-names", opts.ECRRepository,
 		"--region", opts.AWSRegion); err == nil {
@@ -88,7 +93,7 @@ func isAccessDenied(err error) bool {
 // operations are Docker-only (images are small, ~3-5 GB, unaffected by lease
 // timeouts). Podman ECR support is planned for a future release.
 func authenticateECR(ctx context.Context, r *runner.Runner, opts PushOptions) error {
-	// Bridge for legacy PushOptions (validated upstream).
+	// Bridge for legacy PushOptions (validated upstream by early RepositoryURI in Push; see above).
 	loginURI, err := awsenv.RegistryURI(awsenv.Env{AccountID: opts.AWSAccountID, Region: opts.AWSRegion})
 	if err != nil {
 		return err

--- a/internal/ecr/push_test.go
+++ b/internal/ecr/push_test.go
@@ -21,8 +21,8 @@ func TestPush_MissingAccountID(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing account ID")
 	}
-	if !strings.Contains(err.Error(), "must be configured") {
-		t.Errorf("error should mention missing config, got: %v", err)
+	if !strings.Contains(err.Error(), "aws.accountId is required") {
+		t.Errorf("error should mention aws.accountId, got: %v", err)
 	}
 }
 
@@ -37,8 +37,8 @@ func TestPush_MissingRegion(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing region")
 	}
-	if !strings.Contains(err.Error(), "must be configured") {
-		t.Errorf("error should mention missing config, got: %v", err)
+	if !strings.Contains(err.Error(), "aws.region is required") {
+		t.Errorf("error should mention aws.region, got: %v", err)
 	}
 }
 
@@ -53,8 +53,8 @@ func TestPush_MissingRepository(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for missing repository")
 	}
-	if !strings.Contains(err.Error(), "must be configured") {
-		t.Errorf("error should mention missing config, got: %v", err)
+	if !strings.Contains(err.Error(), "repository name is empty") {
+		t.Errorf("error should mention repository name, got: %v", err)
 	}
 }
 

--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -82,7 +82,10 @@ func (d *Deployer) CreateContainerGroupDefinition(ctx context.Context) (string, 
 				}
 				return arn, nil
 			}
-			// fall through to error if describe fails
+			if derr != nil {
+				return "", fmt.Errorf("creating container group definition: conflict on create but describe failed: %w (create err: %v)", derr, err)
+			}
+			// fall through (unexpected) to original create error
 		}
 		return "", fmt.Errorf("creating container group definition: %w", err)
 	}

--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/gamelift"
 	"github.com/aws/aws-sdk-go-v2/service/iam"
+	"github.com/jpvelasco/ludus/internal/awsutil"
 	"github.com/jpvelasco/ludus/internal/deploy"
 	"github.com/jpvelasco/ludus/internal/glsession"
 	"github.com/jpvelasco/ludus/internal/tags"
@@ -65,9 +66,24 @@ func (d *Deployer) resourceTags() map[string]string {
 }
 
 // CreateContainerGroupDefinition creates the container group definition in GameLift.
+// If the definition already exists (e.g. from a prior partial deploy), reuses it.
 func (d *Deployer) CreateContainerGroupDefinition(ctx context.Context) (string, error) {
 	out, err := d.glClient.CreateContainerGroupDefinition(ctx, d.containerGroupDefinitionInput())
 	if err != nil {
+		if awsutil.IsConflict(err) {
+			// Already exists (from partial failure or retry); describe + wait instead of failing.
+			desc, derr := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
+				Name: aws.String(d.opts.ContainerGroupName),
+			})
+			if derr == nil && desc.ContainerGroupDefinition != nil {
+				arn := aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn)
+				if werr := d.waitForContainerGroupReady(ctx); werr != nil {
+					return arn, werr
+				}
+				return arn, nil
+			}
+			// fall through to error if describe fails
+		}
 		return "", fmt.Errorf("creating container group definition: %w", err)
 	}
 


### PR DESCRIPTION
Addresses the loose ties from the post-#367 review report:

- Dry-run guards added to all deploy paths (pipeline stages + direct fleet/stack/ec2/anywhere) to prevent real AWS calls
- Unified to single awsenv.Resolve() in container & engine push (eliminated split wrapper calls)
- Removed weak duplicate guard in ecr/push.go; now consistent precise errors from awsenv
- Added comments + minimal tightening for manual Env{} bridge sites
- Surgical idempotency improvement: reuse existing container group def on create conflict
- AGENTS.md updated

All changes surgical/minimal diff. Build, lint (via prior), tests green. Follows project conventions.

Refs #367