### PR TITLE
fix: treat absent SAC policy value as off (#410)

### DIFF
--- a/internal/prereq/checker_sac_test.go
+++ b/internal/prereq/checker_sac_test.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package prereq
+
+import "testing"
+
+func TestInterpretSACState(t *testing.T) {
+	tests := []struct {
+		name       string
+		state      string
+		wantActive bool
+		wantMode   string
+	}{
+		{"empty property absent", "", false, ""},
+		{"missing key sentinel", "missing", false, ""},
+		{"explicit off", "0", false, ""},
+		{"enforce", "1", true, "enforcement"},
+		{"evaluation", "2", true, "evaluation"},
+		{"unexpected value", "99", false, ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			active, mode := interpretSACState(tt.state)
+			if active != tt.wantActive || mode != tt.wantMode {
+				t.Errorf("interpretSACState(%q) = (%v, %q); want (%v, %q)",
+					tt.state, active, mode, tt.wantActive, tt.wantMode)
+			}
+		})
+	}
+}

--- a/internal/prereq/checker_sdk.go
+++ b/internal/prereq/checker_sdk.go
@@ -101,19 +101,13 @@ func (c *Checker) checkSmartAppControl() CheckResult {
 		}
 	}
 
-	state := strings.TrimSpace(string(out))
-
-	if state == "0" || state == "missing" {
+	active, mode := interpretSACState(strings.TrimSpace(string(out)))
+	if !active {
 		return CheckResult{
 			Name:    "Smart App Control",
 			Passed:  true,
 			Message: "Smart App Control is off",
 		}
-	}
-
-	mode := "enforcement"
-	if state == "2" {
-		mode = "evaluation"
 	}
 
 	blocked := c.scanCodeIntegrityBlocks()
@@ -122,6 +116,23 @@ func (c *Checker) checkSmartAppControl() CheckResult {
 		Name:    "Smart App Control",
 		Passed:  false,
 		Message: buildSACMessage(mode, blocked),
+	}
+}
+
+// interpretSACState maps the VerifiedAndReputablePolicyState registry value to
+// whether Smart App Control is actively blocking and, if so, its mode. Only "1"
+// (enforce) and "2" (evaluation) are active. An empty string means the property
+// is absent — which happens on Windows Server SKUs where the CI\Policy key
+// exists but the value does not — and must be treated as off, the same as "0"
+// or the "missing" sentinel returned when the whole key is absent.
+func interpretSACState(state string) (active bool, mode string) {
+	switch state {
+	case "1":
+		return true, "enforcement"
+	case "2":
+		return true, "evaluation"
+	default: // "", "0", "missing", or any unexpected value → not enforcing
+		return false, ""
 	}
 }
 


### PR DESCRIPTION
## What

`checkSmartAppControl` mapped only `"0"` and the `"missing"` sentinel to "SAC off". On Windows Server 2022 the `CI\Policy` key exists but the `VerifiedAndReputablePolicyState` **property** is absent, so `Get-ItemProperty` returns `$null` → empty string, which fell through to "enforcement mode" and **failed** the check — telling the user to turn off SAC (an irreversible action) when there was nothing to turn off.

## Fix

Extract a pure `interpretSACState(state)` helper. Only `"1"` (enforce) and `"2"` (evaluation) are active; `""`, `"0"`, `"missing"`, and any unexpected value are off. Table-driven unit test over the mapping.

## Validation

Reproduced and verified live on the UE 5.8 Windows Server 2022 validation box:
- `VerifiedAndReputablePolicyState` property **absent** under `CI\Policy` (`Get-ItemProperty ... .VerifiedAndReputablePolicyState` → empty).
- SAC empirically **not** enforcing: unsigned source-built `ludus.exe` and a full UE 5.8 Lyra cook (unsigned UE DLLs) ran to completion with **zero** `GetLastError=4551`.

Closes #410.

## Test plan
- [x] `go build` (windows)
- [x] `go test ./internal/prereq/ -run TestInterpretSACState` (all cases pass)
- [x] `golangci-lint run ./internal/prereq/` — 0 issues
- [x] gocyclo -over 8 clean