### PR TITLE
feat: add --skip-setup to engine build for headless Windows (#412)

### DIFF
--- a/cmd/engine/engine.go
+++ b/cmd/engine/engine.go
@@ -28,6 +28,7 @@ var (
 	noCache    bool
 	baseImage  string
 	skipEngine bool
+	skipSetup  bool
 	keepCache  bool
 	wslNative  bool
 	wslDistro  string
@@ -81,6 +82,7 @@ func init() {
 	buildCmd.Flags().BoolVar(&noCache, "no-cache", false, "disable build caching (forces rebuild even if inputs are unchanged)")
 	buildCmd.Flags().StringVar(&baseImage, "base-image", "", "base image for container builds (default: from ludus.yaml or ubuntu:22.04)")
 	buildCmd.Flags().BoolVar(&skipEngine, "skip-engine", false, "skip engine compilation; package pre-built Linux binaries into the image")
+	buildCmd.Flags().BoolVar(&skipSetup, "skip-setup", false, "skip the Setup step (Setup.sh/Setup.bat); use when dependencies are already fetched (avoids redist-installer hangs on headless Windows)")
 	buildCmd.Flags().BoolVar(&keepCache, "keep-cache", false, "retain BuildKit intermediate layer cache after build (default: cache is pruned to reclaim ~200 GB)")
 	buildCmd.Flags().BoolVar(&wslNative, "wsl-native", false, "sync engine source to WSL2 native ext4 for faster builds")
 	buildCmd.Flags().StringVar(&wslDistro, "wsl-distro", "", "WSL2 distro override (default: first running WSL2 distro)")
@@ -113,6 +115,7 @@ func makeBuilder() (*engBuilder.Builder, error) {
 		SourcePath: sourcePath,
 		MaxJobs:    maxJobs,
 		Verbose:    globals.Verbose,
+		SkipSetup:  skipSetup,
 	}, r), nil
 }
 

--- a/cmd/mcp/tools_async.go
+++ b/cmd/mcp/tools_async.go
@@ -29,6 +29,7 @@ type engineBuildStartInput struct {
 	Backend   string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, podman, or wsl2 (default: from config)"`
 	NoCache   bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
 	DryRun    bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
+	SkipSetup bool   `json:"skip_setup,omitempty" jsonschema:"Skip the Setup step (Setup.sh/Setup.bat) when dependencies are already fetched; avoids redist-installer hangs on headless Windows (native backend only)"`
 	WSLNative bool   `json:"wsl_native,omitempty" jsonschema:"Sync engine source to WSL2 native ext4 for faster builds (requires backend=wsl2)"`
 	WSLDistro string `json:"wsl_distro,omitempty" jsonschema:"WSL2 distro override (default: first running WSL2 distro)"`
 }
@@ -159,7 +160,7 @@ func handleEngineBuildStart(_ context.Context, _ *mcp.CallToolRequest, input eng
 	if dockerbuild.IsWSL2Backend(be) {
 		return startWSL2EngineBuild(cfg, input, dryRun, jobs, engineHash)
 	}
-	return startNativeEngineBuild(cfg, dryRun, jobs, engineHash)
+	return startNativeEngineBuild(cfg, dryRun, jobs, engineHash, input.SkipSetup)
 }
 
 func handleGameBuildStart(_ context.Context, _ *mcp.CallToolRequest, input gameBuildStartInput) (*mcp.CallToolResult, any, error) {
@@ -314,7 +315,7 @@ func startWSL2EngineBuild(cfg *config.Config, input engineBuildStartInput, dryRu
 	return resultOK(buildStartResult{BuildID: id, Type: string(buildTypeEngineBuild), Message: "WSL2 engine build started. Poll with ludus_build_status."})
 }
 
-func startNativeEngineBuild(cfg *config.Config, dryRun bool, jobs int, engineHash string) (*mcp.CallToolResult, any, error) {
+func startNativeEngineBuild(cfg *config.Config, dryRun bool, jobs int, engineHash string, skipSetup bool) (*mcp.CallToolResult, any, error) {
 	id, err := builds.Start(buildTypeEngineBuild, func(ctx context.Context, buf *syncBuffer) (any, error) {
 		r := &runner.Runner{Stdout: buf, Stderr: buf, Verbose: true, DryRun: dryRun}
 
@@ -322,6 +323,7 @@ func startNativeEngineBuild(cfg *config.Config, dryRun bool, jobs int, engineHas
 			SourcePath: cfg.Engine.SourcePath,
 			MaxJobs:    jobs,
 			Verbose:    true,
+			SkipSetup:  skipSetup,
 		}, r).Build(ctx)
 		if buildErr != nil {
 			return nil, fmt.Errorf("engine build failed: %w", buildErr)

--- a/cmd/mcp/tools_engine.go
+++ b/cmd/mcp/tools_engine.go
@@ -29,6 +29,7 @@ type engineBuildInput struct {
 	Backend   string `json:"backend,omitempty" jsonschema:"Build backend: native, docker, podman, or wsl2 (default: from config)"`
 	NoCache   bool   `json:"no_cache,omitempty" jsonschema:"Disable build caching (force rebuild even if inputs are unchanged)"`
 	DryRun    bool   `json:"dry_run,omitempty" jsonschema:"Print commands without executing"`
+	SkipSetup bool   `json:"skip_setup,omitempty" jsonschema:"Skip the Setup step (Setup.sh/Setup.bat) when dependencies are already fetched; avoids redist-installer hangs on headless Windows (native backend only)"`
 	WSLNative bool   `json:"wsl_native,omitempty" jsonschema:"Sync engine source to WSL2 native ext4 for faster builds (requires backend=wsl2)"`
 	WSLDistro string `json:"wsl_distro,omitempty" jsonschema:"WSL2 distro override (default: first running WSL2 distro)"`
 }
@@ -125,6 +126,7 @@ func handleEngineBuild(ctx context.Context, _ *mcp.CallToolRequest, input engine
 		SourcePath: cfg.Engine.SourcePath,
 		MaxJobs:    jobs,
 		Verbose:    true,
+		SkipSetup:  input.SkipSetup,
 	}, r)
 
 	var result engineResult

--- a/cmd/mcp/tools_engine_test.go
+++ b/cmd/mcp/tools_engine_test.go
@@ -81,6 +81,52 @@ func TestEngineBuildWSL2Dispatch(t *testing.T) {
 	assertResultContains(t, result, "WSL2")
 }
 
+// TestEngineBuildInputSkipSetup verifies the skip_setup field round-trips and
+// is omitted when false (the #412 MCP surface).
+func TestEngineBuildInputSkipSetup(t *testing.T) {
+	data, err := json.Marshal(engineBuildInput{SkipSetup: true})
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if !strings.Contains(string(data), "skip_setup") {
+		t.Errorf("skip_setup should be present when true, got: %s", data)
+	}
+
+	off, err := json.Marshal(engineBuildInput{Backend: "native"})
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+	if strings.Contains(string(off), "skip_setup") {
+		t.Errorf("skip_setup should be omitted when false, got: %s", off)
+	}
+}
+
+// TestEngineBuildSkipSetupDryRun drives the native handler with skip_setup=true
+// and dry-run, asserting the Setup step is skipped (the #412 wiring reaches
+// engine.BuildOptions.SkipSetup). A dry-run native build prints the commands
+// without executing them, so this is safe on CI with no engine tree.
+func TestEngineBuildSkipSetupDryRun(t *testing.T) {
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = &config.Config{
+		Engine: config.EngineConfig{SourcePath: t.TempDir(), Backend: "native"},
+	}
+
+	result, _, err := handleEngineBuild(context.Background(), nil, engineBuildInput{
+		Backend:   "native",
+		SkipSetup: true,
+		NoCache:   true,
+		DryRun:    true,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result == nil {
+		t.Fatal("expected non-nil result")
+	}
+	assertResultContains(t, result, "Skipping Setup")
+}
+
 // assertResultContains checks that a CallToolResult's text content contains substr.
 func assertResultContains(t *testing.T, result *mcpsdk.CallToolResult, substr string) {
 	t.Helper()

--- a/internal/engine/builder.go
+++ b/internal/engine/builder.go
@@ -18,6 +18,12 @@ type BuildOptions struct {
 	MaxJobs int
 	// Verbose enables detailed build output.
 	Verbose bool
+	// SkipSetup bypasses the Setup step (Setup.sh / Setup.bat). On headless
+	// Windows, Setup.bat's bundled redist installers (VC++, GameInput) block
+	// waiting on UI that never appears, wedging the build. Set this when the
+	// engine dependencies have already been fetched (e.g. a prior GitDependencies
+	// run) so the build can proceed straight to GenerateProjectFiles + compile.
+	SkipSetup bool
 }
 
 // BuildResult holds the outcome of an engine build.
@@ -48,11 +54,15 @@ func (b *Builder) Build(ctx context.Context) (*BuildResult, error) {
 	start := time.Now()
 	result := &BuildResult{EnginePath: b.opts.SourcePath}
 
-	// Step 1: Setup
-	fmt.Println("  Running Setup...")
-	if err := b.Setup(ctx); err != nil {
-		result.Error = fmt.Errorf("setup failed: %w", err)
-		return result, result.Error
+	// Step 1: Setup (skippable — see BuildOptions.SkipSetup)
+	if b.opts.SkipSetup {
+		fmt.Println("  Skipping Setup (--skip-setup); assuming dependencies are already present...")
+	} else {
+		fmt.Println("  Running Setup...")
+		if err := b.Setup(ctx); err != nil {
+			result.Error = fmt.Errorf("setup failed: %w", err)
+			return result, result.Error
+		}
 	}
 
 	// Step 2: Generate project files.

--- a/internal/engine/builder_test.go
+++ b/internal/engine/builder_test.go
@@ -1,0 +1,47 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+)
+
+// TestBuildSkipSetup verifies the SkipSetup gate: with an empty source tree,
+// a normal build fails at the Setup step (Setup.sh/Setup.bat not found), while
+// SkipSetup bypasses Setup entirely and fails at a later step instead — so the
+// error must never be a setup failure. This is the #412 headless-Windows fix,
+// where Setup.bat's redist installers hang in a non-interactive session.
+func TestBuildSkipSetup(t *testing.T) {
+	tests := []struct {
+		name           string
+		skipSetup      bool
+		wantSetupError bool
+	}{
+		{"setup runs by default", false, true},
+		{"setup skipped", true, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// DryRun runner so no real subprocess is spawned; the missing-file
+			// checks in Setup/GenerateProjectFiles happen before the runner.
+			r := runner.NewRunner(false, true)
+			b := NewBuilder(BuildOptions{SourcePath: t.TempDir(), SkipSetup: tt.skipSetup}, r)
+
+			result, err := b.Build(context.Background())
+			if err == nil {
+				t.Fatal("expected build to fail in an empty source tree")
+			}
+			gotSetupError := strings.Contains(err.Error(), "setup failed")
+			if gotSetupError != tt.wantSetupError {
+				t.Errorf("SkipSetup=%v: setup-error=%v, want %v (err: %v)",
+					tt.skipSetup, gotSetupError, tt.wantSetupError, err)
+			}
+			if result == nil {
+				t.Error("expected non-nil result even on failure")
+			}
+		})
+	}
+}


### PR DESCRIPTION
## What

`engine.Builder.Build` always ran Setup (`Setup.sh`/`Setup.bat`) as step 1. On a **headless Windows** host, `Setup.bat`'s bundled redist installers (VC++, and especially **GameInput**) block waiting on UI that never appears in a non-interactive SSM/WinRM session — wedging the build with no way to opt out.

## Fix

- `SkipSetup` field on `engine.BuildOptions`, honored in `Build()`.
- `--skip-setup` flag on `ludus engine build`.
- `skip_setup` param on the `ludus_engine_build` and `ludus_engine_build_start` MCP tools (native backend — the container/WSL2 paths use their own Linux toolchain bootstrap, not `Setup`).

Intended for when engine dependencies are already fetched (e.g. a prior `GitDependencies` run).

## Validation

Discovered during the UE 5.8 Windows validation run, where `Setup.bat` hung on the GameInput/VC++ redist installers in an SSM-only session; bypassing Setup (run `GenerateProjectFiles.bat` + `Build.bat` directly) unblocked a clean engine + Lyra cook. This flag makes that the supported path.

## Test plan
- [x] `go build`
- [x] `go test ./internal/engine/ -run TestBuildSkipSetup` (gate: default → setup error; skip → past setup)
- [x] `go test ./cmd/mcp/`
- [x] `golangci-lint run` on touched packages — 0 issues
- [x] gocyclo -over 8 clean

Closes #412.