### PR TITLE
fix(game): package server self-contained with -pak -iostore (#406)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,8 +33,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - **Stale `ludus-test` binary removed from repo.** The 59 MB test binary (produced by `go test -c`) was accidentally committed in PR #368 because `.gitignore` only covered `ludus`, `ludus.exe`, and `ludus-*.exe` — not extensionless test binaries. Added `ludus-test` to `.gitignore` to prevent recurrence (#373).
 
-## [Unreleased]
-
 ## [0.8.1] - 2026-06-23
 
 Build-host ergonomics and a batch of backlog fixes.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+
+- **Game server builds are now self-contained.** Server `BuildCookRun` adds `-pak -iostore` so the deployed server loads cooked data from disk instead of requiring a running Unreal Zen Store at runtime (#406). Client builds take a one-time cache invalidation on upgrade — a build-args schema token was added to the game cache keys for future-proofing; client args themselves are unchanged (#409).
+
 ## [0.8.2] - 2026-06-27
 
 **Patch release.** Centralizes AWS account/region resolution and ECR URI construction, with follow-up fixes across deploy, setup, and MCP paths.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,12 +5,6 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
-
-### Changed
-
-- **Game server builds are now self-contained.** Server `BuildCookRun` adds `-pak -iostore` so the deployed server loads cooked data from disk instead of requiring a running Unreal Zen Store at runtime (#406). Client builds take a one-time cache invalidation on upgrade — a build-args schema token was added to the game cache keys for future-proofing; client args themselves are unchanged (#409).
-
 ## [0.8.2] - 2026-06-27
 
 **Patch release.** Centralizes AWS account/region resolution and ECR URI construction, with follow-up fixes across deploy, setup, and MCP paths.

--- a/internal/cache/cache_keys.go
+++ b/internal/cache/cache_keys.go
@@ -10,6 +10,13 @@ import (
 	"github.com/jpvelasco/ludus/internal/config"
 )
 
+// buildArgsSchema versions the BuildCookRun argument set for the game build
+// stages. Bump it whenever the server/client build args change in a way that
+// alters the packaged output, so an existing warm .ludus/cache.json entry does
+// not skip the rebuild and keep deploying a stale package.
+//   - v2: added -pak -iostore to the server build (self-contained packaging, #406)
+const buildArgsSchema = "v2"
+
 // hash computes a SHA-256 hex digest from a list of key-value strings.
 func hash(parts ...string) string {
 	h := sha256.New()
@@ -50,6 +57,7 @@ func GameServerKey(cfg *config.Config, engineHash string) string {
 		fmt.Sprintf("%v", cfg.Game.SkipCook),
 		cfg.Engine.Version,
 		cfg.Game.ResolvedArch(),
+		buildArgsSchema,
 	)
 }
 
@@ -69,6 +77,7 @@ func GameClientKey(cfg *config.Config, engineHash string, platform string) strin
 		fmt.Sprintf("%v", cfg.Game.SkipCook),
 		cfg.Engine.Version,
 		cfg.Game.ResolvedArch(),
+		buildArgsSchema,
 	)
 }
 

--- a/internal/cache/cache_keys.go
+++ b/internal/cache/cache_keys.go
@@ -16,6 +16,11 @@ import (
 // and keep deploying a stale package. Server and client are versioned separately
 // so a server-only change does not needlessly invalidate the client cache.
 //   - server-v2: added -pak -iostore (self-contained packaging, #406)
+//   - client-v1: introduces the schema mechanism on the client key for future
+//     protection; client args are unchanged in this PR, so existing client
+//     caches take a one-time invalidation on upgrade. This is the standard
+//     (one-time) cost of introducing cache versioning — omitting it now would
+//     leave the client path with the #409 hole and defer the same miss to later.
 const (
 	serverBuildArgsSchema = "server-v2"
 	clientBuildArgsSchema = "client-v1"

--- a/internal/cache/cache_keys.go
+++ b/internal/cache/cache_keys.go
@@ -10,12 +10,16 @@ import (
 	"github.com/jpvelasco/ludus/internal/config"
 )
 
-// buildArgsSchema versions the BuildCookRun argument set for the game build
-// stages. Bump it whenever the server/client build args change in a way that
-// alters the packaged output, so an existing warm .ludus/cache.json entry does
-// not skip the rebuild and keep deploying a stale package.
-//   - v2: added -pak -iostore to the server build (self-contained packaging, #406)
-const buildArgsSchema = "v2"
+// Build-args schema versions for the game build stages. Bump the relevant token
+// whenever that stage's BuildCookRun args change in a way that alters the
+// packaged output, so a warm .ludus/cache.json entry does not skip the rebuild
+// and keep deploying a stale package. Server and client are versioned separately
+// so a server-only change does not needlessly invalidate the client cache.
+//   - server-v2: added -pak -iostore (self-contained packaging, #406)
+const (
+	serverBuildArgsSchema = "server-v2"
+	clientBuildArgsSchema = "client-v1"
+)
 
 // hash computes a SHA-256 hex digest from a list of key-value strings.
 func hash(parts ...string) string {
@@ -57,7 +61,7 @@ func GameServerKey(cfg *config.Config, engineHash string) string {
 		fmt.Sprintf("%v", cfg.Game.SkipCook),
 		cfg.Engine.Version,
 		cfg.Game.ResolvedArch(),
-		buildArgsSchema,
+		serverBuildArgsSchema,
 	)
 }
 
@@ -77,7 +81,7 @@ func GameClientKey(cfg *config.Config, engineHash string, platform string) strin
 		fmt.Sprintf("%v", cfg.Game.SkipCook),
 		cfg.Engine.Version,
 		cfg.Game.ResolvedArch(),
-		buildArgsSchema,
+		clientBuildArgsSchema,
 	)
 }
 

--- a/internal/cache/cache_keys_test.go
+++ b/internal/cache/cache_keys_test.go
@@ -57,6 +57,27 @@ func TestGameServerKey_DifferentArchDifferentKey(t *testing.T) {
 	}
 }
 
