### PR TITLE
test: cover ci configArgs + WriteWorkflow error path (17% -> 19%)

### DIFF
--- a/internal/ci/runner_logic_test.go
+++ b/internal/ci/runner_logic_test.go
@@ -1,0 +1,44 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestConfigArgs(t *testing.T) {
+	ri := &RunnerInstaller{
+		Repo:   "jpvelasco/ludus",
+		Labels: "self-hosted,linux,x64",
+		Name:   "ludus-runner-1",
+	}
+	args := ri.configArgs("tok-abc123")
+	joined := strings.Join(args, " ")
+
+	for _, want := range []string{
+		"--url https://github.com/jpvelasco/ludus",
+		"--token tok-abc123",
+		"--labels self-hosted,linux,x64",
+		"--name ludus-runner-1",
+		"--unattended",
+		"--replace",
+	} {
+		if !strings.Contains(joined, want) {
+			t.Errorf("configArgs missing %q\ngot: %s", want, joined)
+		}
+	}
+}
+
+func TestWriteWorkflow_MkdirError(t *testing.T) {
+	// A path whose parent directory is actually a file cannot be created.
+	dir := t.TempDir()
+	fileAsParent := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(fileAsParent, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	target := filepath.Join(fileAsParent, "workflow", "ci.yml")
+	if err := WriteWorkflow(target, "name: CI\n"); err == nil {
+		t.Error("expected error when parent path is a file")
+	}
+}


### PR DESCRIPTION
## What

Coverage campaign, package 9/N. `internal/ci`: **17.2% → 18.8%**.

## What's covered

- **`configArgs`**: GitHub self-hosted runner registration flags (`--url`, `--token`, `--labels`, `--name`, `--unattended`, `--replace`) assembled correctly.
- **`WriteWorkflow`**: the `MkdirAll` error branch (parent path is a regular file).

## Honest scope note

Small gain by design — `internal/ci` is dominated by GitHub Actions **runner-install I/O** (`registrationToken`, `downloadRunner`, `extractRunner`, `configureRunner`, systemd `svc.sh`), all of which shell out or hit the network and are E2E-covered. `workflow.go` (the pure template generation) was already ~100% covered. `configArgs` was the one remaining pure helper worth locking in.

## Test plan

- [x] `go test ./...` — all pass
- [x] `golangci-lint run ./...` — 0 issues
- [x] gocyclo: no test fn over CCN 8
- [x] Test-only
- [ ] CI green; Codecov + Codacy pass