### PR TITLE
fix: address remaining #367 sub-findings (CGD update, setup legacy)

### DIFF
--- a/cmd/setup/aws.go
+++ b/cmd/setup/aws.go
@@ -1,10 +1,10 @@
 package setup
 
 import (
-	"encoding/json"
+	"context"
 	"fmt"
-	"os/exec"
 
+	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/config"
 )
 
@@ -34,21 +34,12 @@ func promptAWSDefault(defaultRegion string, existing *config.Config) (region, ac
 	return region, accountID
 }
 
-// detectAWSAccountID runs aws sts get-caller-identity to detect the account.
+// detectAWSAccountID uses the centralized awsenv resolver (SDK chain → STS/IMDS)
+// so detection is consistent with the rest of the system and works without the AWS CLI.
 func detectAWSAccountID() string {
-	if _, err := exec.LookPath("aws"); err != nil {
-		return ""
-	}
-	cmd := exec.Command("aws", "sts", "get-caller-identity", "--output", "json")
-	out, err := cmd.Output()
+	id, err := awsenv.NewResolver(false).ResolveAccountID(context.Background(), &config.Config{})
 	if err != nil {
 		return ""
 	}
-	var identity struct {
-		Account string `json:"Account"`
-	}
-	if json.Unmarshal(out, &identity) != nil {
-		return ""
-	}
-	return identity.Account
+	return id
 }

--- a/cmd/setup/aws.go
+++ b/cmd/setup/aws.go
@@ -1,3 +1,6 @@
+// Package setup contains the interactive setup wizard used to detect
+// the Unreal Engine source, AWS credentials, and other prerequisites,
+// then writes the initial ludus.yaml configuration.
 package setup
 
 import (

--- a/cmd/setup/aws.go
+++ b/cmd/setup/aws.go
@@ -6,6 +6,7 @@ package setup
 import (
 	"context"
 	"fmt"
+	"time"
 
 	"github.com/jpvelasco/ludus/internal/awsenv"
 	"github.com/jpvelasco/ludus/internal/config"
@@ -28,7 +29,7 @@ func promptAWSDefault(defaultRegion string, existing *config.Config) (region, ac
 		return region, accountID
 	}
 
-	fmt.Println("  Could not detect AWS account (AWS CLI not configured or not installed).")
+	fmt.Println("  Could not detect AWS account (no valid credentials or configuration found).")
 	defaultAccount := ""
 	if existing != nil {
 		defaultAccount = existing.AWS.AccountID
@@ -39,8 +40,11 @@ func promptAWSDefault(defaultRegion string, existing *config.Config) (region, ac
 
 // detectAWSAccountID uses the centralized awsenv resolver (SDK chain → STS/IMDS)
 // so detection is consistent with the rest of the system and works without the AWS CLI.
+// A short timeout bounds any IMDS lookup during interactive setup on non-EC2 hosts.
 func detectAWSAccountID() string {
-	id, err := awsenv.NewResolver(false).ResolveAccountID(context.Background(), &config.Config{})
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+	id, err := awsenv.NewResolver(false).ResolveAccountID(ctx, &config.Config{})
 	if err != nil {
 		return ""
 	}

--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -71,48 +71,46 @@ func (d *Deployer) resourceTags() map[string]string {
 // and creates fresh. This provides better idempotency without leaving stale snapshots.
 func (d *Deployer) CreateContainerGroupDefinition(ctx context.Context) (string, error) {
 	input := d.containerGroupDefinitionInput()
-	out, err := d.glClient.CreateContainerGroupDefinition(ctx, input)
-	if err != nil {
-		if awsutil.IsConflict(err) {
-			// Conflict: check if we can reuse the existing one.
-			desc, derr := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
-				Name: aws.String(d.opts.ContainerGroupName),
-			})
-			if derr != nil {
-				return "", fmt.Errorf("creating container group definition: conflict on create but describe failed: %w (create err: %v)", derr, err)
+	for attempt := 0; attempt < 2; attempt++ {
+		out, err := d.glClient.CreateContainerGroupDefinition(ctx, input)
+		if err == nil {
+			cgdARN := aws.ToString(out.ContainerGroupDefinition.ContainerGroupDefinitionArn)
+			if werr := d.waitForContainerGroupReady(ctx); werr != nil {
+				return cgdARN, werr
 			}
-			if desc.ContainerGroupDefinition != nil {
-				if definitionMatches(desc.ContainerGroupDefinition, input) {
-					arn := aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn)
-					if werr := d.waitForContainerGroupReady(ctx); werr != nil {
-						return arn, werr
-					}
-					return arn, nil
-				}
-				// Mismatch (stale definition): try to remove it so we can create the current one.
-				_, delErr := d.glClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
-					Name: aws.String(d.opts.ContainerGroupName),
-				})
-				if delErr != nil && !awsutil.IsNotFound(delErr) {
-					return "", fmt.Errorf("existing container group definition does not match desired config and could not be removed: %w", delErr)
-				}
-				// Retry create after cleanup.
-				out, err = d.glClient.CreateContainerGroupDefinition(ctx, input)
-				if err != nil {
-					return "", fmt.Errorf("creating container group definition (after stale cleanup): %w", err)
-				}
-			}
+			return cgdARN, nil
 		}
-		if err != nil {
+		if !awsutil.IsConflict(err) {
 			return "", fmt.Errorf("creating container group definition: %w", err)
 		}
+		// Conflict: check if we can reuse.
+		desc, derr := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
+			Name: aws.String(d.opts.ContainerGroupName),
+		})
+		if derr != nil {
+			return "", fmt.Errorf("creating container group definition: conflict on create but describe failed: %w (create err: %v)", derr, err)
+		}
+		if desc.ContainerGroupDefinition != nil {
+			if definitionMatches(desc.ContainerGroupDefinition, input) {
+				arn := aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn)
+				if werr := d.waitForContainerGroupReady(ctx); werr != nil {
+					return arn, werr
+				}
+				return arn, nil
+			}
+			// Mismatch: remove stale and retry create.
+			_, delErr := d.glClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
+				Name: aws.String(d.opts.ContainerGroupName),
+			})
+			if delErr != nil && !awsutil.IsNotFound(delErr) {
+				return "", fmt.Errorf("existing container group definition does not match desired config and could not be removed: %w", delErr)
+			}
+			continue // retry
+		}
+		// No definition object on describe; fall through with original error.
+		return "", fmt.Errorf("creating container group definition: %w", err)
 	}
-
-	cgdARN := aws.ToString(out.ContainerGroupDefinition.ContainerGroupDefinitionArn)
-	if err := d.waitForContainerGroupReady(ctx); err != nil {
-		return cgdARN, err
-	}
-	return cgdARN, nil
+	return "", fmt.Errorf("creating container group definition: too many attempts after conflict")
 }
 
 // CreateFleet creates a new GameLift container fleet.

