### PR TITLE
fix(anywhere): wrapper config + liveness + make prereq (#392, #393)

### DIFF
--- a/cmd/deploy/deploy_anywhere.go
+++ b/cmd/deploy/deploy_anywhere.go
@@ -2,6 +2,7 @@ package deploy
 
 import (
 	"fmt"
+	"runtime"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
 	"github.com/jpvelasco/ludus/internal/config"
@@ -48,6 +49,11 @@ func runAnywhere(cmd *cobra.Command, args []string) error {
 
 	checker := prereq.NewChecker(cfg.Engine.SourcePath, cfg.Engine.Version, false, &cfg.Game)
 	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {
+		return err
+	}
+	// The Anywhere deploy builds the GameLift wrapper for this host (runtime
+	// GOOS/GOARCH). Fail fast if a required build tool (make) is missing.
+	if err := prereq.Validate(checker.CheckWrapperBuildReady(runtime.GOOS, runtime.GOARCH)); err != nil {
 		return err
 	}
 

--- a/cmd/deploy/deploy_ec2.go
+++ b/cmd/deploy/deploy_ec2.go
@@ -56,6 +56,11 @@ func runEC2(cmd *cobra.Command, args []string) error {
 	if err := prereq.Validate(checker.CheckAWSReady()); err != nil {
 		return err
 	}
+	// The EC2 deploy builds the GameLift wrapper for linux/<arch>. Fail fast if
+	// a required build tool (make) is missing.
+	if err := prereq.Validate(checker.CheckWrapperBuildReady("linux", cfg.Game.ResolvedArch())); err != nil {
+		return err
+	}
 
 	target, err := globals.ResolveTarget(cmd.Context(), &cfg, "ec2")
 	if err != nil {

--- a/internal/anywhere/adapter.go
+++ b/internal/anywhere/adapter.go
@@ -83,7 +83,7 @@ func (a *TargetAdapter) createResources(ctx context.Context) (*anywhereResources
 	}
 
 	fmt.Printf("Creating custom location %s...\n", opts.LocationName)
-	locationARN, err := d.CreateLocation(ctx)
+	locationARN, locationCreated, err := d.CreateLocation(ctx)
 	if err != nil {
 		return nil, err
 	}
@@ -97,11 +97,17 @@ func (a *TargetAdapter) createResources(ctx context.Context) (*anywhereResources
 	fmt.Println("Launching game server...")
 	pid, err := d.LaunchServer(ctx, wrapperBinary, fleetARN, locationARN, ipAddress)
 	if err != nil {
-		// The location, fleet, and compute already exist but no state has been
-		// saved yet, so `deploy destroy` could not find them. Roll them back so
-		// a failed launch does not orphan GameLift resources.
+		// The fleet and compute already exist but no state has been saved yet, so
+		// `deploy destroy` could not find them. Roll them back so a failed launch
+		// does not orphan GameLift resources. Only delete the location if THIS
+		// call created it — CreateLocation reuses a pre-existing location on
+		// conflict, and we must not delete one we did not create.
 		fmt.Println("Launch failed; rolling back Anywhere resources...")
-		if derr := d.Destroy(ctx, fleetID, computeName, opts.LocationName, 0); derr != nil {
+		rollbackLocation := ""
+		if locationCreated {
+			rollbackLocation = opts.LocationName
+		}
+		if derr := d.Destroy(ctx, fleetID, computeName, rollbackLocation, 0); derr != nil {
 			fmt.Printf("Warning: rollback incomplete: %v\n", derr)
 		}
 		return nil, fmt.Errorf("launching server: %w", err)

--- a/internal/anywhere/adapter.go
+++ b/internal/anywhere/adapter.go
@@ -97,6 +97,13 @@ func (a *TargetAdapter) createResources(ctx context.Context) (*anywhereResources
 	fmt.Println("Launching game server...")
 	pid, err := d.LaunchServer(ctx, wrapperBinary, fleetARN, locationARN, ipAddress)
 	if err != nil {
+		// The location, fleet, and compute already exist but no state has been
+		// saved yet, so `deploy destroy` could not find them. Roll them back so
+		// a failed launch does not orphan GameLift resources.
+		fmt.Println("Launch failed; rolling back Anywhere resources...")
+		if derr := d.Destroy(ctx, fleetID, computeName, opts.LocationName, 0); derr != nil {
+			fmt.Printf("Warning: rollback incomplete: %v\n", derr)
+		}
 		return nil, fmt.Errorf("launching server: %w", err)
 	}
 	if pid > 0 {

--- a/internal/anywhere/deployer.go
+++ b/internal/anywhere/deployer.go
@@ -71,8 +71,10 @@ func (d *Deployer) resourceTags() map[string]string {
 }
 
 // CreateLocation creates a custom GameLift location, tolerating conflicts
-// (location already exists).
-func (d *Deployer) CreateLocation(ctx context.Context) (string, error) {
+// (location already exists). The returned created flag reports whether this call
+// actually created the location (false when an existing one was reused), so
+// callers can avoid deleting a location they did not create during rollback.
+func (d *Deployer) CreateLocation(ctx context.Context) (locationARN string, created bool, err error) {
 	loc := d.opts.LocationName
 	if !strings.HasPrefix(loc, "custom-") {
 		loc = "custom-" + loc
@@ -86,13 +88,12 @@ func (d *Deployer) CreateLocation(ctx context.Context) (string, error) {
 		// Tolerate ConflictException (location already exists)
 		if awsutil.IsConflict(err) {
 			fmt.Printf("  Location %s already exists, reusing.\n", loc)
-			return fmt.Sprintf("arn:aws:gamelift:%s::location/%s", d.opts.Region, loc), nil
+			return fmt.Sprintf("arn:aws:gamelift:%s::location/%s", d.opts.Region, loc), false, nil
 		}
-		return "", fmt.Errorf("creating location: %w", err)
+		return "", false, fmt.Errorf("creating location: %w", err)
 	}
 
-	locationARN := aws.ToString(out.Location.LocationArn)
-	return locationARN, nil
+	return aws.ToString(out.Location.LocationArn), true, nil
 }
 
 // CreateFleet creates a GameLift Anywhere fleet and returns the fleet ID and ARN.

--- a/internal/anywhere/deployer.go
+++ b/internal/anywhere/deployer.go
@@ -239,11 +239,11 @@ func (d *Deployer) LaunchServer(ctx context.Context, wrapperBinary, fleetARN, lo
 	}
 
 	if d.Runner.DryRun {
-		fmt.Printf("+ %s (would launch wrapper from %s)\n", wrapperBinary, configDir)
+		fmt.Printf("+ %s -c %s (would launch wrapper)\n", wrapperBinary, configPath)
 		return 0, nil
 	}
 
-	return launchProcess(wrapperBinary, configDir)
+	return launchProcess(wrapperBinary, configDir, configPath)
 }
 
 // CreateGameSession creates a game session on the Anywhere fleet.

--- a/internal/anywhere/process_unix.go
+++ b/internal/anywhere/process_unix.go
@@ -10,9 +10,18 @@ import (
 	"time"
 )
 
+// launchLivenessWait is how long launchProcess waits after starting the wrapper
+// to confirm it stayed alive. The wrapper fails fast when it cannot load its
+// config or find the game-server binary (well under a second), so this window
+// catches an immediate exit without stalling a healthy launch.
+const launchLivenessWait = 1500 * time.Millisecond
+
 // launchProcess starts the wrapper binary as a detached background process.
-func launchProcess(binary, workDir string) (int, error) {
-	cmd := exec.Command(binary)
+// configPath is passed explicitly via the wrapper's -c flag rather than relying
+// on the working directory: the wrapper chdir's to its own embedded output
+// directory on startup and would otherwise read the stock sample config there.
+func launchProcess(binary, workDir, configPath string) (int, error) {
+	cmd := exec.Command(binary, "-c", configPath)
 	cmd.Dir = workDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -24,6 +33,16 @@ func launchProcess(binary, workDir string) (int, error) {
 	}
 
 	pid := cmd.Process.Pid
+
+	// Confirm the wrapper stayed alive. A misconfigured wrapper exits almost
+	// immediately; without this check we would report a dead server as "started".
+	time.Sleep(launchLivenessWait)
+	if !processAlive(cmd.Process) {
+		// Reap the exited child to avoid leaving a zombie.
+		_, _ = cmd.Process.Wait()
+		return pid, fmt.Errorf("wrapper process exited immediately after start "+
+			"(PID %d); check the wrapper log above for the cause (e.g. missing game-server binary or bad config)", pid)
+	}
 
 	// Release the process so it continues after we return
 	if err := cmd.Process.Release(); err != nil {

--- a/internal/anywhere/process_unix.go
+++ b/internal/anywhere/process_unix.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"syscall"
 	"time"
 )
@@ -20,11 +21,24 @@ const launchLivenessWait = 1500 * time.Millisecond
 // configPath is passed explicitly via the wrapper's -c flag rather than relying
 // on the working directory: the wrapper chdir's to its own embedded output
 // directory on startup and would otherwise read the stock sample config there.
+//
+// The wrapper's stdout/stderr are redirected to a log file under workDir rather
+// than inherited from this process. The wrapper is a long-lived background
+// server; inheriting os.Stdout/os.Stderr would keep their write ends open for
+// the server's lifetime, which deadlocks callers that capture output via a pipe
+// and wait for EOF (e.g. the MCP server's withCapture around deploy_anywhere).
 func launchProcess(binary, workDir, configPath string) (int, error) {
+	logPath := filepath.Join(workDir, "server.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return 0, fmt.Errorf("creating wrapper log %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+
 	cmd := exec.Command(binary, "-c", configPath)
 	cmd.Dir = workDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 	// Detach process so it survives after ludus exits
 	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
 
@@ -51,7 +65,7 @@ func launchProcess(binary, workDir, configPath string) (int, error) {
 	select {
 	case <-exited:
 		return pid, fmt.Errorf("wrapper process exited immediately after start "+
-			"(PID %d); check the wrapper log above for the cause (e.g. missing game-server binary or bad config)", pid)
+			"(PID %d); see %s for the cause (e.g. missing game-server binary or bad config)", pid, logPath)
 	case <-time.After(launchLivenessWait):
 		return pid, nil
 	}

--- a/internal/anywhere/process_unix.go
+++ b/internal/anywhere/process_unix.go
@@ -35,21 +35,26 @@ func launchProcess(binary, workDir, configPath string) (int, error) {
 	pid := cmd.Process.Pid
 
 	// Confirm the wrapper stayed alive. A misconfigured wrapper exits almost
-	// immediately; without this check we would report a dead server as "started".
-	time.Sleep(launchLivenessWait)
-	if !processAlive(cmd.Process) {
-		// Reap the exited child to avoid leaving a zombie.
-		_, _ = cmd.Process.Wait()
+	// immediately; without this check we would report a dead server as
+	// "started". We detect an early exit by reaping via cmd.Wait() in a
+	// goroutine and racing it against the liveness window — a signal(0) probe is
+	// not enough because an exited-but-unreaped child becomes a zombie that
+	// still answers signal(0) as "alive". On timeout the wrapper is healthy; we
+	// leave it running (detached via Setpgid, reparented to init once ludus
+	// exits) and abandon the waiter goroutine.
+	exited := make(chan struct{})
+	go func() {
+		_ = cmd.Wait()
+		close(exited)
+	}()
+
+	select {
+	case <-exited:
 		return pid, fmt.Errorf("wrapper process exited immediately after start "+
 			"(PID %d); check the wrapper log above for the cause (e.g. missing game-server binary or bad config)", pid)
+	case <-time.After(launchLivenessWait):
+		return pid, nil
 	}
-
-	// Release the process so it continues after we return
-	if err := cmd.Process.Release(); err != nil {
-		return pid, fmt.Errorf("releasing wrapper process: %w", err)
-	}
-
-	return pid, nil
 }
 
 // StopServer stops a running wrapper process by PID.

--- a/internal/anywhere/process_unix_test.go
+++ b/internal/anywhere/process_unix_test.go
@@ -1,0 +1,54 @@
+//go:build !windows
+
+package anywhere
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeScript writes an executable shell script and returns its path.
+func writeScript(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "fake-wrapper.sh")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o755); err != nil {
+		t.Fatalf("writing script: %v", err)
+	}
+	return path
+}
+
+func TestLaunchProcess_ImmediateExitReportsError(t *testing.T) {
+	// A wrapper that exits immediately (e.g. bad config / missing binary) must
+	// surface as an error rather than a false-positive "started".
+	bin := writeScript(t, "exit 1")
+
+	pid, err := launchProcess(bin, t.TempDir(), "/nonexistent/config.yaml")
+	if err == nil {
+		t.Fatalf("launchProcess: expected error for immediately-exiting wrapper, got nil (pid=%d)", pid)
+	}
+	if IsProcessAlive(pid) {
+		t.Errorf("launchProcess: process %d still alive after immediate exit", pid)
+	}
+}
+
+func TestLaunchProcess_StaysAliveSucceeds(t *testing.T) {
+	// A wrapper that stays alive past the liveness window must be reported as
+	// started, with a live PID. Sleep comfortably longer than launchLivenessWait.
+	bin := writeScript(t, "sleep 30")
+
+	pid, err := launchProcess(bin, t.TempDir(), "/some/config.yaml")
+	if err != nil {
+		t.Fatalf("launchProcess: unexpected error for long-lived wrapper: %v", err)
+	}
+	if pid <= 0 {
+		t.Fatalf("launchProcess: expected positive pid, got %d", pid)
+	}
+	if !IsProcessAlive(pid) {
+		t.Errorf("launchProcess: process %d should be alive", pid)
+	}
+	// Clean up the detached process.
+	if err := StopServer(pid); err != nil {
+		t.Logf("cleanup StopServer(%d): %v", pid, err)
+	}
+}

--- a/internal/anywhere/process_windows.go
+++ b/internal/anywhere/process_windows.go
@@ -9,8 +9,13 @@ import (
 )
 
 // launchProcess starts the wrapper binary as a background process on Windows.
-func launchProcess(binary, workDir string) (int, error) {
-	cmd := exec.Command(binary)
+// configPath is passed via the wrapper's -c flag rather than relying on the
+// working directory (see the unix implementation for the rationale). Windows
+// cannot reliably probe process liveness with only the stdlib, so this path
+// does not perform the post-start liveness check; Anywhere is primarily a Linux
+// feature and callers fall back to fleet status.
+func launchProcess(binary, workDir, configPath string) (int, error) {
+	cmd := exec.Command(binary, "-c", configPath)
 	cmd.Dir = workDir
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/anywhere/process_windows.go
+++ b/internal/anywhere/process_windows.go
@@ -6,19 +6,30 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 )
 
 // launchProcess starts the wrapper binary as a background process on Windows.
 // configPath is passed via the wrapper's -c flag rather than relying on the
-// working directory (see the unix implementation for the rationale). Windows
-// cannot reliably probe process liveness with only the stdlib, so this path
-// does not perform the post-start liveness check; Anywhere is primarily a Linux
-// feature and callers fall back to fleet status.
+// working directory (see the unix implementation for the rationale). The
+// wrapper's output is redirected to a log file under workDir rather than
+// inherited, so a long-lived server does not hold a captured stdout/stderr pipe
+// open (see the unix implementation). Windows cannot reliably probe process
+// liveness with only the stdlib, so this path does not perform the post-start
+// liveness check; Anywhere is primarily a Linux feature and callers fall back
+// to fleet status.
 func launchProcess(binary, workDir, configPath string) (int, error) {
+	logPath := filepath.Join(workDir, "server.log")
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o600)
+	if err != nil {
+		return 0, fmt.Errorf("creating wrapper log %s: %w", logPath, err)
+	}
+	defer logFile.Close()
+
 	cmd := exec.Command(binary, "-c", configPath)
 	cmd.Dir = workDir
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
 
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("starting wrapper process: %w", err)

--- a/internal/prereq/checker.go
+++ b/internal/prereq/checker.go
@@ -107,6 +107,7 @@ func (c *Checker) RunAll() []CheckResult {
 	results = append(results, c.checkCommand("git", "Git"))
 	results = append(results, c.checkCommand("go", "Go compiler"))
 	results = append(results, c.checkGoVersion())
+	results = append(results, c.checkMakeForWrapper(runtime.GOOS, runtime.GOARCH))
 	results = append(results, c.platformChecks()...)
 	results = append(results, c.checkDiskSpace())
 	results = append(results, c.checkMemory())

--- a/internal/prereq/checker_make.go
+++ b/internal/prereq/checker_make.go
@@ -1,0 +1,38 @@
+package prereq
+
+import (
+	"os/exec"
+
+	"github.com/jpvelasco/ludus/internal/wrapper"
+)
+
+// checkMakeForWrapper verifies that `make` is installed when building the
+// GameLift server wrapper for the given target requires it. The wrapper's
+// native linux/amd64 build shells out to `make build`; every other target
+// cross-compiles with `go build` and needs no make. This mirrors checkGoVersion
+// (a hard failure when the required tool is absent) so a missing make fails
+// fast at readiness time instead of deep inside `deploy anywhere`/`ec2` with a
+// raw `exec: "make": executable file not found in $PATH`.
+func (c *Checker) checkMakeForWrapper(targetOS, arch string) CheckResult {
+	const name = "make"
+
+	if !wrapper.UsesMake(targetOS, arch) {
+		return CheckResult{Name: name, Passed: true, Message: "skipped — only required for native linux/amd64 wrapper build"}
+	}
+
+	if _, err := exec.LookPath("make"); err != nil {
+		return CheckResult{Name: name, Passed: false,
+			Message: "make not found in PATH; the GameLift wrapper build needs it — install build-essential (Debian/Ubuntu), make (Fedora/RHEL), or the equivalent for your distro"}
+	}
+
+	return CheckResult{Name: name, Passed: true, Message: "make found"}
+}
+
+// CheckWrapperBuildReady validates host prerequisites for deploy targets that
+// build the GameLift server wrapper from source (anywhere, ec2). targetOS/arch
+// are the wrapper build target. Currently this is the make check (needed only
+// for the native linux/amd64 path); the Go toolchain is validated separately at
+// init via RunAll.
+func (c *Checker) CheckWrapperBuildReady(targetOS, arch string) []CheckResult {
+	return []CheckResult{c.checkMakeForWrapper(targetOS, arch)}
+}

--- a/internal/prereq/checker_make.go
+++ b/internal/prereq/checker_make.go
@@ -20,6 +20,12 @@ func (c *Checker) checkMakeForWrapper(targetOS, arch string) CheckResult {
 		return CheckResult{Name: name, Passed: true, Message: "skipped — only required for native linux/amd64 wrapper build"}
 	}
 
+	// A prebuilt wrapper binary in the cache means EnsureBinary returns before
+	// invoking make, so make is not actually needed on this run.
+	if wrapper.IsBinaryCached(targetOS, arch) {
+		return CheckResult{Name: name, Passed: true, Message: "skipped — wrapper binary already cached (no build needed)"}
+	}
+
 	if _, err := exec.LookPath("make"); err != nil {
 		return CheckResult{Name: name, Passed: false,
 			Message: "make not found in PATH; the GameLift wrapper build needs it — install build-essential (Debian/Ubuntu), make (Fedora/RHEL), or the equivalent for your distro"}

--- a/internal/prereq/checker_make_test.go
+++ b/internal/prereq/checker_make_test.go
@@ -4,6 +4,8 @@ import (
 	"os/exec"
 	"runtime"
 	"testing"
+
+	"github.com/jpvelasco/ludus/internal/wrapper"
 )
 
 func TestCheckMakeForWrapper_SkipsWhenMakeNotUsed(t *testing.T) {
@@ -36,11 +38,33 @@ func TestCheckMakeForWrapper_NativeLinuxAmd64(t *testing.T) {
 	}
 
 	res := (&Checker{}).checkMakeForWrapper("linux", "amd64")
+	// The check passes when make is on PATH, OR when a prebuilt wrapper binary is
+	// cached (no build needed, so make is irrelevant). It only fails when make is
+	// absent AND nothing is cached.
 	_, lookErr := exec.LookPath("make")
-	wantPass := lookErr == nil
+	wantPass := lookErr == nil || wrapper.IsBinaryCached("linux", "amd64")
 	if res.Passed != wantPass {
-		t.Errorf("checkMakeForWrapper(linux, amd64): passed=%v, want %v (make on PATH=%v): %s",
-			res.Passed, wantPass, wantPass, res.Message)
+		t.Errorf("checkMakeForWrapper(linux, amd64): passed=%v, want %v: %s",
+			res.Passed, wantPass, res.Message)
+	}
+}
+
+func TestCheckMakeForWrapper_SkipsWhenCached(t *testing.T) {
+	// On a native linux/amd64 host, a cached wrapper binary must make the check
+	// pass even if make were absent (EnsureBinary skips the build on a cache
+	// hit). We can't remove make from PATH here, so assert the skip message and
+	// pass when a binary happens to be cached; otherwise the branch is covered
+	// by the make-present path.
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("cache-skip branch only reachable on a linux/amd64 host")
+	}
+	if !wrapper.IsBinaryCached("linux", "amd64") {
+		t.Skip("no cached wrapper binary on this host; cache-skip branch not exercised")
+	}
+
+	res := (&Checker{}).checkMakeForWrapper("linux", "amd64")
+	if !res.Passed {
+		t.Errorf("checkMakeForWrapper with cached binary: want pass, got fail: %s", res.Message)
 	}
 }
 

--- a/internal/prereq/checker_make_test.go
+++ b/internal/prereq/checker_make_test.go
@@ -1,0 +1,56 @@
+package prereq
+
+import (
+	"os/exec"
+	"runtime"
+	"testing"
+)
+
+func TestCheckMakeForWrapper_SkipsWhenMakeNotUsed(t *testing.T) {
+	// Targets that cross-compile (never shell out to make) must skip the check
+	// and pass without a warning, regardless of host OS. linux/arm64 and
+	// windows/amd64 cross-compile; on a non-Linux host even linux/amd64 skips.
+	c := &Checker{}
+	cases := [][2]string{
+		{"linux", "arm64"},
+		{"windows", "amd64"},
+	}
+	if runtime.GOOS != "linux" {
+		cases = append(cases, [2]string{"linux", "amd64"})
+	}
+
+	for _, tc := range cases {
+		res := c.checkMakeForWrapper(tc[0], tc[1])
+		if !res.Passed || res.Warning {
+			t.Errorf("checkMakeForWrapper(%q, %q): want clean skip-pass, got passed=%v warning=%v msg=%q",
+				tc[0], tc[1], res.Passed, res.Warning, res.Message)
+		}
+	}
+}
+
+func TestCheckMakeForWrapper_NativeLinuxAmd64(t *testing.T) {
+	// The make check only does real work for a native linux/amd64 build on a
+	// Linux host; elsewhere UsesMake is false and the branch is unreachable.
+	if runtime.GOOS != "linux" || runtime.GOARCH != "amd64" {
+		t.Skip("native linux/amd64 make check only runs on a linux/amd64 host")
+	}
+
+	res := (&Checker{}).checkMakeForWrapper("linux", "amd64")
+	_, lookErr := exec.LookPath("make")
+	wantPass := lookErr == nil
+	if res.Passed != wantPass {
+		t.Errorf("checkMakeForWrapper(linux, amd64): passed=%v, want %v (make on PATH=%v): %s",
+			res.Passed, wantPass, wantPass, res.Message)
+	}
+}
+
+func TestCheckWrapperBuildReady_Composition(t *testing.T) {
+	// CheckWrapperBuildReady currently composes exactly the make check.
+	res := (&Checker{}).CheckWrapperBuildReady("linux", "arm64")
+	if len(res) != 1 {
+		t.Fatalf("CheckWrapperBuildReady: got %d results, want 1", len(res))
+	}
+	if res[0].Name != "make" {
+		t.Errorf("CheckWrapperBuildReady: result name = %q, want %q", res[0].Name, "make")
+	}
+}

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -112,11 +112,20 @@ func ensureSource(ctx context.Context, r *runner.Runner, cacheDir string) error 
 	return nil
 }
 
+// UsesMake reports whether building the wrapper for the given target OS/arch
+// shells out to `make` (the Makefile's native build target). This is the case
+// only for a native linux/amd64 build on a Linux host; every other combination
+// cross-compiles directly with `go build`. Prerequisite checks use this to
+// decide whether `make` is a required host tool.
+func UsesMake(targetOS, arch string) bool {
+	return runtime.GOOS == "linux" && targetOS == "linux" && arch == "amd64"
+}
+
 // buildWrapper builds the game server wrapper binary. On systems with make,
 // it delegates to `make build` for native linux/amd64. Otherwise it runs
 // the equivalent steps directly (cross-compilation or non-Linux targets).
 func buildWrapper(ctx context.Context, r *runner.Runner, cacheDir, targetOS, arch string) error {
-	if runtime.GOOS == "linux" && targetOS == "linux" && arch == "amd64" {
+	if UsesMake(targetOS, arch) {
 		return r.RunInDir(ctx, cacheDir, "make", "build")
 	}
 	return buildWrapperCross(ctx, r, cacheDir, targetOS, arch)

--- a/internal/wrapper/wrapper.go
+++ b/internal/wrapper/wrapper.go
@@ -121,6 +121,21 @@ func UsesMake(targetOS, arch string) bool {
 	return runtime.GOOS == "linux" && targetOS == "linux" && arch == "amd64"
 }
 
+// IsBinaryCached reports whether a prebuilt wrapper binary for the given target
+// already exists in the cache. EnsureBinary returns early on a cache hit without
+// building, so prerequisite checks use this to avoid requiring build tools
+// (e.g. make) on hosts that already have a cached binary. A failure to resolve
+// the cache directory is reported as not-cached (the build path, where the
+// prerequisite genuinely applies).
+func IsBinaryCached(targetOS, arch string) bool {
+	cacheDir, err := CacheDir()
+	if err != nil {
+		return false
+	}
+	_, err = os.Stat(BinaryPath(cacheDir, targetOS, arch))
+	return err == nil
+}
+
 // buildWrapper builds the game server wrapper binary. On systems with make,
 // it delegates to `make build` for native linux/amd64. Otherwise it runs
 // the equivalent steps directly (cross-compilation or non-Linux targets).

--- a/internal/wrapper/wrapper_test.go
+++ b/internal/wrapper/wrapper_test.go
@@ -11,6 +11,30 @@ import (
 	"github.com/jpvelasco/ludus/internal/runner"
 )
 
+func TestUsesMake(t *testing.T) {
+	// UsesMake is true only for a native linux/amd64 build on a Linux host.
+	// On a non-Linux host it must be false for every target/arch (those builds
+	// cross-compile with `go build` and never shell out to make).
+	tests := []struct {
+		targetOS, arch string
+		wantOnLinux    bool
+	}{
+		{"linux", "amd64", true},
+		{"linux", "arm64", false},
+		{"windows", "amd64", false},
+		{"", "", false},
+	}
+
+	hostLinux := runtime.GOOS == "linux"
+	for _, tt := range tests {
+		want := tt.wantOnLinux && hostLinux
+		if got := UsesMake(tt.targetOS, tt.arch); got != want {
+			t.Errorf("UsesMake(%q, %q) on %s = %v, want %v",
+				tt.targetOS, tt.arch, runtime.GOOS, got, want)
+		}
+	}
+}
+
 func TestCacheDir(t *testing.T) {
 	dir, err := CacheDir()
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes two `ludus deploy anywhere` bugs found during v0.8.2 E2E testing on Linux. Both verified against current `main` before fixing.

### #393 — wrapper ignored generated config + false-positive "Server started"
- **Config ignored:** `launchProcess` relied on `cmd.Dir` to place the wrapper next to the generated `~/.cache/ludus/anywhere/config.yaml`, but the wrapper chdir's to its own embedded output dir on startup and loads the **stock sample config** there (`MyGame/my-server-executable`), then exits. Now the config is passed explicitly via the wrapper's `-c` flag (both `process_unix.go` and `process_windows.go`).
- **False-positive success:** `launchProcess` returned success on `Start()` with no liveness check, so a wrapper that died immediately was still reported as `Server started (PID …)`. Added a short post-start liveness check (unix; ~1.5s) that reaps the child and returns an error when it exits within the window. Windows keeps its documented no-probe behavior and falls back to fleet status.

### #392 — no `make` prerequisite check
The wrapper's native linux/amd64 build shells out to `make build`, but nothing checked for `make`, so a missing `make` failed deep in the deploy with a raw `exec: "make": not found`. Added a `make` readiness check, gated to the native linux/amd64 path via a new `wrapper.UsesMake(targetOS, arch)` helper (single source of truth shared with `buildWrapper`). Wired into:
- `init` / `RunAll` (host target) — so `init` now reports it
- `deploy anywhere` (host `GOOS/GOARCH`) and `deploy ec2` (`linux`/resolved arch) readiness paths

Actionable message points at `build-essential` / `make` packages.

## Testing
- `go build ./...`, `go test ./...` — all green
- `golangci-lint run` — 0 issues
- Cross-compile `go vet` for linux **and** windows — clean
- New unit tests: `UsesMake` (OS-aware), `checkMakeForWrapper` skip/native branches, `CheckWrapperBuildReady` composition, and `launchProcess` immediate-exit-errors / stays-alive-succeeds (unix). All test funcs under CCN 8.
- Code-reviewer agent pass: no high-confidence issues.

## Test plan (merge gate)
- [ ] Live E2E: `deploy anywhere` on a fresh SSM-only EC2 (no SSH, no inbound ports) — confirm the wrapper loads the generated config, server stays alive, and session creation succeeds.
- [ ] Confirm a host without `make` now fails fast at readiness with the actionable message.

Closes #392
Closes #393