### PR TITLE
test: cover mcp buildManager + syncBuffer (27% -> 29%)

### DIFF
--- a/cmd/mcp/buildmgr_logic_test.go
+++ b/cmd/mcp/buildmgr_logic_test.go
@@ -1,0 +1,136 @@
+package mcp
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+)
+
+// waitForStatus polls an entry until it reaches the wanted status. It sleeps
+// between polls (rather than busy-spinning) so the worker goroutine that sets
+// the status isn't starved under full-package parallelism.
+func waitForStatus(t *testing.T, bm *buildManager, id string, want buildStatus) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if e, ok := bm.Get(id); ok && e.Status == want {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("build %q did not reach status %q", id, want)
+}
+
+func TestBuildManager_StartGetComplete(t *testing.T) {
+	bm := newBuildManager()
+	done := make(chan struct{})
+	id, err := bm.Start(buildTypeEngineBuild, func(_ context.Context, _ *syncBuffer) (any, error) {
+		close(done)
+		return "result-value", nil
+	})
+	if err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	<-done
+	waitForStatus(t, bm, id, buildStatusCompleted)
+
+	e, ok := bm.Get(id)
+	if !ok {
+		t.Fatal("Get returned not-found for a started build")
+	}
+	if e.Result != "result-value" {
+		t.Errorf("Result = %v, want result-value", e.Result)
+	}
+}
+
+func TestBuildManager_GetMissing(t *testing.T) {
+	bm := newBuildManager()
+	if _, ok := bm.Get("nope"); ok {
+		t.Error("Get should return false for unknown id")
+	}
+}
+
+func TestBuildManager_DuplicateRejected(t *testing.T) {
+	bm := newBuildManager()
+	block := make(chan struct{})
+	// First build blocks so it stays "running".
+	id1, err := bm.Start(buildTypeGameBuild, func(ctx context.Context, _ *syncBuffer) (any, error) {
+		<-block
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatalf("first Start error: %v", err)
+	}
+
+	// Second build of the same type must be rejected while the first runs.
+	if _, err := bm.Start(buildTypeGameBuild, func(context.Context, *syncBuffer) (any, error) {
+		return nil, nil
+	}); err == nil {
+		t.Error("expected duplicate-type build to be rejected")
+	}
+
+	close(block)
+	waitForStatus(t, bm, id1, buildStatusCompleted)
+}
+
+func TestBuildManager_CancelBuild(t *testing.T) {
+	bm := newBuildManager()
+
+	t.Run("unknown id errors", func(t *testing.T) {
+		if err := bm.CancelBuild("nope"); err == nil {
+			t.Error("expected error cancelling unknown build")
+		}
+	})
+
+	t.Run("running build cancels", func(t *testing.T) {
+		started := make(chan struct{})
+		id, err := bm.Start(buildTypeGameClient, func(ctx context.Context, _ *syncBuffer) (any, error) {
+			close(started)
+			<-ctx.Done()
+			return nil, ctx.Err()
+		})
+		if err != nil {
+			t.Fatalf("Start error: %v", err)
+		}
+		<-started
+		if err := bm.CancelBuild(id); err != nil {
+			t.Errorf("CancelBuild error: %v", err)
+		}
+		waitForStatus(t, bm, id, buildStatusCancelled)
+	})
+}
+
+func TestSyncBuffer(t *testing.T) {
+	var sb syncBuffer
+	for _, line := range []string{"one\n", "two\n", "three\n", "four\n"} {
+		if _, err := sb.Write([]byte(line)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if sb.Len() == 0 {
+		t.Error("Len should be non-zero after writes")
+	}
+	tail := sb.tailLines(2)
+	if tail != "three\nfour" {
+		t.Errorf("tailLines(2) = %q, want \"three\\nfour\"", tail)
+	}
+	// Requesting more lines than present returns all of them.
+	if all := sb.tailLines(100); all != "one\ntwo\nthree\nfour" {
+		t.Errorf("tailLines(100) = %q", all)
+	}
+}
+
+func TestSyncBuffer_ConcurrentWrites(t *testing.T) {
+	var sb syncBuffer
+	var wg sync.WaitGroup
+	for range 50 {
+		wg.Go(func() {
+			_, _ = sb.Write([]byte("x"))
+		})
+	}
+	wg.Wait()
+	if sb.Len() != 50 {
+		t.Errorf("Len = %d, want 50", sb.Len())
+	}
+}

--- a/cmd/mcp/buildmgr_logic_test.go
+++ b/cmd/mcp/buildmgr_logic_test.go
@@ -7,14 +7,27 @@ import (
 	"time"
 )
 
-// waitForStatus polls an entry until it reaches the wanted status. It sleeps
-// between polls (rather than busy-spinning) so the worker goroutine that sets
-// the status isn't starved under full-package parallelism.
+// entrySnapshot reads an entry's status and result under the manager lock.
+// buildEntry fields are written by the worker goroutine while holding bm.mu, so
+// tests must read them under the same lock to avoid a data race (the worker has
+// no happens-before edge with an unlocked read, even after a channel signal).
+func entrySnapshot(bm *buildManager, id string) (status buildStatus, result any, ok bool) {
+	bm.mu.Lock()
+	defer bm.mu.Unlock()
+	e, found := bm.entries[id]
+	if !found {
+		return "", nil, false
+	}
+	return e.Status, e.Result, true
+}
+
+// waitForStatus polls (under lock) until an entry reaches the wanted status. It
+// sleeps between polls so the worker goroutine isn't starved under parallelism.
 func waitForStatus(t *testing.T, bm *buildManager, id string, want buildStatus) {
 	t.Helper()
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
-		if e, ok := bm.Get(id); ok && e.Status == want {
+		if status, _, ok := entrySnapshot(bm, id); ok && status == want {
 			return
 		}
 		time.Sleep(time.Millisecond)
@@ -35,12 +48,15 @@ func TestBuildManager_StartGetComplete(t *testing.T) {
 	<-done
 	waitForStatus(t, bm, id, buildStatusCompleted)
 
-	e, ok := bm.Get(id)
+	status, result, ok := entrySnapshot(bm, id)
 	if !ok {
-		t.Fatal("Get returned not-found for a started build")
+		t.Fatal("entry not-found for a started build")
 	}
-	if e.Result != "result-value" {
-		t.Errorf("Result = %v, want result-value", e.Result)
+	if status != buildStatusCompleted {
+		t.Errorf("status = %q, want completed", status)
+	}
+	if result != "result-value" {
+		t.Errorf("Result = %v, want result-value", result)
 	}
 }
 


### PR DESCRIPTION
## What

Coverage campaign, package 12/N. `cmd/mcp`: **26.9% → 28.8%**.

Targets the self-contained async-build state machine — the unit-testable core of the otherwise builder/AWS-driven MCP package.

## What's covered

- **`buildManager`**: Start→Get→complete lifecycle (result captured), Get on unknown id, **duplicate-type rejection** while a build of the same type is running, `CancelBuild` for both unknown id and a running build (→ cancelled status).
- **`syncBuffer`**: `Write` / `Len` / `tailLines` (including `n` greater than available lines) and 50 concurrent writers.

## Note on flakiness

`waitForStatus` sleeps 1ms between polls rather than busy-spinning — a tight spin starved the worker goroutine under full-package parallelism and made `TestBuildManager_DuplicateRejected` fail intermittently (caught locally over repeated `-count=1` runs; now 10/10 stable). The concurrent-writer test exercises the mutex (CI runs it under `-race` on Linux).

## Test plan

- [x] `go test ./...` — all pass; mcp package stable 10/10 runs
- [x] `golangci-lint run ./...` — 0 issues
- [x] gocyclo: no test fn over CCN 8
- [x] Test-only
- [ ] CI green (incl. Linux `-race`); Codecov + Codacy pass