--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -77,43 +77,58 @@ func (d *Deployer) CreateContainerGroupDefinition(ctx context.Context) (string, 
 	for attempt := 0; attempt < 2; attempt++ {
 		out, err := d.glClient.CreateContainerGroupDefinition(ctx, input)
 		if err == nil {
-			cgdARN := aws.ToString(out.ContainerGroupDefinition.ContainerGroupDefinitionArn)
-			if werr := d.waitForContainerGroupReady(ctx); werr != nil {
-				return cgdARN, werr
-			}
-			return cgdARN, nil
+			arn := aws.ToString(out.ContainerGroupDefinition.ContainerGroupDefinitionArn)
+			return d.waitAndReturn(ctx, arn)
 		}
 		if !awsutil.IsConflict(err) {
 			return "", fmt.Errorf("creating container group definition: %w", err)
 		}
-		// Conflict: check if we can reuse.
-		desc, derr := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
-			Name: aws.String(d.opts.ContainerGroupName),
-		})
-		if derr != nil {
-			return "", fmt.Errorf("creating container group definition: conflict on create but describe failed: %w (create err: %v)", derr, err)
+		arn, herr := d.handleConflictOnCreate(ctx, err, input)
+		if herr != nil {
+			return "", herr
 		}
-		if desc.ContainerGroupDefinition != nil {
-			if definitionMatches(desc.ContainerGroupDefinition, input) {
-				arn := aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn)
-				if werr := d.waitForContainerGroupReady(ctx); werr != nil {
-					return arn, werr
-				}
-				return arn, nil
-			}
-			// Mismatch: remove stale and retry create.
-			_, delErr := d.glClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
-				Name: aws.String(d.opts.ContainerGroupName),
-			})
-			if delErr != nil && !awsutil.IsNotFound(delErr) {
-				return "", fmt.Errorf("existing container group definition does not match desired config and could not be removed: %w", delErr)
-			}
-			continue // retry
+		if arn != "" {
+			return d.waitAndReturn(ctx, arn)
 		}
-		// No definition object on describe; fall through with original error.
-		return "", fmt.Errorf("creating container group definition: %w", err)
+		// Deleted stale definition; retry create.
 	}
 	return "", fmt.Errorf("creating container group definition: too many attempts after conflict")
