### PR TITLE
docs: align AGENTS.md and CLAUDE.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,9 @@ golangci-lint run ./...
 # Test (all packages)
 go test ./...
 
+# Test with race detector (Linux/macOS; requires CGO)
+go test -race ./...
+
 # Test (single package)
 go test -v ./internal/toolchain
 
@@ -30,15 +33,15 @@ go vet ./...
 go mod tidy
 
 # Pre-commit hooks check
-.git/hooks/pre-commit
+.hooks/pre-commit
 ```
 
 ## Key Project Structure
 
 - `main.go` → `cmd/root/root.go` → subcommand packages in `cmd/`
 - `cmd/globals/globals.go` — shared mutable state (`Cfg`, `Verbose`, `DryRun`, `JSONOutput`, `Profile`)
-- `cmd/mcp/` — MCP server with 26 tools for AI orchestration  
-- `internal/` — all business logic (unexported), one primary type per file
+- `cmd/mcp/` — MCP server with 26 tools for AI orchestration
+- `internal/` — all business logic (unexported); most files stay close to one primary type, but some packages are deliberately split across sibling files by concern when complexity gets too high
 - Platform-specific files: `_windows.go` / `_unix.go` with `//go:build` tags
 
 ## Critical Features to Understand
@@ -55,13 +58,19 @@ go mod tidy
 - Cross-compilation from Windows to Linux binaries
 
 ### DDC (Derived Data Cache) Modes
-- `--ddc zen` (default, persistent UE Zen Store cache) 
-- `--ddc local` (legacy FileSystem cache)
+- `--ddc zen` (default, persistent UE Zen Store cache)
+- `--ddc local` (legacy FileSystem cache, deprecated — recommend `zen`)
 - `--ddc none` (disabled)
+
+### Coverage
+
+- Coverage is uploaded to Codecov from the ubuntu test leg via OIDC.
+- Patch coverage is enforced at 80% in `codecov.yml`; new or changed lines under that threshold post a failing `codecov/patch` status.
+- It is a soft block, not a required check, so genuinely E2E-only code can still merge with judgment.
 
 ## Development Environment
 
-- Go 1.25.10 required (see `go.mod`)
+- Go 1.25.11 required (see `go.mod`; CI follows it)
 - Linux or Windows with Docker/Podman for container builds
 - AWS CLI v2 configured with credentials
 - UE5 source with Lyra game assets (must be downloaded manually)
@@ -83,22 +92,23 @@ go mod tidy
 
 ## Communication Model
 
