### PR TITLE
fix(game): anchor DefaultServerTarget on section header (#404)

### DIFF
--- a/internal/game/logic_test.go
+++ b/internal/game/logic_test.go
@@ -152,56 +152,62 @@ func TestGameTargetName(t *testing.T) {
 
 // --- workarounds: ensureDefaultServerTarget ---------------------------------
 
+// mkServerTargetProject creates a project dir with an optional DefaultEngine.ini
+// and returns the .uproject path.
+func mkServerTargetProject(t *testing.T, iniContent string) string {
+	t.Helper()
+	dir := t.TempDir()
+	uproject := filepath.Join(dir, "MyGame.uproject")
+	writeTestFile(t, uproject, "{}")
+	if iniContent != "" {
+		writeTestFile(t, filepath.Join(dir, "Config", "DefaultEngine.ini"), iniContent)
+	}
+	return uproject
+}
+
+// assertIniContains reads the project's DefaultEngine.ini and checks for want.
+func assertIniContains(t *testing.T, uproject, want string) {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(uproject), "Config", "DefaultEngine.ini"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Errorf("expected %q in ini, got:\n%s", want, data)
+	}
+}
+
 func TestEnsureDefaultServerTarget(t *testing.T) {
-	mkProject := func(t *testing.T, iniContent string) string {
-		t.Helper()
-		dir := t.TempDir()
-		uproject := filepath.Join(dir, "MyGame.uproject")
-		writeTestFile(t, uproject, "{}")
-		if iniContent != "" {
-			writeTestFile(t, filepath.Join(dir, "Config", "DefaultEngine.ini"), iniContent)
-		}
-		return uproject
+	tests := []struct {
+		name    string
+		ini     string
+		opts    BuildOptions
+		want    string // substring expected in the ini after the call ("" = no write check)
+		wantSec bool   // also expect the BuildSettings section header present
+	}{
+		{name: "ini missing is graceful", ini: "", opts: BuildOptions{ProjectName: "MyGame"}},
+		{name: "already set is no-op", ini: "[/Script/Engine]\nDefaultServerTarget=MyGameServer\n", opts: BuildOptions{ProjectName: "MyGame"}, want: "DefaultServerTarget=MyGameServer"},
+		{name: "inserts after section header", ini: "[/Script/BuildSettings.BuildSettings]\nDefaultGameTarget=MyGameGame\n", opts: BuildOptions{ProjectName: "MyGame"}, want: "DefaultServerTarget=MyGameServer"},
+		// #404: game target need not match ProjectName+"Game" (Lyra: project
+		// LyraStarterGame6, target LyraGame). Section-header anchor still works.
+		{name: "game target differs from ProjectName (Lyra)", ini: "[/Script/BuildSettings.BuildSettings]\nDefaultGameTarget=LyraGame\n", opts: BuildOptions{ProjectName: "LyraStarterGame6", ServerTarget: "LyraServer"}, want: "DefaultServerTarget=LyraServer"},
+		{name: "appends section when absent", ini: "[/Script/Engine]\nSomethingElse=1\n", opts: BuildOptions{ProjectName: "MyGame"}, want: "DefaultServerTarget=MyGameServer", wantSec: true},
 	}
 
-	t.Run("ini missing is graceful", func(t *testing.T) {
-		uproject := mkProject(t, "")
-		b := newTestBuilder(BuildOptions{ProjectName: "MyGame"})
-		if err := b.ensureDefaultServerTarget(uproject); err != nil {
-			t.Errorf("expected nil when ini missing, got %v", err)
-		}
-	})
-
-	t.Run("already set is no-op", func(t *testing.T) {
-		uproject := mkProject(t, "[/Script/Engine]\nDefaultServerTarget=MyGameServer\n")
-		b := newTestBuilder(BuildOptions{ProjectName: "MyGame"})
-		if err := b.ensureDefaultServerTarget(uproject); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("no DefaultGameTarget anchor skips", func(t *testing.T) {
-		uproject := mkProject(t, "[/Script/Engine]\nSomethingElse=1\n")
-		b := newTestBuilder(BuildOptions{ProjectName: "MyGame"})
-		if err := b.ensureDefaultServerTarget(uproject); err != nil {
-			t.Errorf("unexpected error: %v", err)
-		}
-	})
-
-	t.Run("inserts after DefaultGameTarget", func(t *testing.T) {
-		uproject := mkProject(t, "DefaultGameTarget=MyGameGame\n")
-		b := newTestBuilder(BuildOptions{ProjectName: "MyGame"})
-		if err := b.ensureDefaultServerTarget(uproject); err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		data, err := os.ReadFile(filepath.Join(filepath.Dir(uproject), "Config", "DefaultEngine.ini"))
-		if err != nil {
-			t.Fatal(err)
-		}
-		if !strings.Contains(string(data), "DefaultServerTarget=MyGameServer") {
-			t.Errorf("expected DefaultServerTarget inserted, got:\n%s", data)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			uproject := mkServerTargetProject(t, tt.ini)
+			if err := newTestBuilder(tt.opts).ensureDefaultServerTarget(uproject); err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if tt.want != "" {
+				assertIniContains(t, uproject, tt.want)
+			}
+			if tt.wantSec {
+				assertIniContains(t, uproject, "[/Script/BuildSettings.BuildSettings]")
+			}
+		})
+	}
 }
 
 // --- builder_client: resolveClientPlatform / clientBuildArgs / binaryPath ---

--- a/internal/game/workarounds.go
+++ b/internal/game/workarounds.go
@@ -89,16 +89,22 @@ func (b *Builder) ensureDefaultServerTarget(projectPath string) error {
 		return nil
 	}
 
-	old := "DefaultGameTarget=" + b.gameTargetName()
-	replacement := old + "\nDefaultServerTarget=" + b.serverTargetName()
-	if !strings.Contains(content, old) {
-		fmt.Printf("  %s does not contain DefaultGameTarget=%s, skipping DefaultServerTarget configuration\n", iniPath, b.gameTargetName())
-		return nil
+	// Anchor on the [/Script/BuildSettings.BuildSettings] section header rather
+	// than a DefaultGameTarget=<ProjectName>Game line: the real game target name
+	// need not match ProjectName+"Game" (e.g. Lyra's project is LyraStarterGame
+	// but its target is LyraGame), which previously made this skip and the cook
+	// fail with "multiple Server targets but no DefaultServerTarget". Matches the
+	// container build path's logic. (#404)
+	const section = "[/Script/BuildSettings.BuildSettings]"
+	line := "DefaultServerTarget=" + b.serverTargetName()
+	if strings.Contains(content, section) {
+		content = strings.Replace(content, section, section+"\n"+line, 1)
+	} else {
+		content += "\n" + section + "\n" + line + "\n"
 	}
 
-	content = strings.Replace(content, old, replacement, 1)
 	fmt.Printf("  Setting DefaultServerTarget=%s in %s\n", b.serverTargetName(), iniPath)
-	return os.WriteFile(iniPath, []byte(content), 0644)
+	return os.WriteFile(iniPath, []byte(content), 0o644)
 }
 
 func (b *Builder) gameTargetName() string {


### PR DESCRIPTION
## Summary

Fixes #404. `ensureDefaultServerTarget` (native build path) anchored its insert on `DefaultGameTarget=<ProjectName>Game`, but the real game target name need not match `ProjectName+"Game"` — Lyra's project is `LyraStarterGame6` while its target is `LyraGame`. The mismatch made the workaround **skip**, and the server cook failed with:
```
Project contains multiple Server targets (...) but no DefaultServerTarget is set
```

Same `ProjectName`-vs-target-name family as #395.

## Fix
Anchor on the `[/Script/BuildSettings.BuildSettings]` section header (creating it if absent) instead of the project-name-derived `DefaultGameTarget=` line. This matches the container build path (`internal/dockerbuild/game_script.go`), which already does it correctly.

## Tests
Rewrote `TestEnsureDefaultServerTarget` as a table covering: ini-missing graceful skip, already-set no-op, insert-after-section-header, **the #404 Lyra regression (game target ≠ ProjectName)**, and append-section-when-absent. All test funcs under CCN 8.

## Provenance
Discovered during the live UE 5.8 + Lyra E2E validation (server cook failed until DefaultServerTarget was set).

Closes #404