+}
+
+// waitAndReturn waits for the container group definition to be ready and returns its ARN.
+func (d *Deployer) waitAndReturn(ctx context.Context, arn string) (string, error) {
+	if werr := d.waitForContainerGroupReady(ctx); werr != nil {
+		return arn, werr
+	}
+	return arn, nil
+}
+
+// handleConflictOnCreate is called after a CreateContainerGroupDefinition conflict.
+// It returns:
+//   - (arn, nil) if an existing matching definition was found (caller should wait+return)
+//   - ("", nil) if a stale definition was deleted (caller should retry create)
+//   - ("", err) on fatal error (bad describe or unrecoverable delete)
+func (d *Deployer) handleConflictOnCreate(ctx context.Context, createErr error, input *gamelift.CreateContainerGroupDefinitionInput) (string, error) {
+	desc, derr := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
+		Name: aws.String(d.opts.ContainerGroupName),
+	})
+	if derr != nil {
+		return "", fmt.Errorf("creating container group definition: conflict on create but describe failed: %w (create err: %v)", derr, createErr)
+	}
+	if desc.ContainerGroupDefinition == nil {
+		return "", fmt.Errorf("creating container group definition: %w", createErr)
+	}
+	if definitionMatches(desc.ContainerGroupDefinition, input) {
+		return aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn), nil
+	}
+	// Mismatch: remove the stale one so the next create attempt can succeed.
+	_, delErr := d.glClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
+		Name: aws.String(d.opts.ContainerGroupName),
+	})
+	if delErr != nil && !awsutil.IsNotFound(delErr) {
+		return "", fmt.Errorf("existing container group definition does not match desired config and could not be removed: %w", delErr)
+	}
+	return "", nil
 }
 
 // CreateFleet creates a new GameLift container fleet.

--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -66,28 +66,46 @@ func (d *Deployer) resourceTags() map[string]string {
 }
 
 // CreateContainerGroupDefinition creates the container group definition in GameLift.
-// If the definition already exists (e.g. from a prior partial deploy), reuses it.
+// Reuses on conflict if the existing definition matches the desired input exactly.
+// On mismatch (e.g. different image after re-push of :latest), removes the stale definition
+// and creates fresh. This provides better idempotency without leaving stale snapshots.
 func (d *Deployer) CreateContainerGroupDefinition(ctx context.Context) (string, error) {
-	out, err := d.glClient.CreateContainerGroupDefinition(ctx, d.containerGroupDefinitionInput())
+	input := d.containerGroupDefinitionInput()
+	out, err := d.glClient.CreateContainerGroupDefinition(ctx, input)
 	if err != nil {
 		if awsutil.IsConflict(err) {
-			// Already exists (from partial failure or retry); describe + wait instead of failing.
+			// Conflict: check if we can reuse the existing one.
 			desc, derr := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
 				Name: aws.String(d.opts.ContainerGroupName),
 			})
-			if derr == nil && desc.ContainerGroupDefinition != nil {
-				arn := aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn)
-				if werr := d.waitForContainerGroupReady(ctx); werr != nil {
-					return arn, werr
-				}
-				return arn, nil
-			}
 			if derr != nil {
 				return "", fmt.Errorf("creating container group definition: conflict on create but describe failed: %w (create err: %v)", derr, err)
 			}
-			// fall through (unexpected) to original create error
+			if desc.ContainerGroupDefinition != nil {
+				if definitionMatches(desc.ContainerGroupDefinition, input) {
+					arn := aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn)
+					if werr := d.waitForContainerGroupReady(ctx); werr != nil {
+						return arn, werr
+					}
+					return arn, nil
+				}
+				// Mismatch (stale definition): try to remove it so we can create the current one.
+				_, delErr := d.glClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
+					Name: aws.String(d.opts.ContainerGroupName),
+				})
+				if delErr != nil && !awsutil.IsNotFound(delErr) {
+					return "", fmt.Errorf("existing container group definition does not match desired config and could not be removed: %w", delErr)
+				}
+				// Retry create after cleanup.
+				out, err = d.glClient.CreateContainerGroupDefinition(ctx, input)
+				if err != nil {
+					return "", fmt.Errorf("creating container group definition (after stale cleanup): %w", err)
+				}
+			}
 		}
-		return "", fmt.Errorf("creating container group definition: %w", err)
+		if err != nil {
+			return "", fmt.Errorf("creating container group definition: %w", err)
+		}
 	}
 
 	cgdARN := aws.ToString(out.ContainerGroupDefinition.ContainerGroupDefinitionArn)

