### PR TITLE
test: cover deploy target adapters (anywhere/stack/ec2)

### DIFF
--- a/internal/anywhere/adapter_test.go
+++ b/internal/anywhere/adapter_test.go
@@ -1,0 +1,29 @@
+package anywhere
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+)
+
+func TestTargetAdapter(t *testing.T) {
+	d := NewDeployer(DeployOptions{FleetName: "f"}, aws.Config{}, runner.NewRunner(false, true))
+	a := NewTargetAdapter(d)
+
+	if a.Name() != "anywhere" {
+		t.Errorf("Name() = %q, want anywhere", a.Name())
+	}
+	if a.Deployer() != d {
+		t.Error("Deployer() did not return the wrapped deployer")
+	}
+
+	caps := a.Capabilities()
+	if caps.NeedsContainerBuild || caps.NeedsContainerPush {
+		t.Error("anywhere should not need container build/push")
+	}
+	if !caps.SupportsSession || !caps.SupportsDeploy || !caps.SupportsDestroy {
+		t.Errorf("anywhere should support session/deploy/destroy, got %+v", caps)
+	}
+}

--- a/internal/ec2fleet/adapter_test.go
+++ b/internal/ec2fleet/adapter_test.go
@@ -1,0 +1,29 @@
+package ec2fleet
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+)
+
+func TestTargetAdapter(t *testing.T) {
+	d := NewDeployer(DeployOptions{FleetName: "f"}, aws.Config{}, runner.NewRunner(false, true))
+	a := NewTargetAdapter(d)
+
+	if a.Name() != "ec2" {
+		t.Errorf("Name() = %q, want ec2", a.Name())
+	}
+	if a.Deployer() != d {
+		t.Error("Deployer() did not return the wrapped deployer")
+	}
+
+	caps := a.Capabilities()
+	if caps.NeedsContainerBuild || caps.NeedsContainerPush {
+		t.Error("ec2 should not need container build/push")
+	}
+	if !caps.SupportsSession || !caps.SupportsDeploy || !caps.SupportsDestroy {
+		t.Errorf("ec2 should support session/deploy/destroy, got %+v", caps)
+	}
+}

--- a/internal/stack/adapter_test.go
+++ b/internal/stack/adapter_test.go
@@ -1,0 +1,27 @@
+package stack
+
+import (
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+)
+
+func TestTargetAdapter(t *testing.T) {
+	d := NewStackDeployer(StackOptions{FleetName: "f"}, aws.Config{})
+	a := NewTargetAdapter(d)
+
+	if a.Name() != "stack" {
+		t.Errorf("Name() = %q, want stack", a.Name())
+	}
+	if a.Deployer() != d {
+		t.Error("Deployer() did not return the wrapped deployer")
+	}
+
+	caps := a.Capabilities()
+	if !caps.NeedsContainerBuild || !caps.NeedsContainerPush {
+		t.Error("stack should need container build/push")
+	}
+	if !caps.SupportsSession || !caps.SupportsDeploy || !caps.SupportsDestroy {
+		t.Errorf("stack should support session/deploy/destroy, got %+v", caps)
+	}
+}


### PR DESCRIPTION
## What

Coverage campaign, package 5/N. Adapter tests for the three deploy targets that had no adapter coverage.

- `internal/anywhere`: 8.7% → 10.8%
- `internal/stack`: 14.5% → 17.4%
- `internal/ec2fleet`: 0.9% → 2.3%

## Approach

Each adapter test constructs a deployer with a zero `aws.Config` — `gamelift/cloudformation.NewFromConfig` just stores the client without making any API call — wraps it in the `TargetAdapter`, and asserts the pure adapter surface:
- `Name()` returns the expected target name
- `Deployer()` round-trips the wrapped deployer
- `Capabilities()` flags are correct (e.g. stack needs container build/push, anywhere/ec2 don't; all support session/deploy/destroy)

## Honest scope note

These three packages are dominated by AWS-calling deploy/session/destroy logic (GameLift, CloudFormation, EC2, S3) that isn't unit-testable without a mocking layer — they're E2E-covered. The adapters are the testable slice, so the absolute gains are modest but they're the right ones to take here.

## Test plan

- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] gocyclo: no test fn over CCN 8
- [x] Test-only
- [ ] CI green; Codecov + Codacy pass