### PR TITLE
feat(toolchain): add UE 5.8 support

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -151,7 +151,7 @@ On macOS with container backends (`--backend docker`/`podman`), engine builds ar
 ### DDC Backend (Zen vs legacy FileSystem)
 
 Unreal Engine uses the **Zen Store** as its default local DDC backend from **UE 5.4 onward** (the
-legacy FileSystem DDC is delete-only since 5.4). Ludus supports UE 5.4–5.7, so `ddc.mode` defaults
+legacy FileSystem DDC is delete-only since 5.4). Ludus supports UE 5.4–5.8, so `ddc.mode` defaults
 to `zen` unconditionally — there is no version gate. (An earlier assumption that ZenStore applied
 only to UE 5.6+ was incorrect; if you find a "5.6+" reference to DDC, it is a bug.)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,7 +69,7 @@ Network-facing operations (Docker, AWS) wrap calls with `internal/retry/`: expon
 
 ### DDC (Derived Data Cache)
 
-`internal/ddc/` manages UE5's Derived Data Cache — persistent shader/asset cache that survives Docker container lifecycles. Three modes (`internal/ddc/ddc.go`): `zen` (default since v0.7.0 — the Unreal Zen Store, UE's default local backend since 5.4, applies to UE 5.4–5.7), `local` (legacy FileSystem cache, **deprecated** — delete-only in UE since 5.4; `doctor`/`ddc status`/config load warn and recommend `zen`), and `none` (disabled). `NormalizeMode` maps the empty string to `zen`.
+`internal/ddc/` manages UE5's Derived Data Cache — persistent shader/asset cache that survives Docker container lifecycles. Three modes (`internal/ddc/ddc.go`): `zen` (default since v0.7.0 — the Unreal Zen Store, UE's default local backend since 5.4, applies to UE 5.4–5.8), `local` (legacy FileSystem cache, **deprecated** — delete-only in UE since 5.4; `doctor`/`ddc status`/config load warn and recommend `zen`), and `none` (disabled). `NormalizeMode` maps the empty string to `zen`.
 
 Integration points (`internal/dockerbuild/game.go`): for `zen`, the host Zen directory (`ddc.zenPath`, default `~/.ludus/zen`) is bind-mounted to the container's fixed ZenStore data path (`ddc.ZenContainerPath` = `/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data`); the game-build preamble recursively chowns `/home/ue/.config` so `zenserver` (running as `ue`) can write it. For legacy `local`, the host DDC dir is mounted at `/ddc` and passed via `UE-LocalDataCachePath`.
 

--- a/README.md
+++ b/README.md
@@ -478,7 +478,7 @@ Run `ludus doctor` for macOS + container environment checks.
 
 One of the biggest time sinks in UE5 dedicated server builds is a cold Derived Data Cache (DDC). Every container run previously started with a completely cold cache, forcing hours of shader compilation and asset derivation.
 
-Ludus makes DDC **persistent by default**, using the **Unreal Zen Store** — the default local DDC backend in Unreal Engine since UE 5.4 (the legacy FileSystem DDC has been delete-only since 5.4). All UE versions Ludus supports (5.4–5.7) default to Zen.
+Ludus makes DDC **persistent by default**, using the **Unreal Zen Store** — the default local DDC backend in Unreal Engine since UE 5.4 (the legacy FileSystem DDC has been delete-only since 5.4). All UE versions Ludus supports (5.4–5.8) default to Zen.
 
 - `--ddc zen` (default) — Persists UE's Zen Store cook cache. For container builds (Docker/Podman), the host Zen directory (`~/.ludus/zen`) is mounted into the container so the cache survives `--rm`. For native and WSL2 builds, UE's autolaunched Zen Store already persists in your home directory, so Ludus leaves it untouched.
 - `--ddc local` (deprecated) — Legacy FileSystem cache on the host (`~/.ludus/ddc`), redirected via `UE-LocalDataCachePath`. Retained for edge cases; prefer `zen`.