--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -1,3 +1,6 @@
+// Package gamelift implements the deploy.Target adapter and supporting
+// logic for AWS GameLift container fleets (including container group
+// definitions, fleet creation, and IAM roles).
 package gamelift
 
 import (

--- a/internal/gamelift/deployer_container.go
+++ b/internal/gamelift/deployer_container.go
@@ -57,14 +57,30 @@ func definitionMatches(current *gltypes.ContainerGroupDefinition, desired *gamel
 	if aws.ToString(c.ServerSdkVersion) != aws.ToString(d.ServerSdkVersion) {
 		return false
 	}
-	if current.TotalMemoryLimitMebibytes != nil && desired.TotalMemoryLimitMebibytes != nil {
-		if *current.TotalMemoryLimitMebibytes != *desired.TotalMemoryLimitMebibytes {
+	// Normalize nils for numeric fields (desired always sets them; described may omit)
+	if aws.ToInt32(current.TotalMemoryLimitMebibytes) != aws.ToInt32(desired.TotalMemoryLimitMebibytes) {
+		return false
+	}
+	if aws.ToFloat64(current.TotalVcpuLimit) != aws.ToFloat64(desired.TotalVcpuLimit) {
+		return false
+	}
+	// Compare port configuration (desired sets from ServerPort)
+	cPorts := c.PortConfiguration
+	dPorts := d.PortConfiguration
+	if (cPorts == nil) != (dPorts == nil) {
+		return false
+	}
+	if cPorts != nil && dPorts != nil {
+		if len(cPorts.ContainerPortRanges) != len(dPorts.ContainerPortRanges) {
 			return false
 		}
-	}
-	if current.TotalVcpuLimit != nil && desired.TotalVcpuLimit != nil {
-		if *current.TotalVcpuLimit != *desired.TotalVcpuLimit {
-			return false
+		for i := range cPorts.ContainerPortRanges {
+			cr, dr := cPorts.ContainerPortRanges[i], dPorts.ContainerPortRanges[i]
+			if aws.ToInt32(cr.FromPort) != aws.ToInt32(dr.FromPort) ||
+				aws.ToInt32(cr.ToPort) != aws.ToInt32(dr.ToPort) ||
+				cr.Protocol != dr.Protocol {
+				return false
+			}
 		}
 	}
 	return true

--- a/internal/gamelift/deployer_container.go
+++ b/internal/gamelift/deployer_container.go
@@ -40,6 +40,33 @@ func (d *Deployer) containerGroupDefinitionInput() *gamelift.CreateContainerGrou
 	}
 }
 
+// definitionMatches returns whether the on-disk (described) container group definition
+// is equivalent to what we want to create right now. Used to safely decide reuse vs replace.
+func definitionMatches(current *gltypes.ContainerGroupDefinition, desired *gamelift.CreateContainerGroupDefinitionInput) bool {
+	if current == nil || desired == nil || current.GameServerContainerDefinition == nil || desired.GameServerContainerDefinition == nil {
+		return false
+	}
+	c := current.GameServerContainerDefinition
+	d := desired.GameServerContainerDefinition
+	if aws.ToString(c.ImageUri) != aws.ToString(d.ImageUri) {
+		return false
+	}
+	if aws.ToString(c.ServerSdkVersion) != aws.ToString(d.ServerSdkVersion) {
+		return false
+	}
+	if current.TotalMemoryLimitMebibytes != nil && desired.TotalMemoryLimitMebibytes != nil {
+		if *current.TotalMemoryLimitMebibytes != *desired.TotalMemoryLimitMebibytes {
+			return false
+		}
+	}
+	if current.TotalVcpuLimit != nil && desired.TotalVcpuLimit != nil {
+		if *current.TotalVcpuLimit != *desired.TotalVcpuLimit {
+			return false
+		}
+	}
+	return true
+}
+
 func (d *Deployer) waitForContainerGroupReady(ctx context.Context) error {
 	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
 		desc, err := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{

--- a/internal/gamelift/deployer_container.go
+++ b/internal/gamelift/deployer_container.go
@@ -1,3 +1,6 @@
+// Package gamelift implements the deploy.Target adapter and supporting
+// logic for AWS GameLift container fleets (including container group
+// definitions, fleet creation, and IAM roles).
 package gamelift
 
 import (

--- a/internal/gamelift/deployer_container.go
+++ b/internal/gamelift/deployer_container.go
@@ -46,44 +46,62 @@ func (d *Deployer) containerGroupDefinitionInput() *gamelift.CreateContainerGrou
 // definitionMatches returns whether the on-disk (described) container group definition
 // is equivalent to what we want to create right now. Used to safely decide reuse vs replace.
 func definitionMatches(current *gltypes.ContainerGroupDefinition, desired *gamelift.CreateContainerGroupDefinitionInput) bool {
-	if current == nil || desired == nil || current.GameServerContainerDefinition == nil || desired.GameServerContainerDefinition == nil {
+	if !hasGameServerContainers(current, desired) {
 		return false
 	}
 	c := current.GameServerContainerDefinition
 	d := desired.GameServerContainerDefinition
-	if aws.ToString(c.ImageUri) != aws.ToString(d.ImageUri) {
+	if !imageAndSdkMatch(c, d) {
 		return false
 	}
-	if aws.ToString(c.ServerSdkVersion) != aws.ToString(d.ServerSdkVersion) {
+	if !limitsMatch(current, desired) {
 		return false
 	}
-	// Normalize nils for numeric fields (desired always sets them; described may omit)
-	if aws.ToInt32(current.TotalMemoryLimitMebibytes) != aws.ToInt32(desired.TotalMemoryLimitMebibytes) {
+	if !portConfigurationMatches(c.PortConfiguration, d.PortConfiguration) {
 		return false
 	}
-	if aws.ToFloat64(current.TotalVcpuLimit) != aws.ToFloat64(desired.TotalVcpuLimit) {
+	return true
+}
+
+func hasGameServerContainers(current *gltypes.ContainerGroupDefinition, desired *gamelift.CreateContainerGroupDefinitionInput) bool {
+	return current != nil &&
+		desired != nil &&
+		current.GameServerContainerDefinition != nil &&
+		desired.GameServerContainerDefinition != nil
+}
+
+func imageAndSdkMatch(c *gltypes.GameServerContainerDefinition, d *gltypes.GameServerContainerDefinitionInput) bool {
+	return aws.ToString(c.ImageUri) == aws.ToString(d.ImageUri) &&
+		aws.ToString(c.ServerSdkVersion) == aws.ToString(d.ServerSdkVersion)
+}
+
+func limitsMatch(current *gltypes.ContainerGroupDefinition, desired *gamelift.CreateContainerGroupDefinitionInput) bool {
+	return aws.ToInt32(current.TotalMemoryLimitMebibytes) == aws.ToInt32(desired.TotalMemoryLimitMebibytes) &&
+		aws.ToFloat64(current.TotalVcpuLimit) == aws.ToFloat64(desired.TotalVcpuLimit)
+}
+
+func portConfigurationMatches(c, d *gltypes.ContainerPortConfiguration) bool {
+	if (c == nil) != (d == nil) {
 		return false
 	}
-	// Compare port configuration (desired sets from ServerPort)
-	cPorts := c.PortConfiguration
-	dPorts := d.PortConfiguration
-	if (cPorts == nil) != (dPorts == nil) {
+	if c == nil {
+		return true
+	}
+	if len(c.ContainerPortRanges) != len(d.ContainerPortRanges) {
 		return false
 	}
-	if cPorts != nil && dPorts != nil {
-		if len(cPorts.ContainerPortRanges) != len(dPorts.ContainerPortRanges) {
+	for i := range c.ContainerPortRanges {
+		if !portRangeMatches(c.ContainerPortRanges[i], d.ContainerPortRanges[i]) {
 			return false
-		}
-		for i := range cPorts.ContainerPortRanges {
-			cr, dr := cPorts.ContainerPortRanges[i], dPorts.ContainerPortRanges[i]
-			if aws.ToInt32(cr.FromPort) != aws.ToInt32(dr.FromPort) ||
-				aws.ToInt32(cr.ToPort) != aws.ToInt32(dr.ToPort) ||
-				cr.Protocol != dr.Protocol {
-				return false
-			}
 		}
 	}
 	return true
+}
+
+func portRangeMatches(c, d gltypes.ContainerPortRange) bool {
+	return aws.ToInt32(c.FromPort) == aws.ToInt32(d.FromPort) &&
+		aws.ToInt32(c.ToPort) == aws.ToInt32(d.ToPort) &&
+		c.Protocol == d.Protocol
 }
 
 func (d *Deployer) waitForContainerGroupReady(ctx context.Context) error {


### PR DESCRIPTION
## Summary
Follow-up to #369 / #368 for the remaining lower-severity items from #367 that were scoped as future/minor.

### Changes
- internal/gamelift/deployer.go + deployer_container.go: In conflict path for container group definition, now explicitly deletes stale definition (on image/config mismatch) and retries create. This implements better "reusing/updating" behavior for changed deploys while keeping safe reuse for true partial failures. Errors on unremovable stale defs.
- cmd/setup/aws.go: Switched account detection to use centralized awsenv.NewResolver().ResolveAccountID (removes raw aws sts exec + json in the wizard for consistency with runtime paths).

Refs #367
