### PR TITLE
ci: add Codecov coverage upload (OIDC, informational gates)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,4 +92,7 @@ jobs:
         with:
           use_oidc: true
           files: ./coverage.out
-          fail_ci_if_error: true
+          # false: this step runs inside the required Test (ubuntu-latest) check,
+          # so a Codecov/OIDC/network outage must NOT fail the test leg and block
+          # merges. Coverage is informational; infra flakiness shouldn't gate PRs.
+          fail_ci_if_error: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
+      id-token: write   # OIDC: lets the Linux leg mint a short-lived Codecov upload token
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c  # v6
@@ -81,3 +84,12 @@ jobs:
       - name: Display coverage summary
         if: runner.os == 'Linux'
         run: go tool cover -func=coverage.out
+      - name: Upload coverage to Codecov
+        # Linux leg only (it produces coverage.out); skip forks (OIDC tokens
+        # aren't issued to forked-repo runs).
+        if: runner.os == 'Linux' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
+        with:
+          use_oidc: true
+          files: ./coverage.out
+          fail_ci_if_error: true

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,48 @@
+# Codecov configuration. See https://docs.codecov.com/docs/codecov-yaml
+#
+# Coverage is uploaded from the Linux test leg via OIDC (no stored CODECOV_TOKEN).
+#
+# Soft target: 80%. Both gates are `informational: true` for now — they post a
+# status and PR comment but NEVER block a merge. Flip informational to false to
+# enforce once coverage is at/above target.
+coverage:
+  status:
+    project:
+      default:
+        target: 80%
+        threshold: 1%       # tolerate <=1% drift
+        informational: true # report only; do not block
+    patch:
+      default:
+        target: 80%         # new/changed lines should be >=80% covered
+        informational: true # report only; do not block
+
+# Virtual coverage groupings by path — no upload changes required. Lets the
+# dashboard and PR comment break coverage down by architectural layer.
+component_management:
+  default_rules:
+    statuses:
+      - type: project
+        target: 80%
+        threshold: 1%
+        informational: true
+  individual_components:
+    - component_id: cmd
+      name: cmd (CLI layer)
+      paths:
+        - cmd/**
+    - component_id: internal
+      name: internal (core)
+      paths:
+        - internal/**
+
+comment:
+  layout: "reach, diff, flags, components, files"
+  behavior: default
+  require_changes: false
+
+# Paths excluded from coverage math.
+ignore:
+  - "**/*_test.go"
+  - "**/testdata/**"
+  - "internal/wrapper/**"   # separate PID-1 binary compiled into the container; E2E-covered


### PR DESCRIPTION
## What

Wires the repo into Codecov to track our coverage campaign toward the **80% soft target**.

- Uploads the existing `coverage.out` (already produced by the Linux test leg) to Codecov.
- **OIDC trusted publishing** — no `CODECOV_TOKEN` secret stored anywhere.
- `codecov.yml`: 80% target for **project + patch + components** (cmd / internal), all `informational: true` — they post a status + PR comment but **never block a merge**. We flip `informational: false` to enforce once coverage reaches target.

## Safety / correctness

- Upload runs on the **Linux leg only** (the one that generates the profile) — avoids ingesting the report 3× from the OS matrix.
- **Fork-guarded**: skipped on forked-repo PRs, where OIDC tokens aren't issued (otherwise `fail_ci_if_error: true` would fail a fork's CI after green tests).
- `id-token: write` scoped to the test job only; workflow default stays `contents: read`.
- `codecov/codecov-action` pinned by commit SHA (`fb8b358` = v7.0.0) to match the repo's existing SHA-pinning convention.
- `codecov.yml` validated against `https://codecov.io/validate` → `Valid!`

## Note

This is the setup PR for the coverage campaign. Public repo, so tokenless would also work, but OIDC is preferred (nothing at rest). Test Analytics (JUnit upload) is a deliberate easy follow-up, not included here.

## Test plan

- [x] `codecov.yml` validates (`Valid!`)
- [x] Action resolved + SHA-pinned with `# v7.0.0` comment
- [ ] CI green; the "Upload coverage to Codecov" step concludes **success** (OIDC token minted) on this PR's own run
- [ ] `codecov/project` + `codecov/patch` statuses post on the PR (as informational)