### PR TITLE
fix: detect VS 2022 Build Tools via vswhere -products * (#411)

### DIFF
--- a/internal/prereq/checker_msvc.go
+++ b/internal/prereq/checker_msvc.go
@@ -79,7 +79,7 @@ func findVSInstalls(vswherePath string) ([]vswhereResult, error) {
 		return nil, fmt.Errorf("vswhere.exe not found; install Visual Studio with C++ workloads")
 	}
 
-	out, err := exec.Command(vswherePath, "-format", "json", "-utf8").Output()
+	out, err := exec.Command(vswherePath, vswhereListArgs()...).Output()
 	if err != nil {
 		return nil, fmt.Errorf("vswhere failed: %v", err)
 	}
@@ -91,14 +91,25 @@ func findVSInstalls(vswherePath string) ([]vswhereResult, error) {
 	return installs, nil
 }
 
+// vswhereListArgs builds the vswhere args to enumerate installed VS instances.
+// -products * includes the BuildTools edition; without it vswhere only returns
+// the IDE editions (Community/Professional/Enterprise), so a headless
+// Build-Tools-only install reports as "no Visual Studio detected".
+func vswhereListArgs() []string {
+	return []string{"-products", "*", "-format", "json", "-utf8"}
+}
+
+// vswhereRequiresArgs builds the vswhere args to check for a component, scoped
+// to all products (including BuildTools) for the same reason as vswhereListArgs.
+func vswhereRequiresArgs(componentID string) []string {
+	return []string{"-products", "*", "-requires", componentID, "-format", "json", "-utf8"}
+}
+
 // findMissingComponents checks which required VS components are not installed.
 func findMissingComponents(vswherePath string, required []vsComponent) []string {
 	var missing []string
 	for _, comp := range required {
-		compOut, compErr := exec.Command(vswherePath,
-			"-requires", comp.id,
-			"-format", "json", "-utf8",
-		).Output()
+		compOut, compErr := exec.Command(vswherePath, vswhereRequiresArgs(comp.id)...).Output()
 		if compErr != nil {
 			missing = append(missing, comp.name)
 			continue

--- a/internal/prereq/checker_msvc_test.go
+++ b/internal/prereq/checker_msvc_test.go
@@ -50,3 +50,43 @@ func TestMSVCVersionForEngine(t *testing.T) {
 		})
 	}
 }
+
+// containsProductsStar reports whether args scope vswhere to all products,
+// which is what makes the BuildTools edition discoverable.
+func containsProductsStar(args []string) bool {
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-products" && args[i+1] == "*" {
+			return true
+		}
+	}
+	return false
+}
+
+// TestVswhereArgsScopeAllProducts guards the #411 fix: both the instance-listing
+// and component-checking vswhere invocations must pass "-products *", otherwise
+// a headless VS 2022 Build Tools install is reported as "no Visual Studio detected".
+func TestVswhereArgsScopeAllProducts(t *testing.T) {
+	if !containsProductsStar(vswhereListArgs()) {
+		t.Errorf("vswhereListArgs() = %v; missing -products *", vswhereListArgs())
+	}
+	reqArgs := vswhereRequiresArgs("Microsoft.VisualStudio.Component.VC.Tools.x86.x64")
+	if !containsProductsStar(reqArgs) {
+		t.Errorf("vswhereRequiresArgs() = %v; missing -products *", reqArgs)
+	}
+}
+
+// TestVswhereRequiresArgsIncludesComponent confirms the component id is threaded
+// into the -requires query.
+func TestVswhereRequiresArgsIncludesComponent(t *testing.T) {
+	const id = "Microsoft.VisualStudio.Component.VC.14.44.17.14.x86.x64"
+	args := vswhereRequiresArgs(id)
+	found := false
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "-requires" && args[i+1] == id {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("vswhereRequiresArgs(%q) = %v; component id not present", id, args)
+	}
+}


### PR DESCRIPTION
## What

`findVSInstalls` and `findMissingComponents` called `vswhere` without `-products *`, so vswhere returned only the IDE editions (Community/Professional/Enterprise) and **excluded the BuildTools edition**. On a headless box with VS 2022 Build Tools — the standard non-interactive install — `ludus init` reported **"no Visual Studio installation detected"** even though the required MSVC component was present and the engine built fine.

## Fix

Extract `vswhereListArgs()` and `vswhereRequiresArgs(id)`, both scoped with `-products *`. Unit-test that the scope and component id are threaded through.

## Validation

Reproduced and verified live on the UE 5.8 Windows Server 2022 box (VS 2022 Build Tools + MSVC 14.44):
- `vswhere -format json -utf8` → `[]`
- `vswhere -products * -format json -utf8` → `Visual Studio Build Tools 2022` (`Microsoft.VisualStudio.Product.BuildTools`)
- The native UE 5.8 engine build + Lyra cook completed cleanly with MSVC 14.44.

Closes #411.

## Test plan
- [x] `go build` (windows)
- [x] `go test ./internal/prereq/ -run TestVswhere`
- [x] `golangci-lint run ./internal/prereq/` — 0 issues
- [x] gocyclo -over 8 clean