### PR TITLE
feat(diagnose): hint for BuildSettingsVersion mismatch (#405)

### DIFF
--- a/internal/game/diagnostics.go
+++ b/internal/game/diagnostics.go
@@ -97,6 +97,12 @@ var knownLogPatterns = []knownLogPattern{
 		"A build product listed in the UBT manifest was not generated. " +
 			"For .sym files on ARM64 cross-compile, this is caused by dump_syms.exe crashing — " +
 			"ludus should handle this automatically; please report as a bug if it persists"},
+	{"has build products in common with",
+		"Build-settings mismatch: a project target pins an older DefaultBuildSettings " +
+			"(e.g. BuildSettingsVersion.V6) whose warning levels conflict with this engine's " +
+			"defaults (UE 5.8 promotes Unreachable/ReturnType/Dangling warnings to errors). " +
+			"Bump DefaultBuildSettings to BuildSettingsVersion.Latest (or this engine's version) " +
+			"in your *.Target.cs files"},
 }
 
 // scanBuildLogs reads the RunUAT log file and returns hints for any known

--- a/internal/game/diagnostics.go
+++ b/internal/game/diagnostics.go
@@ -97,18 +97,23 @@ var knownLogPatterns = []knownLogPattern{
 		"A build product listed in the UBT manifest was not generated. " +
 			"For .sym files on ARM64 cross-compile, this is caused by dump_syms.exe crashing — " +
 			"ludus should handle this automatically; please report as a bug if it persists"},
-	// Match the specific warning-level promotion signature, NOT the generic
-	// "has build products in common with" clause — UBT emits that same clause for
-	// other shared-build-environment violations (GlobalDefinitions, CustomConfig,
-	// etc.) where bumping DefaultBuildSettings is the wrong remedy. "WarningLevel:
-	// Off != Error" only appears for the UE 5.8 warning-default mismatch.
-	{"WarningLevel: Off != Error",
-		"Build-settings mismatch: a project target pins an older DefaultBuildSettings " +
-			"(e.g. BuildSettingsVersion.V6) whose warning levels conflict with this engine's " +
-			"defaults (UE 5.8 promotes Unreachable/ReturnType/Dangling warnings to errors). " +
-			"Bump DefaultBuildSettings to BuildSettingsVersion.Latest (or this engine's version) " +
-			"in your *.Target.cs files"},
+	// Match the specific properties UE 5.8 promotes to errors, NOT the generic
+	// "has build products in common with" clause (also emitted for GlobalDefinitions/
+	// CustomConfig violations) nor any "*WarningLevel: Off != Error" (a project could
+	// explicitly override some other warning property). Only these three named
+	// properties default-flip in 5.8; all map to the same DefaultBuildSettings hint.
+	{"UnreachableCodeWarningLevel: Off != Error", buildSettingsMismatchHint},
+	{"ReturnTypeWarningLevel: Off != Error", buildSettingsMismatchHint},
+	{"DanglingWarningLevel: Off != Error", buildSettingsMismatchHint},
 }
+
+// buildSettingsMismatchHint guides users hitting the UE 5.8 warning-level
+// promotion failure when a project target pins an older DefaultBuildSettings.
+const buildSettingsMismatchHint = "Build-settings mismatch: a project target pins an older DefaultBuildSettings " +
+	"(e.g. BuildSettingsVersion.V6) whose warning levels conflict with this engine's " +
+	"defaults (UE 5.8 promotes Unreachable/ReturnType/Dangling warnings to errors). " +
+	"Bump DefaultBuildSettings to BuildSettingsVersion.Latest (or this engine's version) " +
+	"in your *.Target.cs files"
 
 // scanBuildLogs reads the RunUAT log file and returns hints for any known
 // error patterns found. Returns nil if the log doesn't exist or no patterns match.

--- a/internal/game/diagnostics.go
+++ b/internal/game/diagnostics.go
@@ -97,7 +97,12 @@ var knownLogPatterns = []knownLogPattern{
 		"A build product listed in the UBT manifest was not generated. " +
 			"For .sym files on ARM64 cross-compile, this is caused by dump_syms.exe crashing — " +
 			"ludus should handle this automatically; please report as a bug if it persists"},
-	{"has build products in common with",
+	// Match the specific warning-level promotion signature, NOT the generic
+	// "has build products in common with" clause — UBT emits that same clause for
+	// other shared-build-environment violations (GlobalDefinitions, CustomConfig,
+	// etc.) where bumping DefaultBuildSettings is the wrong remedy. "WarningLevel:
+	// Off != Error" only appears for the UE 5.8 warning-default mismatch.
+	{"WarningLevel: Off != Error",
 		"Build-settings mismatch: a project target pins an older DefaultBuildSettings " +
 			"(e.g. BuildSettingsVersion.V6) whose warning levels conflict with this engine's " +
 			"defaults (UE 5.8 promotes Unreachable/ReturnType/Dangling warnings to errors). " +

--- a/internal/game/logic_test.go
+++ b/internal/game/logic_test.go
@@ -59,47 +59,46 @@ func TestBuildLogError_WrapsAndMentionsLog(t *testing.T) {
 }
 
 func TestMatchBuildLogHints(t *testing.T) {
-	t.Run("no matches", func(t *testing.T) {
-		if hints := matchBuildLogHints("nothing interesting here"); hints != nil {
-			t.Errorf("expected no hints, got %v", hints)
-		}
-	})
+	tests := []struct {
+		name      string
+		content   string
+		wantCount int
+		wantHint  string // substring expected in the first hint (when wantCount==1)
+	}{
+		{"no matches", "nothing interesting here", 0, ""},
+		{"single match", "error: GameFeatureData is missing from disk", 1, "Missing game content"},
+		{"multiple distinct matches", "C1076: compiler limit reached\nalso LINUX_MULTIARCH_ROOT not set", 2, ""},
+		// repeated pattern → deduped by hint
+		{"duplicate hint deduped", "GameFeatureData is missing ... GameFeatureData is missing again", 1, "Missing game content"},
+		// #405: warning-promotion signature → BuildSettingsVersion hint
+		{"build settings mismatch (#405)",
+			"LyraEditor modifies the values of properties: [ UnreachableCodeWarningLevel: Off != Error ]. " +
+				"This is not allowed, as LyraEditor has build products in common with UnrealEditor.",
+			1, "BuildSettingsVersion"},
+		// #408 guard: generic shared-build clause with a non-warning property must NOT match
+		{"generic shared-build violation does not match",
+			"FooEditor modifies the values of properties: [ GlobalDefinitions ]. " +
+				"This is not allowed, as FooEditor has build products in common with UnrealEditor.",
+			0, ""},
+	}
 
-	t.Run("single match", func(t *testing.T) {
-		hints := matchBuildLogHints("error: GameFeatureData is missing from disk")
-		if len(hints) != 1 || !strings.Contains(hints[0], "Missing game content") {
-			t.Errorf("unexpected hints: %v", hints)
-		}
-	})
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertHints(t, matchBuildLogHints(tt.content), tt.wantCount, tt.wantHint)
+		})
+	}
+}
 