-Ludus uses the [Model Context Protocol](https://modelcontextprotocol.io/). 
+Ludus uses the [Model Context Protocol](https://modelcontextprotocol.io/).
 The MCP server is started with `ludus mcp` and exposes 26 tools for AI orchestration.
 
 ## Command Execution Patterns
 
 - Commands produce output via `fmt.Printf` (status) and `fmt.Fprintln(os.Stderr)` (warnings)
 - All test commands expect the working directory to be the project root
-- Commands with long-running operations provide `*_start` variants for async operations 
+- Commands with long-running operations provide `*_start` variants for async operations
 - Environment variables and CLI flags are merged with config precedence:
-  `config.yaml` → `--flag` → `mcp-parameter`
+  `ludus.yaml` → `--flag` → `mcp-parameter`
 
 ## Testing Constraints
 
-- All tests use Go standard library only
-- `t.TempDir()` for temporary directories  
-- `t.Setenv()` for environment variable overrides
-- `t.Chdir()` for working directory changes
-- All internal packages with tests (except deploy and version)
-- Unit test files co-located with source files
+- All tests use Go standard library only.
+- Prefer table-driven tests with `tt` as the loop variable, and keep tests in the same package when they need unexported symbols.
+- Use `t.TempDir()` for temporary directories, `t.Setenv()` for environment variable overrides, and `t.Chdir()` for working directory changes.
+- AWS/Docker/`wsl.exe`/subprocess-bound code (`gamelift`, `ec2fleet`, `stack`, `wrapper`, `wsl`, and most deploy logic) is E2E-covered; unit tests there should cover only the pure surface such as adapter `Name`/`Capabilities`, argument assembly, and parameter parsing.
+- Keep each test function under cyclomatic complexity 8. Codacy's Lizard check counts test files and fails PRs otherwise; convert flat assertion chains to map/table loops and extract `t.Run` bodies into named helpers. Verify with `go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 <file>` printing nothing.
+- Read mutex-guarded struct fields under the same lock in tests. CI runs `-race` on ubuntu and macOS, so unlocked reads of fields that a goroutine writes under a lock can fail CI even if they pass locally; a channel signal is not a happens-before edge for a lock-protected write.
+- Unit test files stay co-located with source files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,7 +20,13 @@ go mod tidy                                                          # Clean up 
 
 Pre-commit hooks at `.hooks/pre-commit` run build + lint + tests. Activate: `git config core.hooksPath .hooks`.
 
-CI runs 6 required checks on PRs: Build (ubuntu/windows), Lint (ubuntu/windows), Test (ubuntu/windows). Ubuntu tests run with `-race` and `-coverprofile`; coverage summary prints via `go tool cover` in CI logs. Windows tests skip race detection (needs CGO).
+CI runs 6 required checks on PRs: Build (ubuntu/windows), Lint (ubuntu/windows), Test (ubuntu/windows). Ubuntu and macOS tests run with `-race`; ubuntu also runs `-coverprofile` and uploads to Codecov. Windows tests skip race detection (needs CGO).
+
+`main` is protected by a repo **ruleset** (not classic branch protection — `gh api repos/.../branches/main/protection` 404s; use `gh api repos/.../rules/branches/main`). It requires the 6 checks above to pass, all review threads resolved (incl. bot reviewers — Codacy, Octopus, Codex/chatgpt-codex-connector), and `strict_required_status_checks_policy: true` (a PR must be up-to-date with `main` — `gh pr update-branch` when `mergeStateStatus` is `BEHIND`). A required check occasionally re-enters `pending` after first going green, briefly showing `BLOCKED`; re-watch and retry rather than assuming failure.
+
+### Coverage (Codecov)
+
+Coverage is uploaded from the ubuntu test leg via **OIDC** (`use_oidc: true`, `fail_ci_if_error: false` — a Codecov/network outage must never fail the test leg). Config in `codecov.yml`: **patch coverage is enforced** (`informational: false`, target 80%) — new/changed lines under 80% post a failing `codecov/patch` status (visible red). It is intentionally a *soft* block (not in the required-checks ruleset) so a skipped upload can't deadlock a PR; self-police on the red, merge past it with judgment when new code is genuinely E2E-territory. Project/component coverage stays informational (whole-repo ~41%, much of it I/O-bound).
 
 ## Architecture
 
@@ -69,9 +75,9 @@ Network-facing operations (Docker, AWS) wrap calls with `internal/retry/`: expon
 
 ### DDC (Derived Data Cache)
 
-`internal/ddc/` manages UE5's Derived Data Cache — persistent shader/asset cache that survives Docker container lifecycles. Three modes (`internal/ddc/ddc.go`): `zen` (default since v0.7.0 — the Unreal Zen Store, UE's default local backend since 5.4, applies to UE 5.4–5.8), `local` (legacy FileSystem cache, **deprecated** — delete-only in UE since 5.4; `doctor`/`ddc status`/config load warn and recommend `zen`), and `none` (disabled). `NormalizeMode` maps the empty string to `zen`.
+`internal/ddc/` manages UE5's Derived Data Cache — persistent shader/asset cache that survives Docker container lifecycles. Three modes: `zen` (default since v0.7.0 — the Unreal Zen Store, UE's default local backend since 5.4, applies to UE 5.4+), `local` (legacy FileSystem cache, **deprecated** — delete-only in UE since 5.4; `doctor`/`ddc status`/config load warn and recommend `zen`), and `none` (disabled). The package is split by concern: `ddc.go` (mode constants, `ValidateDDCMode` which maps `""` → `zen`, env/Zen-path constants), `paths.go` (path resolution), `size.go` (dir sizing), `ops.go` (clean/prune).
 