--- a/cmd/configcmd/configcmd.go
+++ b/cmd/configcmd/configcmd.go
@@ -24,7 +24,7 @@ var setCmd = &cobra.Command{
 
 Examples:
   ludus config set engine.sourcePath /path/to/UnrealEngine
-  ludus config set engine.version 5.7.3
+  ludus config set engine.version 5.8.0
   ludus config set gamelift.instanceType c6g.large
   ludus config set gamelift.fleetName ludus-fleet-ue57
   ludus config set deploy.target ec2

--- a/cmd/setup/engine_discovery_test.go
+++ b/cmd/setup/engine_discovery_test.go
@@ -1,13 +1,25 @@
 package setup
 
 import (
+	"bufio"
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/config"
 )
+
+// withScannerInput swaps the package scanner to read from in for the duration of
+// the test, restoring the original afterward. Lets prompt-driven paths be tested
+// without real stdin.
+func withScannerInput(t *testing.T, in string) {
+	t.Helper()
+	orig := scanner
+	scanner = bufio.NewScanner(strings.NewReader(in))
+	t.Cleanup(func() { scanner = orig })
+}
 
 // writeBuildVersion creates an engine tree with a Build.version file under root.
 func writeBuildVersion(t *testing.T, root string, major, minor, patch int) {
@@ -99,6 +111,14 @@ func TestDetectEngineVersion(t *testing.T) {
 		writeBuildVersion(t, dir, 5, 6, 1)
 		if got := detectEngineVersion(dir); got != "5.6.1" {
 			t.Errorf("detectEngineVersion() = %q, want 5.6.1", got)
+		}
+	})
+	t.Run("falls back to prompt when Build.version unparseable", func(t *testing.T) {
+		// No Build.version under the path → ParseBuildVersion fails → prompt.
+		// Inject the answer so the interactive fallback is exercised.
+		withScannerInput(t, "5.8.0\n")
+		if got := detectEngineVersion(t.TempDir()); got != "5.8.0" {
+			t.Errorf("detectEngineVersion() = %q, want 5.8.0 (from prompt)", got)
 		}
 	})
 }

--- a/cmd/setup/wizard.go
+++ b/cmd/setup/wizard.go
@@ -155,7 +155,7 @@ func detectEngineVersion(enginePath string) string {
 		return version
 	}
 	fmt.Println("\nCould not auto-detect engine version from Build.version.")
-	return prompt("Engine version (e.g., 5.7.3)", "")
+	return prompt("Engine version (e.g., 5.8.0)", "")
 }
 
 // printSummary displays the collected configuration before writing.

