### PR TITLE
fix(connect): discover staged client binary instead of guessing its name (#395)

### DIFF
--- a/internal/config/client_binary.go
+++ b/internal/config/client_binary.go
@@ -6,16 +6,21 @@ import (
 	"strings"
 )
 
-// nonBinaryExts are file extensions in the Binaries directory that are never the
-// client executable (debug symbols and sidecar files).
-var nonBinaryExts = map[string]bool{
-	".pdb":   true,
-	".sym":   true,
-	".debug": true,
-	".so":    true,
-	".dylib": true,
-	".map":   true,
-	".txt":   true,
+// isClientBinaryCandidate reports whether a file in the staged Binaries
+// directory could be the client executable for the platform.
+//
+// On Windows the executable ends in .exe. On Linux the packaged UE executable
+// has no extension at all (e.g. "LyraGame", or "LyraGame-Linux-Shipping"),
+// while every sidecar UE stages alongside it contains a dot — debug symbols
+// (.debug/.sym), shared objects (.so), build receipts (.target), and module
+// manifests (.modules). So "no dot in the name" cleanly selects the executable
+// and rejects sidecars, matching how resolveServerBinaryPath picks the server
+// binary in internal/ec2fleet.
+func isClientBinaryCandidate(name string, isWindows bool) bool {
+	if isWindows {
+		return strings.EqualFold(filepath.Ext(name), ".exe")
+	}
+	return !strings.Contains(name, ".")
 }
 
 // DiscoverClientBinary returns the path to the staged client executable in
@@ -39,18 +44,9 @@ func DiscoverClientBinary(binariesDir, fallback string, isWindows bool) string {
 		if e.IsDir() {
 			continue
 		}
-		name := e.Name()
-		ext := strings.ToLower(filepath.Ext(name))
-		if isWindows {
-			if ext != ".exe" {
-				continue
-			}
-		} else {
-			if nonBinaryExts[ext] {
-				continue
-			}
+		if isClientBinaryCandidate(e.Name(), isWindows) {
+			matches = append(matches, e.Name())
 		}
-		matches = append(matches, name)
 	}
 
 	// Only trust discovery when it is unambiguous; otherwise keep the

--- a/internal/config/client_binary.go
+++ b/internal/config/client_binary.go
@@ -1,0 +1,62 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// nonBinaryExts are file extensions in the Binaries directory that are never the
+// client executable (debug symbols and sidecar files).
+var nonBinaryExts = map[string]bool{
+	".pdb":   true,
+	".sym":   true,
+	".debug": true,
+	".so":    true,
+	".dylib": true,
+	".map":   true,
+	".txt":   true,
+}
+
+// DiscoverClientBinary returns the path to the staged client executable in
+// binariesDir. UE names the binary after the project's real client target (e.g.
+// Lyra's .uproject is LyraStarterGame but its target is LyraGame), which does
+// not always match the ProjectName+"Game" convention — so we discover the actual
+// file rather than computing its name. fallback is the conventionally-computed
+// path returned when discovery cannot identify a single executable (e.g. the
+// directory does not exist yet, as in a dry run).
+//
+// isWindows selects the .exe matching rule: on Windows the client binary ends in
+// .exe; on Linux it has no extension.
+func DiscoverClientBinary(binariesDir, fallback string, isWindows bool) string {
+	entries, err := os.ReadDir(binariesDir)
+	if err != nil {
+		return fallback
+	}
+
+	var matches []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		name := e.Name()
+		ext := strings.ToLower(filepath.Ext(name))
+		if isWindows {
+			if ext != ".exe" {
+				continue
+			}
+		} else {
+			if nonBinaryExts[ext] {
+				continue
+			}
+		}
+		matches = append(matches, name)
+	}
+
+	// Only trust discovery when it is unambiguous; otherwise keep the
+	// conventional path so behavior never regresses.
+	if len(matches) != 1 {
+		return fallback
+	}
+	return filepath.Join(binariesDir, matches[0])
+}

--- a/internal/config/client_binary_test.go
+++ b/internal/config/client_binary_test.go
@@ -18,9 +18,18 @@ func writeFiles(t *testing.T, dir string, names ...string) {
 
 func TestDiscoverClientBinary_LinuxFindsRealTarget(t *testing.T) {
 	// #395: the staged binary is LyraGame, but the conventional fallback would be
-	// LyraStarterGameGame. Discovery must return the actual file on disk.
+	// LyraStarterGameGame. Discovery must return the actual file on disk,
+	// ignoring the UE sidecars UE stages alongside it (debug symbols, build
+	// receipts, and module manifests all contain a dot; the executable does not).
 	dir := t.TempDir()
-	writeFiles(t, dir, "LyraGame", "LyraGame.debug", "LyraGame.sym")
+	writeFiles(t, dir,
+		"LyraGame",
+		"LyraGame.debug",
+		"LyraGame.sym",
+		"LyraGame.target",  // UE build receipt
+		"LyraGame.modules", // UE module manifest
+		"libfoo.so",
+	)
 	fallback := filepath.Join(dir, "LyraStarterGameGame")
 
 	got := DiscoverClientBinary(dir, fallback, false)

--- a/internal/config/client_binary_test.go
+++ b/internal/config/client_binary_test.go
@@ -1,0 +1,75 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// writeFiles creates each named file (empty) under dir.
+func writeFiles(t *testing.T, dir string, names ...string) {
+	t.Helper()
+	for _, n := range names {
+		if err := os.WriteFile(filepath.Join(dir, n), nil, 0o600); err != nil {
+			t.Fatalf("writing %s: %v", n, err)
+		}
+	}
+}
+
+func TestDiscoverClientBinary_LinuxFindsRealTarget(t *testing.T) {
+	// #395: the staged binary is LyraGame, but the conventional fallback would be
+	// LyraStarterGameGame. Discovery must return the actual file on disk.
+	dir := t.TempDir()
+	writeFiles(t, dir, "LyraGame", "LyraGame.debug", "LyraGame.sym")
+	fallback := filepath.Join(dir, "LyraStarterGameGame")
+
+	got := DiscoverClientBinary(dir, fallback, false)
+	want := filepath.Join(dir, "LyraGame")
+	if got != want {
+		t.Errorf("DiscoverClientBinary() = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverClientBinary_WindowsPrefersExe(t *testing.T) {
+	dir := t.TempDir()
+	writeFiles(t, dir, "LyraGame.exe", "LyraGame.pdb")
+	fallback := filepath.Join(dir, "LyraStarterGameGame.exe")
+
+	got := DiscoverClientBinary(dir, fallback, true)
+	want := filepath.Join(dir, "LyraGame.exe")
+	if got != want {
+		t.Errorf("DiscoverClientBinary() = %q, want %q", got, want)
+	}
+}
+
+func TestDiscoverClientBinary_Fallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		setup func(t *testing.T, dir string)
+	}{
+		{"missing directory", func(t *testing.T, dir string) {
+			// Point at a subpath that does not exist.
+		}},
+		{"ambiguous: two executables", func(t *testing.T, dir string) {
+			writeFiles(t, dir, "LyraGame", "ExtraTool")
+		}},
+		{"empty: only symbols", func(t *testing.T, dir string) {
+			writeFiles(t, dir, "LyraGame.sym", "LyraGame.debug")
+		}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			scanDir := dir
+			if tt.name == "missing directory" {
+				scanDir = filepath.Join(dir, "nope")
+			}
+			tt.setup(t, dir)
+			fallback := filepath.Join(scanDir, "Fallback")
+			if got := DiscoverClientBinary(scanDir, fallback, false); got != fallback {
+				t.Errorf("DiscoverClientBinary() = %q, want fallback %q", got, fallback)
+			}
+		})
+	}
+}

--- a/internal/dockerbuild/game.go
+++ b/internal/dockerbuild/game.go
@@ -132,7 +132,18 @@ func (b *DockerGameBuilder) BuildClient(ctx context.Context) (*game.ClientBuildR
 	if clientPlatform == "LinuxArm64" {
 		binSub = "LinuxArm64"
 	}
-	result.ClientBinary = filepath.Join(outputDir, clientPlatform, projectName, "Binaries", binSub, projectName+"Game")
+	// Discover the staged client executable rather than assuming its name: UE
+	// names it after the project's real client target (e.g. Lyra's
+	// LyraStarterGame.uproject builds LyraGame), which need not match
+	// ProjectName+"Game". Fall back to the configured client target, then the
+	// ProjectName+"Game" convention.
+	clientTarget := b.opts.ClientTarget
+	if clientTarget == "" {
+		clientTarget = projectName + "Game"
+	}
+	binariesDir := filepath.Join(outputDir, clientPlatform, projectName, "Binaries", binSub)
+	fallback := filepath.Join(binariesDir, clientTarget)
+	result.ClientBinary = config.DiscoverClientBinary(binariesDir, fallback, false)
 	result.Duration = time.Since(start).Seconds()
 	return result, nil
 }

--- a/internal/game/builder_client.go
+++ b/internal/game/builder_client.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/progress"
 )
 
@@ -115,7 +116,11 @@ func (b *Builder) clientBuildArgs(projectPath, platform, outputDir string) []str
 	return args
 }
 
-// clientBinaryPath returns the expected client binary path for the given platform.
+// clientBinaryPath returns the path to the staged client binary for the given
+// platform. It discovers the actual executable on disk (UE names it after the
+// project's real client target, which need not match ProjectName+"Game" — e.g.
+// Lyra's LyraStarterGame.uproject builds LyraGame), falling back to the
+// conventional name when discovery is not possible (e.g. a dry run).
 func (b *Builder) clientBinaryPath(outputDir, platform string) string {
 	projectName := b.opts.ProjectName
 	if projectName == "" {
@@ -126,12 +131,17 @@ func (b *Builder) clientBinaryPath(outputDir, platform string) string {
 		clientTarget = projectName + "Game"
 	}
 
-	switch platform {
-	case "Win64":
-		return filepath.Join(outputDir, "Windows", projectName, "Binaries", "Win64", clientTarget+".exe")
-	default:
-		return filepath.Join(outputDir, "Linux", projectName, "Binaries", "Linux", clientTarget)
+	isWindows := platform == "Win64"
+	platformDir := "Linux"
+	binSub := "Linux"
+	suffix := ""
+	if isWindows {
+		platformDir, binSub, suffix = "Windows", "Win64", ".exe"
 	}
+
+	binariesDir := filepath.Join(outputDir, platformDir, projectName, "Binaries", binSub)
+	fallback := filepath.Join(binariesDir, clientTarget+suffix)
+	return config.DiscoverClientBinary(binariesDir, fallback, isWindows)
 }
 
 // PartialClientBuildHint checks for cooked content from a previous client build.

--- a/internal/game/builder_test.go
+++ b/internal/game/builder_test.go
@@ -76,6 +76,27 @@ func TestResolveMaxJobs(t *testing.T) {
 	}
 }
 
+func TestClientBinaryPath_DiscoversRealTargetOnDisk(t *testing.T) {
+	// #395: for Lyra, ProjectName is "LyraStarterGame" but the built client
+	// target is "LyraGame". When the real binary exists on disk, clientBinaryPath
+	// must return it rather than the ProjectName+"Game" guess.
+	outputDir := t.TempDir()
+	binDir := filepath.Join(outputDir, "Linux", "LyraStarterGame", "Binaries", "Linux")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "LyraGame"), nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	b := NewBuilder(BuildOptions{ProjectName: "LyraStarterGame"}, runner.NewRunner(false, true))
+	got := b.clientBinaryPath(outputDir, "Linux")
+	want := filepath.Join(binDir, "LyraGame")
+	if got != want {
+		t.Errorf("clientBinaryPath() = %q, want %q (should discover real target, not LyraStarterGameGame)", got, want)
+	}
+}
+
 func TestClientBinaryPath(t *testing.T) {
 	tests := []struct {
 		name         string


### PR DESCRIPTION
## Summary

Fixes #395 — after a successful `ludus game client` build, `ludus connect` failed with `client binary not found`. Verified against current `main`.

### Root cause
The recorded client binary path derived its name as `ProjectName + "Game"`. For the Lyra sample, `ProjectName` is the `.uproject` name (`LyraStarterGame`), so this yields `LyraStarterGameGame` — but `BuildCookRun` runs with **no `-target`**, so UE builds the project's real default client target (`LyraGame`). The binary on disk is `LyraGame`; ludus recorded `LyraStarterGameGame`, so `connect` looked for the wrong file even though the client built fine. Same class as #327 (name-derivation mismatch).

The container path (`internal/dockerbuild/game.go` `BuildClient`) was worse — it ignored `ClientTarget` entirely and hardcoded `projectName+"Game"`.

### Fix
New `config.DiscoverClientBinary(binariesDir, fallback, isWindows)`:
- Scans the staged `Binaries/<platform>` dir for the actual executable (skips `.pdb`/`.sym`/`.debug`/`.so`/etc on Linux; requires `.exe` on Windows).
- Returns the conventional computed name (`ClientTarget` → `ProjectName+"Game"`) as **fallback** when discovery is ambiguous (≠1 match) or the dir is absent (e.g. dry run) — so behavior never regresses, and `connect` still `os.Stat`s + errors clearly if truly missing.

Both client build paths use it: native/WSL (`internal/game/builder_client.go`) and container (`internal/dockerbuild/game.go`).

## Testing
- `go build ./...`, `go test ./...` — all green
- `golangci-lint run` — 0 issues
- Cross-compile `go vet` linux/windows — clean
- New `client_binary_test.go`: Linux finds real target (the #395 Lyra case), Windows prefers `.exe`, fallback on missing/ambiguous/symbols-only. New `builder_test.go` case: `clientBinaryPath` discovers `LyraGame` on disk under `LyraStarterGame` project. All test funcs under CCN 8.

## Test plan
- [ ] Lyra: `ludus game client` then `ludus connect` resolves the real `LyraGame` binary instead of failing on `LyraStarterGameGame`.

Closes #395