### PR TITLE
fix: remove stale ludus-test binary and add to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 ludus
 ludus.exe
 ludus-*.exe
+ludus-test
 
 # Config with real values (contains AWS account IDs, paths, etc.)
 ludus.yaml


### PR DESCRIPTION
Fixes #371

A 59 MB `ludus-test` binary was accidentally committed in PR #368 because `.gitignore` didn't cover extensionless test binaries produced by `go test -c`.

**Changes:**
- Remove `ludus-test` from git tracking
- Add `ludus-test` to `.gitignore` to prevent recurrence

**Note:** The binary is already in history. A history rewrite to reclaim ~59 MB would require a force-push and disrupt all clones — not worth it for this one-off. Leaving history as-is.