--- a/internal/prereq/checker_msvc_test.go
+++ b/internal/prereq/checker_msvc_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package prereq
+
+import "testing"
+
+// TestNeedsNewerMSVC pins the engine-version gate that selects the MSVC toolset.
+// UE 5.7+ (incl. 5.8) needs MSVC 14.44; 5.6 and earlier use 14.38. A drift in
+// the `minor >= 7` gate would silently mis-pin MSVC for 5.8 and break Windows
+// container builds, so 5.8 is asserted explicitly here. Passing only a config
+// version exercises DetectEngineVersion's config fallback (no engine tree needed).
+func TestNeedsNewerMSVC(t *testing.T) {
+	tests := []struct {
+		configVersion string
+		want          bool
+	}{
+		{"5.4.4", false},
+		{"5.5.4", false},
+		{"5.6.1", false},
+		{"5.7.3", true},
+		{"5.8.0", true},
+		{"", false},
+		{"garbage", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.configVersion, func(t *testing.T) {
+			if got := needsNewerMSVC("", tt.configVersion); got != tt.want {
+				t.Errorf("needsNewerMSVC(%q) = %v, want %v", tt.configVersion, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestMSVCVersionForEngine confirms the gate maps to the right MSVC toolset
+// string — the value actually written into BuildConfiguration.xml.
+func TestMSVCVersionForEngine(t *testing.T) {
+	tests := []struct {
+		configVersion string
+		want          string
+	}{
+		{"5.6.1", "14.38.33130"},
+		{"5.7.3", "14.44.35207"},
+		{"5.8.0", "14.44.35207"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.configVersion, func(t *testing.T) {
+			if got := msvcVersionForEngine("", tt.configVersion); got != tt.want {
+				t.Errorf("msvcVersionForEngine(%q) = %q, want %q", tt.configVersion, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/prereq/checker_plugins.go
+++ b/internal/prereq/checker_plugins.go
@@ -56,7 +56,10 @@ var knownPluginDLLFixes = []pluginDLLFix{
 		description: "AESGCMHandlerComponent depends on PlatformCrypto DLLs not in Engine/Binaries/Win64/",
 		// 5.7+: PlatformCrypto moved from engine binaries to a plugin-only location.
 		// AESGCMHandlerComponent can't resolve its import dependency without the copy.
-		minorVersions: []int{7},
+		// 5.8 keeps the plugin at the same Engine/Plugins/Experimental/PlatformCrypto
+		// path (verified at the 5.8.0 release tag), so the fix applies there too;
+		// omitting 8 would make cleanupStaleDLLs delete the needed DLLs on 5.8.
+		minorVersions: []int{7, 8},
 		dllNames: []string{
 			"UnrealEditor-PlatformCrypto.dll",
 			"UnrealEditor-PlatformCryptoContext.dll",

--- a/internal/prereq/checker_plugins_test.go
+++ b/internal/prereq/checker_plugins_test.go
@@ -1,0 +1,44 @@
+//go:build windows
+
+package prereq
+
+import (
+	"slices"
+	"testing"
+)
+
+// findPluginFix returns the knownPluginDLLFixes entry with the given name.
+func findPluginFix(t *testing.T, name string) pluginDLLFix {
+	t.Helper()
+	for _, f := range knownPluginDLLFixes {
+		if f.name == name {
+			return f
+		}
+	}
+	t.Fatalf("plugin fix %q not found", name)
+	return pluginDLLFix{}
+}
+
+// TestPluginFixVersionGates pins the version gates for the known plugin DLL
+// fixes. PlatformCrypto must cover both 5.7 and 5.8 (the plugin lives at the
+// same path on 5.8, and omitting 8 would make cleanupStaleDLLs delete the
+// needed DLLs); Dataflow must remain 5.6-only (Epic moved it into engine
+// binaries natively from 5.7, so copying it causes class conflicts).
+func TestPluginFixVersionGates(t *testing.T) {
+	tests := []struct {
+		fixName      string
+		wantVersions []int
+	}{
+		{"PlatformCrypto Plugin DLLs", []int{7, 8}},
+		{"Dataflow Plugin DLLs", []int{6}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.fixName, func(t *testing.T) {
+			fix := findPluginFix(t, tt.fixName)
+			if !slices.Equal(fix.minorVersions, tt.wantVersions) {
+				t.Errorf("%s minorVersions = %v, want %v", tt.fixName, fix.minorVersions, tt.wantVersions)
+			}
+		})
+	}
+}

--- a/internal/toolchain/detection_test.go
+++ b/internal/toolchain/detection_test.go
@@ -238,6 +238,13 @@ func TestLinuxToolchainPath(t *testing.T) {
 			wantPrefix: "v26_clang-20",
 		},
 		{
+			name:       "5.8 toolchain present (shares v26 with 5.7)",
+			version:    "5.8",
+			setupDirs:  []string{"v26_clang-20.1.8-rockylinux8"},
+			wantFound:  true,
+			wantPrefix: "v26_clang-20",
+		},
+		{
 			name:       "5.6 toolchain present",
 			version:    "5.6",
 			setupDirs:  []string{"v25_clang-18.1.0-rockylinux8"},

--- a/internal/toolchain/toolchain.go
+++ b/internal/toolchain/toolchain.go
@@ -34,12 +34,24 @@ type CheckResult struct {
 	Message       string
 }
 
+// v26Toolchain is the Linux cross-compile toolchain shared by UE 5.7 and 5.8.
+// Both releases pin the identical SDK (v26 / clang 20.1.8), verified against
+// Engine/Config/Linux/Linux_SDK.json at the 5.7.3 and 5.8.0 release tags. Shared
+// here so the URL/clang values can never drift between the two versions.
+var v26Toolchain = ToolchainSpec{
+	SDKVersion:   "v26",
+	ClangMajor:   20,
+	DirPrefix:    "v26_clang-20",
+	InstallerURL: "https://cdn.unrealengine.com/CrossToolchain_Linux/v26_clang-20.1.8-rockylinux8.exe",
+}
+
 // toolchainMap maps engine major.minor versions to their required toolchain.
 var toolchainMap = map[string]ToolchainSpec{
 	"5.4": {SDKVersion: "v22", ClangMajor: 16, DirPrefix: "v22_clang-16", InstallerURL: "https://cdn.unrealengine.com/CrossToolchain_Linux/v22_clang-16.0.6-centos7.exe"},
 	"5.5": {SDKVersion: "v23", ClangMajor: 18, DirPrefix: "v23_clang-18", InstallerURL: "https://cdn.unrealengine.com/CrossToolchain_Linux/v23_clang-18.1.0-rockylinux8.exe"},
 	"5.6": {SDKVersion: "v25", ClangMajor: 18, DirPrefix: "v25_clang-18", InstallerURL: "https://cdn.unrealengine.com/CrossToolchain_Linux/v25_clang-18.1.0-rockylinux8.exe"},
-	"5.7": {SDKVersion: "v26", ClangMajor: 20, DirPrefix: "v26_clang-20", InstallerURL: "https://cdn.unrealengine.com/CrossToolchain_Linux/v26_clang-20.1.8-rockylinux8.exe"},
+	"5.7": v26Toolchain,
+	"5.8": v26Toolchain,
 }
 
 // ParseBuildVersion reads and parses the Build.version JSON file from the engine source.

--- a/internal/toolchain/version_test.go
+++ b/internal/toolchain/version_test.go
@@ -114,35 +114,52 @@ func TestDetectEngineVersion(t *testing.T) {
 
 func TestLookupToolchain(t *testing.T) {
 	tests := []struct {
-		version string
-		wantNil bool
-		clang   int
+		version    string
+		wantNil    bool
+		clang      int
+		sdkVersion string
+		dirPrefix  string
 	}{
-		{"5.4", false, 16},
-		{"5.5", false, 18},
-		{"5.6", false, 18},
-		{"5.7", false, 20},
-		{"5.3", true, 0},
-		{"", true, 0},
-		{"6.0", true, 0},
+		{"5.4", false, 16, "v22", "v22_clang-16"},
+		{"5.5", false, 18, "v23", "v23_clang-18"},
+		{"5.6", false, 18, "v25", "v25_clang-18"},
+		{"5.7", false, 20, "v26", "v26_clang-20"},
+		// 5.8 reuses 5.7's v26 toolchain (shared v26Toolchain value); a drift in
+		// that value would fail both the 5.7 and 5.8 rows.
+		{"5.8", false, 20, "v26", "v26_clang-20"},
+		{"5.3", true, 0, "", ""},
+		{"", true, 0, "", ""},
+		{"6.0", true, 0, "", ""},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.version, func(t *testing.T) {
-			spec := LookupToolchain(tt.version)
-			if tt.wantNil {
-				if spec != nil {
-					t.Errorf("expected nil for version %q, got %+v", tt.version, spec)
-				}
-				return
-			}
-			if spec == nil {
-				t.Fatalf("expected spec for version %q, got nil", tt.version)
-				return
-			}
-			if spec.ClangMajor != tt.clang {
-				t.Errorf("got ClangMajor %d, want %d", spec.ClangMajor, tt.clang)
-			}
+			assertToolchainSpec(t, tt.version, tt.wantNil, tt.clang, tt.sdkVersion, tt.dirPrefix)
 		})
+	}
+}
+
+// assertToolchainSpec checks LookupToolchain against expected fields, keeping the
+// test loop body under the cyclomatic-complexity limit.
+func assertToolchainSpec(t *testing.T, version string, wantNil bool, clang int, sdkVersion, dirPrefix string) {
+	t.Helper()
+	spec := LookupToolchain(version)
+	if wantNil {
+		if spec != nil {
+			t.Errorf("expected nil for version %q, got %+v", version, spec)
+		}
+		return
+	}
+	if spec == nil {
+		t.Fatalf("expected spec for version %q, got nil", version)
+	}
+	if spec.ClangMajor != clang {
+		t.Errorf("version %q: got ClangMajor %d, want %d", version, spec.ClangMajor, clang)
+	}
+	if spec.SDKVersion != sdkVersion {
+		t.Errorf("version %q: got SDKVersion %q, want %q", version, spec.SDKVersion, sdkVersion)
+	}
+	if spec.DirPrefix != dirPrefix {
+		t.Errorf("version %q: got DirPrefix %q, want %q", version, spec.DirPrefix, dirPrefix)
 	}
 }

--- a/scripts/validate_ue_versions.sh
+++ b/scripts/validate_ue_versions.sh
@@ -15,6 +15,7 @@ TARBALLS=(
     "UnrealEngine-5.5.4-release.tar.gz"
     "UnrealEngine-5.6.1-release.tar.gz"
     "UnrealEngine-5.7.3-release.tar.gz"
+    "UnrealEngine-5.8.0-release.tar.gz"
 )
 
 PASS="[PASS]"

--- a/scripts/validate_ue_versions.sh
+++ b/scripts/validate_ue_versions.sh
@@ -91,7 +91,7 @@ for tarball in "${TARBALLS[@]}"; do
         echo "  $PASS Build.version found: ${MAJOR}.${MINOR}.${PATCH}"
 
         case "$ENGINE_VER" in
-            5.4|5.5|5.6|5.7)
+            5.4|5.5|5.6|5.7|5.8)
                 echo "  $PASS Engine $ENGINE_VER is in Ludus toolchainMap"
                 ;;
             *)


### PR DESCRIPTION
## Summary

Adds UE **5.8** to the supported version matrix. UE 5.8.0 (released 2026-06-17) reuses 5.7's Linux cross-toolchain **byte-identical** (`v26_clang-20.1.8-rockylinux8`), so this is an additive version-matrix change, not a new toolchain integration. Per the approved design spec (`docs/superpowers/specs/2026-06-28-ue58-support-design.md`).

## Changes
- **`internal/toolchain`**: extract a shared `v26Toolchain` value; map both `5.7` and `5.8` to it so the SDK/clang/URL can't drift between them.
- **`internal/prereq`**: extend the PlatformCrypto DLL fix from `{7}` to `{7,8}` — the plugin lives at the same path on 5.8, and omitting `8` would make `cleanupStaleDLLs` delete the needed DLLs. *(Windows-host-only path; see gate below.)*
- **Docs**: bump supported range `5.4–5.7` → `5.4–5.8` (README, ARCHITECTURE, CLAUDE.md); example version hints → `5.8.0`.
- **`scripts/validate_ue_versions.sh`**: add the 5.8.0 tarball.
- **Tests**: 5.8 cases in `LookupToolchain` (asserts full v26 spec) + `LinuxToolchainPath`; windows-tagged assertion that PlatformCrypto covers `{7,8}` and Dataflow stays `{6}`.

No-change verified: `needsNewerMSVC` (`minor>=7`), NuGet workaround (5.6-only), non-root build user (5.7+) all handle 5.8 correctly.

## Validation — live UE 5.8.0 build (SSM-only EC2, native backend)

Ran on a fresh Ubuntu 24.04 / 32-vCPU box (SSM-only, no SSH, no inbound ports; torn down after):

- ✅ Cloned UE **5.8.0-release**. `Build.version` → MinorVersion **8**; `Engine/Config/Linux/Linux_SDK.json` → `v26_clang-20.1.8-rockylinux8` (confirms the spec's core assumption on the real release).
- ✅ `ludus init` → **`[OK] Toolchain  toolchain v26_clang-20 found ... (engine 5.8 from Build.version)`** — the toolchain-map change resolves 5.8 end-to-end.
- ✅ **Full UE 5.8 engine built cleanly** via `ludus engine build --backend native` (`exit=0`, `UnrealEditor` produced, ~55 min, zero toolchain errors) — the editor + all `libUnrealEditor-*.so` compiled with `clang 20.1.8` from the v26 toolchain this PR maps.

## Merge gate — remaining items (per spec, hard block)

These could not be completed in the autonomous run and remain before merge:

- [ ] **Lyra Linux dedicated server cooks/packages on 5.8.** The engine-bundled `Samples/Games/Lyra` is a source-only skeleton (0 uassets) and segfaults in cook (missing `DefaultGameData`/GameFeature content — a fixture gap, not a code defect). Needs a content-complete Lyra (e.g. `LyraStarterGame6`). *Env notes for the runner: native build must run as a non-root user (UE 5.7+ refuses root); editor needs GTK/ATK runtime libs.*
- [ ] **PlatformCrypto `{7,8}` at editor load (Windows host).** This fix is `//go:build windows` (Win64 DLL copy for Windows-host cooks) and cannot be exercised on a Linux box. Confirm on a Windows-host 5.8 cook that the editor loads with no PlatformCrypto/Dataflow DLL conflicts.
- [ ] **deploy + connect** on 5.8 server build (validates alongside the #392/#393/#394/#395 fixes).

## CI
- `go build`, `go test`, `golangci-lint`, cross-vet (linux/windows) all green locally; CI validates the same.

Do not merge until the gate items above are checked.