-Integration points (`internal/dockerbuild/game.go`): for `zen`, the host Zen directory (`ddc.zenPath`, default `~/.ludus/zen`) is bind-mounted to the container's fixed ZenStore data path (`ddc.ZenContainerPath` = `/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data`); the game-build preamble recursively chowns `/home/ue/.config` so `zenserver` (running as `ue`) can write it. For legacy `local`, the host DDC dir is mounted at `/ddc` and passed via `UE-LocalDataCachePath`.
+Integration points live in `internal/dockerbuild/game_ddc.go` (mount-arg assembly) and `game_script.go` (build-script preamble): for `zen`, the host Zen directory (`ddc.zenPath`, default `~/.ludus/zen`) is bind-mounted to the container's fixed ZenStore data path (`ddc.ZenContainerPath` = `/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data`); the preamble recursively chowns `/home/ue/.config` so `zenserver` (running as `ue`) can write it. For legacy `local`, the host DDC dir is mounted at `/ddc` and passed via `UE-LocalDataCachePath`.
 
 `ludus ddc` subcommands: `status`, `clean`, `prune`, `warmup`. Config in `ludus.yaml` under `ddc.mode` / `ddc.zenPath` / `ddc.localPath`, overridable via `--ddc` flag.
 
@@ -81,7 +87,9 @@ Integration points (`internal/dockerbuild/game.go`): for `zen`, the host Zen dir
 
 `internal/tracing/` adds optional OpenTelemetry (OTLP) trace export — one span per pipeline stage under a `ludus.run` root span, wired in `cmd/pipeline/executeStages`. No-op with zero overhead unless `observability.otlp.enabled` (or standard `OTEL_*` env vars) is set. Initialized in root `PersistentPreRunE`, flushed in `Execute()`.
 
-`internal/dflint/` lints Dockerfiles (hadolint) and scans the built image for vulnerabilities (trivy), surfaced via `ludus status`. Both tools degrade gracefully when not installed.
+`internal/dflint/` lints Dockerfiles (hadolint) and scans the built image for vulnerabilities (trivy), surfaced via `ludus status`. Both tools degrade gracefully when not installed. Built-in rules live in `checks.go`; `lint.go` holds the result types and orchestration; `hadolint.go` / `trivy.go` wrap the external tools.
+
+Several packages keep one concern per file rather than one giant file (Codacy's Lizard flags high per-file complexity). `internal/dockerbuild/game.go` is split into `game_resolver.go` (name/arch resolution), `game_script.go` (build-script generation), `game_ddc.go` (DDC mount args), and `game_container.go` (container execution); `game.go` keeps the option/builder types and the `Build`/`BuildClient` entry points. When a file's summed function complexity approaches 50, split along a clean seam into sibling files rather than refactoring logic.
 
 ### BuildGraph
 
@@ -89,7 +97,7 @@ Integration points (`internal/dockerbuild/game.go`): for `zen`, the host Zen dir
 
 ### MCP Server
 
-`cmd/mcp/` exposes 25 tools via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout). Long-running builds have async variants returning build IDs.
+`cmd/mcp/` exposes 26 tools via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout). Long-running builds have async variants returning build IDs.
 
 ### GameLift Wrapper
 
@@ -136,7 +144,7 @@ Full style guide in [AGENTS.md](AGENTS.md). Key points for quick reference:
 - **Errors**: `fmt.Errorf("context: %w", err)`. No sentinel errors, no custom types. AWS errors via `smithy.APIError` + `errors.As()`. `internal/diagnose/` matches error patterns to user-facing hints — add new patterns there rather than embedding hint strings in command code.
 - **Output**: `fmt.Println`/`fmt.Printf` for status. No logging library. JSON conditional on `globals.JSONOutput`. Human-readable stdout is filtered through `internal/output` (account-ID masking) when `privacy.maskAccountId` is on and `--show-account-id` is not set — installed once in root `PersistentPreRunE`, skipped for `--json` and `mcp`. Mask new sensitive identifiers by adding a pattern to `internal/output/sanitize.go`, not at call sites.
 - **Shell execution**: Always through `runner.Runner`, never raw `exec.Command`.
-- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. 34/37 internal packages have tests. AWS-heavy packages (ec2fleet) and interface-only packages (deploy, version) rely on E2E or integration coverage.
+- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. AWS/Docker/`wsl.exe`/subprocess-bound code (gamelift, ec2fleet, stack, wrapper, wsl, most deploy logic) relies on E2E coverage — unit tests there cover only the pure surface (adapters' `Name`/`Capabilities`, arg assembly, param parsing). Two hard constraints: (1) keep each test function under **cyclomatic complexity 8** or Codacy's Lizard check fails the PR — convert flat assertion chains to map/table loops and extract `t.Run` bodies into named helpers (`go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 <file>` must print nothing); (2) read mutex-guarded struct fields **under the same lock** in tests — CI runs `-race` on ubuntu/macos (not Windows, which lacks CGO), and a channel signal alone is not a happens-before edge with a lock-protected write.
 - **Platform code**: `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
 - **Imports**: Two groups separated by a blank line — stdlib first, then third-party and project imports together (alphabetically sorted). Aliases only to resolve conflicts (e.g. `gltypes`, `cftypes`).
 - **Naming**: Acronyms fully uppercase (`ID`, `URI`, `ARN`, `ECR`). Constructors `New*` returning a pointer. Single-letter pointer receivers matching type initial (`b *Builder`, `d *Deployer`). `context.Context` is the first parameter for all I/O or long-running methods.
@@ -171,3 +179,4 @@ Releasing is a gated, ordered process — do not improvise it:
 npm package: `ludus-cli`. README in `npm/README.md`, keywords in `npm/package.json`.
 
 The published tarball is a thin shim and ships **no binary** (`bin/` is git/npm-ignored). `npm/install.js` exports `ensureBinary()`, which downloads the platform archive from the GitHub release, SHA-256-verifies it against `package.json`'s `binaryChecksums`, extracts atomically (unique temp dir + rename), and writes a `bin/.installed-version` marker. `postinstall` runs it once; `npm/run.js` (the `bin` entry) also calls it before every spawn, so a skipped postinstall (`ignore-scripts`/pnpm), a failed download, or a version-skewed binary self-heals on first run. The marker comparison short-circuits the common path (cheap file reads, no network). **All `ensureBinary` progress must go to stderr** — `ludus mcp` (JSON-RPC) and `--json` write to stdout. `LUDUS_SKIP_AUTO_DOWNLOAD=1` bypasses the self-heal for air-gapped/self-managed binaries. Tests: `cd npm && npm test` (`node --test`, network-free).
+


### PR DESCRIPTION
## What

Refreshes and aligns the two agent-facing docs so they agree on every shared fact and match the current code.

### Corrections (verified against code)
- **DDC**: zen applies to UE **5.4+** (was 5.4–5.7); function is `ValidateDDCMode` (main's copy wrongly said `NormalizeMode`); package-split note (`ddc.go`/`paths.go`/`size.go`/`ops.go`) and integration points (`game_ddc.go`/`game_script.go`) reflect the actual layout.
- **MCP**: **26 tools** (confirmed: 26 `AddTool` calls; the bare `"ludus"` is the `mcp.NewServer` name, not a tool).
- **Go 1.25.11** (was 1.25.10).
- **Config precedence** `ludus.yaml → --flag → mcp-parameter` (AGENTS.md had stale `config.yaml`).
- `.hooks/pre-commit` (was `.git/hooks/pre-commit`).
- `--ddc local` flagged **deprecated → recommend zen** in both files.

### Additions
- Coverage (Codecov) section: OIDC upload, enforced 80% patch coverage as a soft block.
- `main` ruleset notes (strict checks, bot-reviewer thread resolution, transient BLOCKED).
- Test constraints: CCN-8 Lizard gate + read mutex-guarded fields under the same lock under `-race`.

Docs-only; no code changes.

## Test plan
- [x] Cross-checked shared facts between AGENTS.md and CLAUDE.md (tool count, Go version, DDC range, precedence, CCN gate)
- [x] Verified `ValidateDDCMode`, ddc package split, and game_ddc/game_script files exist in code