+// TestBuildArgsSchemaInGameKeys guards #409: the build-args schema version must
+// participate in the game build cache keys, so bumping it when build args change
+// (e.g. adding -pak -iostore) invalidates stale cache entries and forces a
+// rebuild. We verify by re-hashing with the same inputs plus a different schema
+// token and confirming the result differs.
+func TestBuildArgsSchemaInGameKeys(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{SourcePath: "/fake/engine", Version: "5.8.0"},
+		Game:   config.GameConfig{ProjectPath: "/fake/p.uproject", ProjectName: "G", ServerTarget: "GServer", Arch: "amd64"},
+	}
+
+	// The current key includes buildArgsSchema. A key built from the same inputs
+	// but a different schema token must differ — proving the schema is hashed in.
+	current := GameServerKey(cfg, "eng")
+	bumped := hash("eng", fileKey("/fake/p.uproject"), cfg.Game.ResolvedServerTarget(),
+		cfg.Game.ResolvedGameTarget(), cfg.Game.ServerMap, "false", "5.8.0", "amd64", "vNEXT")
+	if current == bumped {
+		t.Error("GameServerKey must incorporate buildArgsSchema (a schema bump must change the key)")
+	}
+}
+
 func TestContainerKey_DifferentPort(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmpDir, "test.bin"), []byte("data"), 0644); err != nil {

--- a/internal/cache/cache_keys_test.go
+++ b/internal/cache/cache_keys_test.go
@@ -57,25 +57,43 @@ func TestGameServerKey_DifferentArchDifferentKey(t *testing.T) {
 	}
 }
 
-// TestBuildArgsSchemaInGameKeys guards #409: the build-args schema version must
+// TestBuildArgsSchemaInGameKeys guards #409: the build-args schema token must
 // participate in the game build cache keys, so bumping it when build args change
 // (e.g. adding -pak -iostore) invalidates stale cache entries and forces a