-	t.Run("multiple distinct matches", func(t *testing.T) {
-		content := "C1076: compiler limit reached\nalso LINUX_MULTIARCH_ROOT not set"
-		hints := matchBuildLogHints(content)
-		if len(hints) != 2 {
-			t.Errorf("expected 2 hints, got %d: %v", len(hints), hints)
-		}
-	})
-
-	t.Run("duplicate hint deduped", func(t *testing.T) {
-		// Both SAC patterns... use two patterns that map to distinct hints, then
-		// repeat one pattern to confirm dedup by hint.
-		content := "GameFeatureData is missing ... GameFeatureData is missing again"
-		hints := matchBuildLogHints(content)
-		if len(hints) != 1 {
-			t.Errorf("expected deduped single hint, got %v", hints)
-		}
-	})
-
-	t.Run("build settings mismatch hint (#405)", func(t *testing.T) {
-		// The UBT failure when an older project target conflicts with newer engine
-		// warning-level defaults (e.g. Lyra V6 vs UE 5.8).
-		content := "LyraEditor modifies the values of properties: [ ... ]. " +
-			"This is not allowed, as LyraEditor has build products in common with UnrealEditor."
-		hints := matchBuildLogHints(content)
-		if len(hints) != 1 || !strings.Contains(hints[0], "BuildSettingsVersion") {
-			t.Errorf("expected BuildSettingsVersion hint, got %v", hints)
-		}
-	})
+// assertHints checks the hint slice length and (for single matches) a substring
+// of the first hint, keeping the test loop body under the complexity limit.
+func assertHints(t *testing.T, hints []string, wantCount int, wantHint string) {
+	t.Helper()
+	if len(hints) != wantCount {
+		t.Fatalf("got %d hints, want %d: %v", len(hints), wantCount, hints)
+	}
+	if wantHint != "" && !strings.Contains(hints[0], wantHint) {
+		t.Errorf("hint %q does not contain %q", hints[0], wantHint)
+	}
 }
 
 func TestDiagnoseBuildError_AppendsLogHints(t *testing.T) {

--- a/internal/game/logic_test.go
+++ b/internal/game/logic_test.go
@@ -89,6 +89,17 @@ func TestMatchBuildLogHints(t *testing.T) {
 			t.Errorf("expected deduped single hint, got %v", hints)
 		}
 	})
+
+	t.Run("build settings mismatch hint (#405)", func(t *testing.T) {
+		// The UBT failure when an older project target conflicts with newer engine
+		// warning-level defaults (e.g. Lyra V6 vs UE 5.8).
+		content := "LyraEditor modifies the values of properties: [ ... ]. " +
+			"This is not allowed, as LyraEditor has build products in common with UnrealEditor."
+		hints := matchBuildLogHints(content)
+		if len(hints) != 1 || !strings.Contains(hints[0], "BuildSettingsVersion") {
+			t.Errorf("expected BuildSettingsVersion hint, got %v", hints)
+		}
+	})
 }
 
 func TestDiagnoseBuildError_AppendsLogHints(t *testing.T) {


### PR DESCRIPTION
## Summary

Fixes #405. Cooking an older project (e.g. Lyra pinned to `BuildSettingsVersion.V6`) against UE 5.8 fails with an opaque UBT error and `ExitCode=6`:
```
LyraEditor modifies the values of properties: [ UnreachableCodeWarningLevel: Off != Error, ... ].
This is not allowed, as LyraEditor has build products in common with UnrealEditor.
```
UE 5.8 promotes Unreachable/ReturnType/Dangling warnings to `Error` by default; an older `DefaultBuildSettings` leaves them `Off`, and UBT rejects the mismatch against shared UnrealEditor build products.

## Fix
Add a `knownLogPatterns` entry (the existing build-log diagnostic mechanism) matching `has build products in common with` → actionable hint to bump `DefaultBuildSettings` to `BuildSettingsVersion.Latest` in the project's `*.Target.cs`.

This is a project/engine-version compatibility gap (not a ludus build bug), but the bare ExitCode=6 was unhelpful.

## Tests
Added a subtest to `TestMatchBuildLogHints` exercising the new pattern. Under CCN 8.

## Provenance
Discovered during the live UE 5.8 + Lyra E2E (Lyra V6 targets failed to cook until bumped to Latest).

Closes #405