### PR TITLE
test: cover container copyFile + dry-run staging (51% -> 61%)

### DIFF
--- a/internal/container/builder_logic_test.go
+++ b/internal/container/builder_logic_test.go
@@ -34,12 +34,17 @@ func testCopyFileSuccess(t *testing.T) {
 		t.Errorf("content = %q, want %q", got, "hello wrapper")
 	}
 	// Mode preservation is meaningful on Unix; Windows reports 0666/0777.
-	if runtime.GOOS == "windows" {
-		return
+	if runtime.GOOS != "windows" {
+		assertSameMode(t, src, dst)
 	}
-	// Compare to the source's ACTUAL mode, not a literal: os.WriteFile is subject
-	// to the process umask, so 0o755 may land as 0o750/0o700. copyFile's contract
-	// is "preserve the source mode", so that's what we assert.
+}
+
+// assertSameMode checks that dst has the same permission bits as src. copyFile's
+// contract is "preserve the source mode", and os.WriteFile is subject to the
+// process umask (a 0o755 request can land as 0o750/0o700), so we compare to the
+// source's actual stat mode rather than a hardcoded literal.
+func assertSameMode(t *testing.T, src, dst string) {
+	t.Helper()
 	srcInfo, err := os.Stat(src)
 	if err != nil {
 		t.Fatal(err)

--- a/internal/container/builder_logic_test.go
+++ b/internal/container/builder_logic_test.go
@@ -37,12 +37,19 @@ func testCopyFileSuccess(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		return
 	}
-	info, err := os.Stat(dst)
+	// Compare to the source's ACTUAL mode, not a literal: os.WriteFile is subject
+	// to the process umask, so 0o755 may land as 0o750/0o700. copyFile's contract
+	// is "preserve the source mode", so that's what we assert.
+	srcInfo, err := os.Stat(src)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if info.Mode().Perm() != 0o755 {
-		t.Errorf("dst mode = %v, want 0755", info.Mode().Perm())
+	dstInfo, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if dstInfo.Mode().Perm() != srcInfo.Mode().Perm() {
+		t.Errorf("dst mode = %v, want %v (source mode)", dstInfo.Mode().Perm(), srcInfo.Mode().Perm())
 	}
 }
 

--- a/internal/container/builder_logic_test.go
+++ b/internal/container/builder_logic_test.go
@@ -1,0 +1,92 @@
+package container
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+)
+
+func TestCopyFile(t *testing.T) {
+	t.Run("copies content and preserves mode", testCopyFileSuccess)
+	t.Run("missing source errors", testCopyFileMissingSource)
+	t.Run("unwritable destination errors", testCopyFileBadDest)
+}
+
+func testCopyFileSuccess(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	dst := filepath.Join(dir, "dst.bin")
+	if err := os.WriteFile(src, []byte("hello wrapper"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(src, dst); err != nil {
+		t.Fatalf("copyFile error: %v", err)
+	}
+	got, err := os.ReadFile(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != "hello wrapper" {
+		t.Errorf("content = %q, want %q", got, "hello wrapper")
+	}
+	// Mode preservation is meaningful on Unix; Windows reports 0666/0777.
+	if runtime.GOOS == "windows" {
+		return
+	}
+	info, err := os.Stat(dst)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if info.Mode().Perm() != 0o755 {
+		t.Errorf("dst mode = %v, want 0755", info.Mode().Perm())
+	}
+}
+
+func testCopyFileMissingSource(t *testing.T) {
+	dir := t.TempDir()
+	if err := copyFile(filepath.Join(dir, "nope.bin"), filepath.Join(dir, "out.bin")); err == nil {
+		t.Error("expected error for missing source")
+	}
+}
+
+func testCopyFileBadDest(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "src.bin")
+	if err := os.WriteFile(src, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	// A destination path whose parent is a file (not a dir) cannot be created.
+	badDst := filepath.Join(src, "child.bin")
+	if err := copyFile(src, badDst); err == nil {
+		t.Error("expected error when destination cannot be created")
+	}
+}
+
+func TestGenerateAndWriteDockerfile_DryRunIsNoop(t *testing.T) {
+	dir := t.TempDir()
+	b := NewBuilder(BuildOptions{
+		ServerBuildDir: dir,
+		ImageName:      "ludus-server",
+		Tag:            "latest",
+		ServerPort:     7777,
+		ProjectName:    "Lyra",
+	}, runner.NewRunner(false, true)) // dry-run
+
+	cleanup, err := b.generateAndWriteDockerfile(context.Background())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	cleanup() // must be safe to call
+
+	// In dry-run, nothing should be staged into the build dir.
+	for _, f := range []string{"Dockerfile", ".dockerignore", "config.yaml",
+		"amazon-gamelift-servers-game-server-wrapper"} {
+		if _, statErr := os.Stat(filepath.Join(dir, f)); statErr == nil {
+			t.Errorf("dry-run should not have written %s", f)
+		}
+	}
+}


### PR DESCRIPTION
## What

Coverage campaign, package 4/N. `internal/container`: **50.8% → 60.8%**.

## What's covered

- **`copyFile`** (was 0%): content copy + Unix mode preservation, missing-source error, uncreatable-destination error.
- **`generateAndWriteDockerfile`** dry-run branch: confirms the noop path stages nothing into the build dir and the returned cleanup is safe to call.

`TestCopyFile`'s subtests are extracted into named helpers to keep it under the Codacy Lizard CCN limit (the same structural-noise check that flagged #381).

## Scope note

The rest of the file (`Build`, `runDockerBuild`, `Push`, `ensureWrapper`, `checkContainerPlatformSupport`) shells out to Docker/buildx/ECR and is E2E-covered; `Build`/`runDockerBuild` dry-run paths were already covered by existing tests.

## Test plan

- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] gocyclo: no test fn over CCN 8
- [x] Test-only
- [ ] CI green; Codecov + Codacy pass