-// rebuild. We verify by re-hashing with the same inputs plus a different schema
-// token and confirming the result differs.
+// rebuild. The assertion compares against the key WITHOUT any schema token, so
+// it fails if GameServerKey/GameClientKey ever stop hashing the schema (a weaker
+// "differs from a different token" check would pass even if the schema were
+// dropped entirely — Codex #409).
 func TestBuildArgsSchemaInGameKeys(t *testing.T) {
 	cfg := &config.Config{
 		Engine: config.EngineConfig{SourcePath: "/fake/engine", Version: "5.8.0"},
 		Game:   config.GameConfig{ProjectPath: "/fake/p.uproject", ProjectName: "G", ServerTarget: "GServer", Arch: "amd64"},
 	}
 
-	// The current key includes buildArgsSchema. A key built from the same inputs
-	// but a different schema token must differ — proving the schema is hashed in.
-	current := GameServerKey(cfg, "eng")
-	bumped := hash("eng", fileKey("/fake/p.uproject"), cfg.Game.ResolvedServerTarget(),
-		cfg.Game.ResolvedGameTarget(), cfg.Game.ServerMap, "false", "5.8.0", "amd64", "vNEXT")
-	if current == bumped {
-		t.Error("GameServerKey must incorporate buildArgsSchema (a schema bump must change the key)")
-	}
+	t.Run("server key hashes its schema", func(t *testing.T) {
+		current := GameServerKey(cfg, "eng")
+		noSchema := hash("eng", fileKey("/fake/p.uproject"), cfg.Game.ResolvedServerTarget(),
+			cfg.Game.ResolvedGameTarget(), cfg.Game.ServerMap, "false", "5.8.0", "amd64")
+		if current == noSchema {
+			t.Error("GameServerKey must hash serverBuildArgsSchema (dropping it must change the key)")
+		}
+	})
+
+	t.Run("client key hashes its schema", func(t *testing.T) {
+		current := GameClientKey(cfg, "eng", "Linux")
+		noSchema := hash("eng", fileKey("/fake/p.uproject"), cfg.Game.ResolvedClientTarget(),
+			"Linux", "false", "5.8.0", "amd64")
+		if current == noSchema {
+			t.Error("GameClientKey must hash clientBuildArgsSchema (dropping it must change the key)")
+		}
+	})
+
+	t.Run("server and client schemas are independent", func(t *testing.T) {
+		// A server-only schema bump must not change the client key.
+		if serverBuildArgsSchema == clientBuildArgsSchema {
+			t.Error("server and client schema tokens must be distinct so a server-only bump doesn't invalidate the client cache")
+		}
+	})
 }
 
 func TestContainerKey_DifferentPort(t *testing.T) {

--- a/internal/dockerbuild/game_script.go
+++ b/internal/dockerbuild/game_script.go
@@ -136,13 +136,16 @@ fi
 
 	uePlatform := config.UEPlatformName(b.resolveArch())
 	serverPlatform := config.UEServerPlatformName(b.resolveArch())
+	// -pak -iostore produce a self-contained server (pak + IoStore) so the
+	// deployed binary loads cooked data from disk rather than relying on Zen
+	// loose-file streaming, which a deployed server cannot reach. (#406)
 	args := fmt.Sprintf(`bash Engine/Build/BatchFiles/RunUAT.sh BuildCookRun \
   -project="%s" \
   -platform=%s \
   -serverplatform=%s \
   -server -noclient \
   -servertargetname=%s \
-  -build -stage -package -archive \
+  -build -stage -package -pak -iostore -archive \
   -archivedirectory="/output"`,
 		projectPath, uePlatform, serverPlatform, serverTarget)
 

--- a/internal/dockerbuild/game_script_test.go
+++ b/internal/dockerbuild/game_script_test.go
@@ -19,7 +19,7 @@ var generateBuildScriptServerTests = []struct {
 		contains: []string{
 			"#!/bin/bash", "set -e", "RunUAT.sh BuildCookRun",
 			"-server -noclient", "-servertargetname=LyraServer",
-			"-build -stage -package -archive", `-archivedirectory="/output"`,
+			"-build -stage -package -pak -iostore -archive", `-archivedirectory="/output"`,
 			"-cook", "Lyra/Lyra.uproject", "DefaultServerTarget",
 		},
 		notContains: []string{"-skipcook"},

--- a/internal/game/server_build_args.go
+++ b/internal/game/server_build_args.go
@@ -34,6 +34,12 @@ func (b *Builder) baseServerBuildArgs(projectPath, outputDir, serverTarget, arch
 		"-build",
 		"-stage",
 		"-package",
+		// -pak -iostore produce a self-contained server (pak + IoStore .utoc/.ucas)
+		// so the deployed binary loads cooked data from disk. Without these the
+		// staged build relies on Zen loose-file streaming and a deployed server
+		// exits at launch ("Unreal Zen Storage process not currently running"). (#406)
+		"-pak",
+		"-iostore",
 		"-archive",
 		fmt.Sprintf(`-archivedirectory="%s"`, outputDir),
 	}

--- a/internal/game/server_build_args_test.go
+++ b/internal/game/server_build_args_test.go
@@ -41,6 +41,8 @@ func TestResolveServerBuildArgs(t *testing.T) {
 		"-servertargetname=LyraDedicated",
 		"-serverconfig=Shipping",
 		"-cook",
+		"-pak",
+		"-iostore",
 		`-map="L_Expanse"`,
 		"-MaxParallelActions=4",
 	} {


### PR DESCRIPTION
## Summary

Fixes #406. The server `BuildCookRun` passed `-stage -package -archive` but **no `-pak`/`-iostore`**, so the staged output was loose cooked files served via Zen loose-file streaming. A deployed server then exits at launch:
```
Network data streaming failed to connect ... the Unreal Zen Storage process not currently running ...
you can use an installed build without network data streaming by building with the '-pak' argument.
```
The build/cook/package all succeed — only the runtime packaging mode is wrong for a standalone deployment.

## Fix
Add `-pak -iostore` to the server build args in **both** paths:
- `internal/game/server_build_args.go` (native)
- `internal/dockerbuild/game_script.go` (container)

This produces a self-contained server (pak + IoStore `.utoc`/`.ucas`) that loads cooked data from disk. Client build args are unchanged.

## Tests
- `server_build_args_test.go`: assert `-pak` and `-iostore` present in the resolved native args.
- `game_script_test.go`: updated the server-script assertion to `-build -stage -package -pak -iostore -archive`; client assertion unchanged.

## ⚠️ Validation note
This changes packaging *output* — it's the one change in this batch I want confirmed on the **Windows EC2 validation run** (a deployed server that actually launches + accepts a session). Local build/test/lint all green; runtime behavior validated next.

## Provenance
Discovered during the live UE 5.8 deploy-anywhere E2E (the #393 liveness check correctly caught the deployed server exiting on the missing Zen stream).

Closes #406