### PR TITLE
refactor: clear remaining Codacy complexity findings

### DIFF
--- a/cmd/globals/ddc_test.go
+++ b/cmd/globals/ddc_test.go
@@ -176,6 +176,15 @@ func TestResolveEngineImage(t *testing.T) {
 	}
 }
 
+// assertOptionalEqual checks got == want, but treats an empty want as
+// "don't assert" (the resolver fills some defaults the table doesn't pin).
+func assertOptionalEqual(t *testing.T, label, got, want string) {
+	t.Helper()
+	if want != "" && got != want {
+		t.Errorf("%s = %q, want %q", label, got, want)
+	}
+}
+
 func TestResolveDDC(t *testing.T) {
 	absPath := "/test/ddc"
 	if runtime.GOOS == "windows" {
@@ -229,12 +238,8 @@ func TestResolveDDC(t *testing.T) {
 			}
 			// wantPath/wantZenPath of "" means "don't assert exact value"
 			// (the resolver fills defaults we don't pin here).
-			if tt.wantPath != "" && path != tt.wantPath {
-				t.Errorf("path = %q, want %q", path, tt.wantPath)
-			}
-			if tt.wantZenPath != "" && zenPath != tt.wantZenPath {
-				t.Errorf("zenPath = %q, want %q", zenPath, tt.wantZenPath)
-			}
+			assertOptionalEqual(t, "path", path, tt.wantPath)
+			assertOptionalEqual(t, "zenPath", zenPath, tt.wantZenPath)
 			if tt.wantMode == "none" && (path != "" || zenPath != "") {
 				t.Errorf("none mode should return empty paths, got path=%q zenPath=%q", path, zenPath)
 			}

--- a/internal/config/config_defaults.go
+++ b/internal/config/config_defaults.go
@@ -3,61 +3,85 @@ package config
 // Defaults returns a Config with sensible defaults.
 func Defaults() *Config {
 	return &Config{
-		Engine: EngineConfig{
-			MaxJobs:         0,
-			Backend:         "native",
-			DockerImageName: "ludus-engine",
-			DockerBaseImage: "ubuntu:22.04",
-		},
-		Game: GameConfig{
-			ProjectName: "Lyra",
-			Platform:    "linux",
-			Arch:        "amd64",
-			ServerMap:   "L_Expanse",
-		},
-		Container: ContainerConfig{
-			ImageName:  "ludus-server",
-			Tag:        "latest",
-			ServerPort: 7777,
-		},
-		Deploy: DeployConfig{
-			Target: "gamelift",
-		},
-		EC2Fleet: EC2FleetConfig{
-			ServerSDKVersion: "5.4.0",
-		},
-		Anywhere: AnywhereConfig{
-			LocationName: "custom-ludus-dev",
-			AWSProfile:   "default",
-		},
-		GameLift: GameLiftConfig{
-			FleetName:             "ludus-fleet",
-			InstanceType:          "c6i.large",
-			MaxConcurrentSessions: 1,
-			ContainerGroupName:    "ludus-container-group",
-		},
-		AWS: AWSConfig{
-			Region:        "us-east-1",
-			ECRRepository: "ludus-server",
-			Tags:          map[string]string{"ManagedBy": "ludus"},
-		},
-		CI: CIConfig{
-			WorkflowPath: ".github/workflows/ludus-pipeline.yml",
-			RunnerDir:    "~/actions-runner",
-			RunnerLabels: []string{"self-hosted", "linux", "x64"},
-		},
-		DDC: DDCConfig{
-			Mode: "zen",
-		},
-		Observability: ObservabilityConfig{
-			Logs: LogsConfig{
-				// EnabledPtr nil → Enabled() returns true by default.
-				Dir:        ".ludus/logs",
-				RetainRuns: 20,
-			},
-		},
-		Privacy: PrivacyConfig{
-			MaskAccountID: true,
+		Engine:        defaultEngine(),
+		Game:          defaultGame(),
+		Container:     defaultContainer(),
+		Deploy:        DeployConfig{Target: "gamelift"},
+		EC2Fleet:      EC2FleetConfig{ServerSDKVersion: "5.4.0"},
+		Anywhere:      defaultAnywhere(),
+		GameLift:      defaultGameLift(),
+		AWS:           defaultAWS(),
+		CI:            defaultCI(),
+		DDC:           DDCConfig{Mode: "zen"},
+		Observability: defaultObservability(),
+		Privacy:       PrivacyConfig{MaskAccountID: true},
+	}
+}
+
+func defaultEngine() EngineConfig {
+	return EngineConfig{
+		MaxJobs:         0,
+		Backend:         "native",
+		DockerImageName: "ludus-engine",
+		DockerBaseImage: "ubuntu:22.04",
+	}
+}
+
+func defaultGame() GameConfig {
+	return GameConfig{
+		ProjectName: "Lyra",
+		Platform:    "linux",
+		Arch:        "amd64",
+		ServerMap:   "L_Expanse",
+	}
+}
+
+func defaultContainer() ContainerConfig {
+	return ContainerConfig{
+		ImageName:  "ludus-server",
+		Tag:        "latest",
+		ServerPort: 7777,
+	}
+}
+
+func defaultAnywhere() AnywhereConfig {
+	return AnywhereConfig{
+		LocationName: "custom-ludus-dev",
+		AWSProfile:   "default",
+	}
+}
+
+func defaultGameLift() GameLiftConfig {
+	return GameLiftConfig{
+		FleetName:             "ludus-fleet",
+		InstanceType:          "c6i.large",
+		MaxConcurrentSessions: 1,
+		ContainerGroupName:    "ludus-container-group",
+	}
+}
+
+func defaultAWS() AWSConfig {
+	return AWSConfig{
+		Region:        "us-east-1",
+		ECRRepository: "ludus-server",
+		Tags:          map[string]string{"ManagedBy": "ludus"},
+	}
+}
+
+func defaultCI() CIConfig {
+	return CIConfig{
+		WorkflowPath: ".github/workflows/ludus-pipeline.yml",
+		RunnerDir:    "~/actions-runner",
+		RunnerLabels: []string{"self-hosted", "linux", "x64"},
+	}
+}
+
+func defaultObservability() ObservabilityConfig {
+	return ObservabilityConfig{
+		Logs: LogsConfig{
+			// EnabledPtr nil → Enabled() returns true by default.
+			Dir:        ".ludus/logs",
+			RetainRuns: 20,
 		},
 	}
 }

--- a/internal/container/builder_test.go
+++ b/internal/container/builder_test.go
@@ -46,68 +46,70 @@ func TestNewBuilder(t *testing.T) {
 	}
 }
 
-func TestGenerateDockerfile(t *testing.T) {
-	tests := []struct {
-		name        string
-		opts        BuildOptions
-		wantContain []string
-	}{
-		{
-			name: "amd64 defaults",
-			opts: BuildOptions{
-				ServerPort:  7777,
-				ProjectName: "Lyra",
-			},
-			wantContain: []string{
-				"FROM public.ecr.aws/amazonlinux/amazonlinux:2023",
-				"Lyra/Binaries/Linux/LyraServer",
-				"EXPOSE 7777/udp",
-				"USER ueserver",
-				"ENTRYPOINT [\"./amazon-gamelift-servers-game-server-wrapper\"]",
-			},
-		},
-		{
-			name: "arm64",
-			opts: BuildOptions{
-				ServerPort:   7777,
-				ProjectName:  "MyGame",
-				ServerTarget: "MyGameServer",
-				Arch:         "arm64",
-			},
-			wantContain: []string{
-				"MyGame/Binaries/LinuxArm64/MyGameServer",
-				"EXPOSE 7777/udp",
-			},
-		},
-		{
-			name: "custom port",
-			opts: BuildOptions{
-				ServerPort:  9999,
-				ProjectName: "Test",
-			},
-			wantContain: []string{
-				"EXPOSE 9999/udp",
-			},
-		},
-		{
-			// Real-world case that broke the live build: the .uproject name
-			// (packaged content dir), the project name, and the server target
-			// are all different. The Dockerfile must chmod the binary under the
-			// PACKAGED DIR name, not ProjectName.
-			name: "packaged dir differs from project name and target",
-			opts: BuildOptions{
-				ServerPort:      7777,
-				ProjectName:     "Lyra",
-				PackagedDirName: "LyraStarterGame6",
-				ServerTarget:    "LyraServer",
-			},
-			wantContain: []string{
-				"LyraStarterGame6/Binaries/Linux/LyraServer",
-			},
-		},
-	}
+type generateDockerfileCase struct {
+	name        string
+	opts        BuildOptions
+	wantContain []string
+}
 
-	for _, tt := range tests {
+var generateDockerfileCases = []generateDockerfileCase{
+	{
+		name: "amd64 defaults",
+		opts: BuildOptions{
+			ServerPort:  7777,
+			ProjectName: "Lyra",
+		},
+		wantContain: []string{
+			"FROM public.ecr.aws/amazonlinux/amazonlinux:2023",
+			"Lyra/Binaries/Linux/LyraServer",
+			"EXPOSE 7777/udp",
+			"USER ueserver",
+			"ENTRYPOINT [\"./amazon-gamelift-servers-game-server-wrapper\"]",
+		},
+	},
+	{
+		name: "arm64",
+		opts: BuildOptions{
+			ServerPort:   7777,
+			ProjectName:  "MyGame",
+			ServerTarget: "MyGameServer",
+			Arch:         "arm64",
+		},
+		wantContain: []string{
+			"MyGame/Binaries/LinuxArm64/MyGameServer",
+			"EXPOSE 7777/udp",
+		},
+	},
+	{
+		name: "custom port",
+		opts: BuildOptions{
+			ServerPort:  9999,
+			ProjectName: "Test",
+		},
+		wantContain: []string{
+			"EXPOSE 9999/udp",
+		},
+	},
+	{
+		// Real-world case that broke the live build: the .uproject name
+		// (packaged content dir), the project name, and the server target
+		// are all different. The Dockerfile must chmod the binary under the
+		// PACKAGED DIR name, not ProjectName.
+		name: "packaged dir differs from project name and target",
+		opts: BuildOptions{
+			ServerPort:      7777,
+			ProjectName:     "Lyra",
+			PackagedDirName: "LyraStarterGame6",
+			ServerTarget:    "LyraServer",
+		},
+		wantContain: []string{
+			"LyraStarterGame6/Binaries/Linux/LyraServer",
+		},
+	},
+}
+
+func TestGenerateDockerfile(t *testing.T) {
+	for _, tt := range generateDockerfileCases {
 		t.Run(tt.name, func(t *testing.T) {
 			b := NewBuilder(tt.opts, nil)
 			dockerfile := b.GenerateDockerfile()


### PR DESCRIPTION
## What

Clears the three remaining Codacy/Lizard complexity findings (all Warning, all behavior-preserving):

| File | Function | Metric | Before | After | Limit |
|------|----------|--------|--------|-------|-------|
| `internal/config/config_defaults.go` | `Defaults()` | NLOC | 59 | 16 | 50 |
| `internal/container/builder_test.go` | `TestGenerateDockerfile` | NLOC | 60 | 23 | 50 |
| `cmd/globals/ddc_test.go` | `TestResolveDDC` closure | CCN | 11 | 7 | 8 |

## How

- **`Defaults()`** — split the one large struct literal into per-section constructors (`defaultEngine`, `defaultGame`, `defaultContainer`, `defaultAnywhere`, `defaultGameLift`, `defaultAWS`, `defaultCI`, `defaultObservability`) composed in `Defaults()`.
- **`TestGenerateDockerfile`** — hoist the case table to a package-level `generateDockerfileCases` var. The 'packaged dir differs' regression case and its guard assertion are preserved intact.
- **`TestResolveDDC`** — extract the two guarded path assertions into an `assertOptionalEqual` helper, moving those branches out of the `t.Run` closure.

## Test plan

- [x] `go build -o ludus.exe -v .` passes
- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] gocyclo / direct NLOC measurement confirms all three under threshold

Follow-up to #375 (which cleared the 4th finding, `checkCrossArchEmulation`).