### PR TITLE
[codex] increase unit coverage to 50 percent

### DIFF
--- a/cmd/ci/ci_test.go
+++ b/cmd/ci/ci_test.go
@@ -1,0 +1,152 @@
+package ci
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestRunInitDryRunUsesDefaults(t *testing.T) {
+	resetCIGlobals(t)
+	globals.Cfg = &config.Config{}
+	globals.DryRun = true
+
+	output, err := captureCIStdout(t, func() error { return runInit(initCmd, nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"runs-on: [self-hosted, linux, x64]",
+		"# push:",
+		"# pull_request:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output does not contain %q", want)
+		}
+	}
+}
+
+func TestRunInitWritesConfiguredWorkflow(t *testing.T) {
+	resetCIGlobals(t)
+	path := filepath.Join(t.TempDir(), "nested", "workflow.yml")
+	globals.Cfg = &config.Config{}
+	globals.Cfg.CI.WorkflowPath = path
+	globals.Cfg.CI.RunnerLabels = []string{"self-hosted", "windows", "ue5"}
+	enablePush = true
+	enablePR = true
+
+	output, err := captureCIStdout(t, func() error { return runInit(initCmd, nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	for _, want := range []string{
+		"runs-on: [self-hosted, windows, ue5]",
+		"  push:",
+		"  pull_request:",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("workflow does not contain %q", want)
+		}
+	}
+	if !strings.Contains(output, "Workflow written to "+path) {
+		t.Fatalf("output = %q, want written path", output)
+	}
+}
+
+func TestRunnerResolvers(t *testing.T) {
+	resetCIGlobals(t)
+	globals.Cfg = &config.Config{}
+	globals.Cfg.CI.RunnerDir = "/configured/runner"
+	globals.Cfg.CI.RunnerLabels = []string{"self-hosted", "linux", "arm64"}
+
+	tests := []struct {
+		name string
+		set  func()
+		got  func() string
+		want string
+	}{
+		{"configured directory", func() {}, resolveDir, "/configured/runner"},
+		{"directory override", func() { runnerDir = "/flag/runner" }, resolveDir, "/flag/runner"},
+		{"configured labels", func() {}, resolveLabels, "self-hosted,linux,arm64"},
+		{"label override", func() { runnerLabels = "custom,gpu" }, resolveLabels, "custom,gpu"},
+		{"name override", func() { runnerName = "build-host" }, resolveName, "build-host"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			runnerDir, runnerLabels, runnerName = "", "", ""
+			tt.set()
+			if got := tt.got(); got != tt.want {
+				t.Fatalf("result = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveLabelsDefault(t *testing.T) {
+	resetCIGlobals(t)
+	globals.Cfg = &config.Config{}
+	if got, want := resolveLabels(), "self-hosted,linux,x64"; got != want {
+		t.Fatalf("resolveLabels() = %q, want %q", got, want)
+	}
+}
+
+func TestResolveRepoExplicit(t *testing.T) {
+	resetCIGlobals(t)
+	runnerRepo = "owner/repository"
+	got, err := resolveRepo(context.Background(), nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != runnerRepo {
+		t.Fatalf("resolveRepo() = %q, want %q", got, runnerRepo)
+	}
+}
+
+func resetCIGlobals(t *testing.T) {
+	t.Helper()
+	previousCfg, previousDryRun := globals.Cfg, globals.DryRun
+	previousOutput, previousPush, previousPR := outputPath, enablePush, enablePR
+	previousDir, previousLabels := runnerDir, runnerLabels
+	previousName, previousRepo := runnerName, runnerRepo
+	globals.DryRun = false
+	outputPath, enablePush, enablePR = "", false, false
+	runnerDir, runnerLabels, runnerName, runnerRepo = "", "", "", ""
+	t.Cleanup(func() {
+		globals.Cfg, globals.DryRun = previousCfg, previousDryRun
+		outputPath, enablePush, enablePR = previousOutput, previousPush, previousPR
+		runnerDir, runnerLabels = previousDir, previousLabels
+		runnerName, runnerRepo = previousName, previousRepo
+	})
+}
+
+func captureCIStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	runErr := run()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = previous
+	t.Cleanup(func() { os.Stdout = previous })
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data), runErr
+}

--- a/cmd/connect/connect_test.go
+++ b/cmd/connect/connect_test.go
@@ -1,0 +1,104 @@
+package connect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/state"
+)
+
+func TestResolveClientBinary(t *testing.T) {
+	binary := filepath.Join(t.TempDir(), "client")
+	if err := os.WriteFile(binary, []byte("binary"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name    string
+		client  *state.ClientState
+		want    string
+		wantErr string
+	}{
+		{name: "missing state", wantErr: "no client build found"},
+		{name: "empty path", client: &state.ClientState{}, wantErr: "no client build found"},
+		{name: "missing binary", client: &state.ClientState{BinaryPath: binary + "-missing"}, wantErr: "client binary not found"},
+		{name: "existing binary", client: &state.ClientState{BinaryPath: binary}, want: binary},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := resolveClientBinary(&state.State{Client: tt.client})
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("resolveClientBinary() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil || got != tt.want {
+				t.Errorf("resolveClientBinary() = (%q, %v), want (%q, nil)", got, err, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveAddressOverride(t *testing.T) {
+	oldAddress := address
+	t.Cleanup(func() { address = oldAddress })
+	tests := []struct {
+		name     string
+		value    string
+		wantIP   string
+		wantPort int
+		wantErr  string
+	}{
+		{name: "valid", value: "127.0.0.1:7777", wantIP: "127.0.0.1", wantPort: 7777},
+		{name: "missing port", value: "127.0.0.1", wantErr: "expected ip:port"},
+		{name: "invalid port", value: "127.0.0.1:nope", wantErr: "invalid port"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			address = tt.value
+			ip, port, err := resolveAddress()
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("resolveAddress() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil || ip != tt.wantIP || port != tt.wantPort {
+				t.Errorf("resolveAddress() = (%q, %d, %v), want (%q, %d, nil)", ip, port, err, tt.wantIP, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestResolveAddressFromState(t *testing.T) {
+	oldAddress := address
+	address = ""
+	t.Cleanup(func() {
+		address = oldAddress
+		state.SetProfile("")
+	})
+	t.Chdir(t.TempDir())
+
+	if _, _, err := resolveAddress(); err == nil || !strings.Contains(err.Error(), "no active game session") {
+		t.Fatalf("resolveAddress() missing session error = %v", err)
+	}
+	want := &state.SessionState{IPAddress: "10.0.0.5", Port: 9000}
+	if err := state.UpdateSession(want); err != nil {
+		t.Fatal(err)
+	}
+	ip, port, err := resolveAddress()
+	if err != nil || ip != want.IPAddress || port != want.Port {
+		t.Errorf("resolveAddress() = (%q, %d, %v), want (%q, %d, nil)", ip, port, err, want.IPAddress, want.Port)
+	}
+}
+
+func TestVerifySessionAddressOverride(t *testing.T) {
+	oldAddress := address
+	address = "localhost:7777"
+	t.Cleanup(func() { address = oldAddress })
+	if err := verifySession(Cmd, &state.State{}); err != nil {
+		t.Errorf("verifySession() with override error = %v", err)
+	}
+}

--- a/cmd/ddc/ddc_commands_test.go
+++ b/cmd/ddc/ddc_commands_test.go
@@ -1,0 +1,152 @@
+package ddc
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	internalddc "github.com/jpvelasco/ludus/internal/ddc"
+)
+
+func TestStatusPath(t *testing.T) {
+	resetDDCGlobals(t)
+	localPath := filepath.Join(t.TempDir(), "local")
+	zenPath := filepath.Join(t.TempDir(), "zen")
+	globals.Cfg = &config.Config{}
+	globals.Cfg.DDC.LocalPath = localPath
+	globals.Cfg.DDC.ZenPath = zenPath
+
+	tests := []struct {
+		mode string
+		want string
+	}{
+		{internalddc.ModeZen, zenPath},
+		{internalddc.ModeLocal, localPath},
+		{internalddc.ModeNone, ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.mode, func(t *testing.T) {
+			got, err := statusPath(tt.mode)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got != tt.want {
+				t.Fatalf("statusPath(%q) = %q, want %q", tt.mode, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunStatusHumanAndJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		json bool
+		want []string
+	}{
+		{"human", false, []string{"DDC Status", "Mode: local", "Size: 5 B"}},
+		{"json", true, []string{`"mode":"local"`, `"size_bytes":5`}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDDCGlobals(t)
+			dir := t.TempDir()
+			if err := os.WriteFile(filepath.Join(dir, "cache.bin"), []byte("12345"), 0o644); err != nil {
+				t.Fatal(err)
+			}
+			globals.Cfg = &config.Config{}
+			globals.Cfg.DDC.Mode = internalddc.ModeLocal
+			globals.Cfg.DDC.LocalPath = dir
+			globals.JSONOutput = tt.json
+
+			output, err := captureDDCStdout(t, func() error { return runStatus(statusCmd, nil) })
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(output, want) {
+					t.Errorf("output %q does not contain %q", output, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRunCleanAndPruneEmptyCache(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{"clean", func() error { return runClean(cleanCmd, nil) }, "already empty"},
+		{"prune", func() error { return runPrune(pruneCmd, nil) }, "No DDC entries older than"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetDDCGlobals(t)
+			globals.Cfg = &config.Config{}
+			globals.Cfg.DDC.LocalPath = t.TempDir()
+			output, err := captureDDCStdout(t, tt.run)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !strings.Contains(output, tt.want) {
+				t.Fatalf("output = %q, want it to contain %q", output, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunWarmupRejectsDisabledDDC(t *testing.T) {
+	resetDDCGlobals(t)
+	globals.Cfg = &config.Config{}
+	globals.Cfg.DDC.Mode = internalddc.ModeNone
+	err := runWarmup(warmupCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires DDC to be enabled") {
+		t.Fatalf("runWarmup() error = %v, want disabled DDC error", err)
+	}
+}
+
+func resetDDCGlobals(t *testing.T) {
+	t.Helper()
+	previousCfg := globals.Cfg
+	previousMode := globals.DDCMode
+	previousJSON := globals.JSONOutput
+	previousDryRun := globals.DryRun
+	previousPruneDays := pruneDays
+	globals.DDCMode = ""
+	globals.JSONOutput = false
+	globals.DryRun = false
+	pruneDays = 30
+	t.Cleanup(func() {
+		globals.Cfg = previousCfg
+		globals.DDCMode = previousMode
+		globals.JSONOutput = previousJSON
+		globals.DryRun = previousDryRun
+		pruneDays = previousPruneDays
+	})
+}
+
+func captureDDCStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	runErr := run()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = previous
+	t.Cleanup(func() { os.Stdout = previous })
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data), runErr
+}

--- a/cmd/engine/engine_test.go
+++ b/cmd/engine/engine_test.go
@@ -1,0 +1,60 @@
+package engine
+
+import (
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestMakeBuilderRequiresSourcePath(t *testing.T) {
+	setEngineTestGlobals(t, &config.Config{})
+
+	if _, err := makeBuilder(); err == nil {
+		t.Fatal("makeBuilder() error = nil, want missing source path error")
+	}
+}
+
+func TestMakeContainerEngineBuilderRequiresSourcePath(t *testing.T) {
+	setEngineTestGlobals(t, &config.Config{})
+
+	if _, err := makeContainerEngineBuilder("docker"); err == nil {
+		t.Fatal("makeContainerEngineBuilder() error = nil, want missing source path error")
+	}
+}
+
+func TestMakeBuildersWithConfiguredSource(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Engine.SourcePath = t.TempDir()
+	cfg.Engine.MaxJobs = 7
+	setEngineTestGlobals(t, cfg)
+
+	if _, err := makeBuilder(); err != nil {
+		t.Fatalf("makeBuilder() error = %v", err)
+	}
+	if _, err := makeContainerEngineBuilder("docker"); err != nil {
+		t.Fatalf("makeContainerEngineBuilder() error = %v", err)
+	}
+}
+
+func TestMaybeRunMacOSPreflightsIsNoopOnLinuxAndWindows(t *testing.T) {
+	setEngineTestGlobals(t, &config.Config{})
+
+	if err := maybeRunMacOSPreflights(t.Context()); err != nil {
+		t.Fatalf("maybeRunMacOSPreflights() error = %v", err)
+	}
+}
+
+func setEngineTestGlobals(t *testing.T, cfg *config.Config) {
+	t.Helper()
+
+	oldCfg := globals.Cfg
+	oldUEPath, oldJobs, oldBackend := uePath, jobs, backend
+	oldBaseImage := baseImage
+	globals.Cfg = cfg
+	uePath, jobs, backend, baseImage = "", 0, "", ""
+	t.Cleanup(func() {
+		globals.Cfg = oldCfg
+		uePath, jobs, backend, baseImage = oldUEPath, oldJobs, oldBackend, oldBaseImage
+	})
+}

--- a/cmd/logs/logs_test.go
+++ b/cmd/logs/logs_test.go
@@ -1,0 +1,136 @@
+package logs
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestLogFilesFiltersAndSortsNewestFirst(t *testing.T) {
+	dir := t.TempDir()
+	setLogsConfig(t, dir)
+
+	writeLogFile(t, dir, "older.log", "old", time.Unix(100, 0))
+	writeLogFile(t, dir, "newer.log", "new", time.Unix(200, 0))
+	writeLogFile(t, dir, "ignored.txt", "text", time.Unix(300, 0))
+	if err := os.Mkdir(filepath.Join(dir, "directory.log"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	files, gotDir, err := logFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if gotDir != dir {
+		t.Fatalf("directory = %q, want %q", gotDir, dir)
+	}
+	got := make([]string, 0, len(files))
+	for _, file := range files {
+		got = append(got, file.Name())
+	}
+	want := []string{"newer.log", "older.log"}
+	if strings.Join(got, ",") != strings.Join(want, ",") {
+		t.Fatalf("files = %v, want %v", got, want)
+	}
+}
+
+func TestLogFilesMissingDirectoryIsEmpty(t *testing.T) {
+	dir := filepath.Join(t.TempDir(), "missing")
+	setLogsConfig(t, dir)
+
+	files, gotDir, err := logFiles()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if files != nil || gotDir != dir {
+		t.Fatalf("logFiles() = (%v, %q), want (nil, %q)", files, gotDir, dir)
+	}
+}
+
+func TestLogCommands(t *testing.T) {
+	dir := t.TempDir()
+	setLogsConfig(t, dir)
+	writeLogFile(t, dir, "latest.log", "build output\n", time.Unix(200, 0))
+
+	tests := []struct {
+		name string
+		run  func() error
+		want []string
+	}{
+		{"path", func() error { return runPath(nil, nil) }, []string{dir}},
+		{"list", func() error { return runList(nil, nil) }, []string{"latest.log", "0 KB"}},
+		{"tail", func() error { return runTail(nil, nil) }, []string{"latest.log", "build output"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output, err := captureStdout(t, tt.run)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(output, want) {
+					t.Errorf("output %q does not contain %q", output, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRunListReportsEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	setLogsConfig(t, dir)
+
+	output, err := captureStdout(t, func() error { return runList(nil, nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "No build logs in " + dir; !strings.Contains(output, want) {
+		t.Fatalf("output = %q, want it to contain %q", output, want)
+	}
+}
+
+func setLogsConfig(t *testing.T, dir string) {
+	t.Helper()
+	previous := globals.Cfg
+	globals.Cfg = &config.Config{}
+	globals.Cfg.Observability.Logs.Dir = dir
+	t.Cleanup(func() { globals.Cfg = previous })
+}
+
+func writeLogFile(t *testing.T, dir, name, content string, modTime time.Time) {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chtimes(path, modTime, modTime); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func captureStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	runErr := run()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = previous
+	t.Cleanup(func() { os.Stdout = previous })
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data), runErr
+}

--- a/cmd/mcp/read_handlers_test.go
+++ b/cmd/mcp/read_handlers_test.go
@@ -1,0 +1,111 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/dflint"
+	"github.com/jpvelasco/ludus/internal/state"
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestHandleConnectInfo(t *testing.T) {
+	t.Chdir(t.TempDir())
+	previousProfile := state.ActiveProfile()
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile(previousProfile) })
+
+	saved := &state.State{
+		Session: &state.SessionState{
+			SessionID: "session-1",
+			IPAddress: "203.0.113.10",
+			Port:      7777,
+		},
+		Client: &state.ClientState{
+			BinaryPath: "/build/LyraClient",
+			Platform:   "Linux",
+		},
+	}
+	if err := state.Save(saved); err != nil {
+		t.Fatal(err)
+	}
+
+	result, _, err := handleConnectInfo(context.Background(), nil, connectInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := toolResultText(t, result)
+	for _, want := range []string{"session-1", "203.0.113.10:7777", "/build/LyraClient", "Linux"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("result %q does not contain %q", text, want)
+		}
+	}
+}
+
+func TestHandleConnectInfoEmptyState(t *testing.T) {
+	t.Chdir(t.TempDir())
+	previousProfile := state.ActiveProfile()
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile(previousProfile) })
+
+	result, _, err := handleConnectInfo(context.Background(), nil, connectInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if text := toolResultText(t, result); text != "{}" {
+		t.Fatalf("result = %q, want empty object", text)
+	}
+}
+
+func TestHandleBuildGraph(t *testing.T) {
+	previous := globals.Cfg
+	cfg := config.Defaults()
+	cfg.Engine.SourcePath = "/opt/unreal-engine"
+	cfg.Engine.Version = "5.7.3"
+	cfg.Game.ProjectPath = "/projects/Lyra/Lyra.uproject"
+	cfg.Game.ProjectName = "Lyra"
+	globals.Cfg = cfg
+	t.Cleanup(func() { globals.Cfg = previous })
+
+	result, _, err := handleBuildGraph(context.Background(), nil, buildGraphInput{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	text := toolResultText(t, result)
+	for _, want := range []string{"<BuildGraph", "Lyra.uproject", "EngineVersion"} {
+		if !strings.Contains(text, want) {
+			t.Errorf("result does not contain %q", want)
+		}
+	}
+}
+
+func TestLintResultToScan(t *testing.T) {
+	result := &dflint.LintResult{
+		Findings: []dflint.Finding{
+			{Source: "hadolint", Rule: "DL3006", Level: dflint.SeverityWarning, Message: "pin image", Line: 4},
+		},
+	}
+	scan := lintResultToScan("Dockerfile", result)
+	if scan.Target != "Dockerfile" || len(scan.Findings) != 1 {
+		t.Fatalf("scan = %+v", scan)
+	}
+	got := scan.Findings[0]
+	if got.Rule != "DL3006" || got.Level != string(dflint.SeverityWarning) || got.Line != 4 {
+		t.Fatalf("finding = %+v", got)
+	}
+}
+
+func toolResultText(t *testing.T, result *sdkmcp.CallToolResult) string {
+	t.Helper()
+	if len(result.Content) != 1 {
+		t.Fatalf("content count = %d, want 1", len(result.Content))
+	}
+	text, ok := result.Content[0].(*sdkmcp.TextContent)
+	if !ok {
+		t.Fatalf("content type = %T, want *mcp.TextContent", result.Content[0])
+	}
+	return text.Text
+}

--- a/cmd/mcp/register_test.go
+++ b/cmd/mcp/register_test.go
@@ -1,0 +1,16 @@
+package mcp
+
+import (
+	"testing"
+
+	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestRegisterTools(t *testing.T) {
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{
+		Name:    "test",
+		Version: "test",
+	}, nil)
+
+	registerTools(server)
+}

--- a/cmd/resources/resources_test.go
+++ b/cmd/resources/resources_test.go
@@ -1,0 +1,126 @@
+package resources
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/inventory"
+)
+
+func TestResolveRegion(t *testing.T) {
+	previous := regionFlag
+	t.Cleanup(func() { regionFlag = previous })
+
+	tests := []struct {
+		name   string
+		flag   string
+		config string
+		want   string
+	}{
+		{"config fallback", "", "us-west-2", "us-west-2"},
+		{"flag override", "eu-west-1", "us-west-2", "eu-west-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			regionFlag = tt.flag
+			if got := resolveRegion(tt.config); got != tt.want {
+				t.Fatalf("resolveRegion(%q) = %q, want %q", tt.config, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveECRRepos(t *testing.T) {
+	tests := []struct {
+		name   string
+		server string
+		engine string
+		want   string
+	}{
+		{"defaults", "", "", "ludus-server,ludus-engine"},
+		{"custom", "server", "engine", "server,engine"},
+		{"deduplicates", "shared", "shared", "shared"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := strings.Join(resolveECRRepos(tt.server, tt.engine), ",")
+			if got != tt.want {
+				t.Fatalf("resolveECRRepos(%q, %q) = %q, want %q", tt.server, tt.engine, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResourceDetail(t *testing.T) {
+	tests := []struct {
+		name     string
+		resource inventory.Resource
+		want     string
+	}{
+		{"detail takes precedence", inventory.Resource{Detail: "detail", Status: "status"}, "detail"},
+		{"status fallback", inventory.Resource{Status: "ready"}, "ready"},
+		{"empty", inventory.Resource{}, "--"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resourceDetail(tt.resource); got != tt.want {
+				t.Fatalf("resourceDetail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintInventory(t *testing.T) {
+	tests := []struct {
+		name      string
+		inventory *inventory.Inventory
+		want      []string
+	}{
+		{
+			name:      "empty",
+			inventory: &inventory.Inventory{},
+			want:      []string{"No ludus-managed resources found in us-west-2."},
+		},
+		{
+			name: "resources",
+			inventory: &inventory.Inventory{Resources: []inventory.Resource{
+				{Type: "ECR Repository", Name: "ludus-server", Detail: "3 images"},
+				{Type: "GameLift Fleet", Name: "fleet", Status: "ACTIVE"},
+			}},
+			want: []string{"Ludus Resources (us-west-2)", "TYPE", "ludus-server", "3 images", "fleet", "ACTIVE"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			output := captureInventoryOutput(t, func() { printInventory(tt.inventory, "us-west-2") })
+			for _, want := range tt.want {
+				if !strings.Contains(output, want) {
+					t.Errorf("output %q does not contain %q", output, want)
+				}
+			}
+		})
+	}
+}
+
+func captureInventoryOutput(t *testing.T, run func()) string {
+	t.Helper()
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	run()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = previous
+	t.Cleanup(func() { os.Stdout = previous })
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}

--- a/internal/ci/runner_unix_test.go
+++ b/internal/ci/runner_unix_test.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build linux
 
 package ci
 

--- a/internal/ci/runner_unix_test.go
+++ b/internal/ci/runner_unix_test.go
@@ -1,0 +1,108 @@
+//go:build !windows
+
+package ci
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+)
+
+func dryRunInstaller(t *testing.T) (*RunnerInstaller, *bytes.Buffer) {
+	t.Helper()
+	var output bytes.Buffer
+	return &RunnerInstaller{
+		Runner:     &runner.Runner{DryRun: true, Stdout: &output, Stderr: &output},
+		InstallDir: t.TempDir(),
+		Labels:     "self-hosted,linux,x64",
+		Name:       "test-runner",
+		Repo:       "owner/repo",
+	}, &output
+}
+
+func TestRunnerInstallerInstallDryRun(t *testing.T) {
+	installer, output := dryRunInstaller(t)
+	if err := installer.Install(context.Background()); err != nil {
+		t.Fatalf("Install() error = %v", err)
+	}
+	for _, want := range []string{"gh api", "curl -o", "tar xzf", "config.sh", "--unattended"} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestRunnerInstallerFinishInstallServiceDryRun(t *testing.T) {
+	installer, output := dryRunInstaller(t)
+	installer.Service = true
+	if err := installer.finishInstall(context.Background(), installer.InstallDir); err != nil {
+		t.Fatalf("finishInstall() error = %v", err)
+	}
+	for _, want := range []string{"svc.sh install", "svc.sh start"} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, output.String())
+		}
+	}
+}
+
+func TestRunnerInstallerStatus(t *testing.T) {
+	tests := []struct {
+		name      string
+		config    bool
+		service   bool
+		want      string
+		wantTrace string
+	}{
+		{name: "not installed", want: "not installed"},
+		{name: "process", config: true, want: "running (process)", wantTrace: "pgrep -f Runner.Listener"},
+		{name: "service", config: true, service: true, want: "running (systemd)", wantTrace: "svc.sh status"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installer, output := dryRunInstaller(t)
+			writeRunnerMarkers(t, installer.InstallDir, tt.config, tt.service)
+			got, err := installer.Status(context.Background())
+			if err != nil {
+				t.Fatalf("Status() error = %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("Status() = %q, want %q", got, tt.want)
+			}
+			if tt.wantTrace != "" && !strings.Contains(output.String(), tt.wantTrace) {
+				t.Errorf("dry-run output missing %q:\n%s", tt.wantTrace, output.String())
+			}
+		})
+	}
+}
+
+func writeRunnerMarkers(t *testing.T, dir string, config, service bool) {
+	t.Helper()
+	for name, enabled := range map[string]bool{"config.sh": config, "svc.sh": service} {
+		if enabled {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"), 0o700); err != nil {
+				t.Fatal(err)
+			}
+		}
+	}
+}
+
+func TestRunnerInstallerUninstallDryRun(t *testing.T) {
+	installer, output := dryRunInstaller(t)
+	writeRunnerMarkers(t, installer.InstallDir, true, true)
+	if err := installer.Uninstall(context.Background(), true); err != nil {
+		t.Fatalf("Uninstall() error = %v", err)
+	}
+	for _, want := range []string{"svc.sh stop", "svc.sh uninstall", "remove-token", "config.sh remove"} {
+		if !strings.Contains(output.String(), want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, output.String())
+		}
+	}
+	if _, err := os.Stat(installer.InstallDir); !os.IsNotExist(err) {
+		t.Errorf("install directory still exists after Uninstall(deleteDir=true): %v", err)
+	}
+}

--- a/internal/dflint/tools_unix_test.go
+++ b/internal/dflint/tools_unix_test.go
@@ -1,0 +1,108 @@
+//go:build !windows
+
+package dflint
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFakeTool(t *testing.T, name, body string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestRunHadolintParsesOutput(t *testing.T) {
+	writeFakeTool(t, "hadolint", `printf '%s' '[{"line":7,"code":"DL3006","message":"pin base image","level":"warning"}]'`)
+	findings, available := runHadolint("FROM example\n")
+	if !available || len(findings) != 1 {
+		t.Fatalf("runHadolint() = (%+v, %v), want one available finding", findings, available)
+	}
+	got := findings[0]
+	if got.Source != "hadolint" || got.Rule != "DL3006" || got.Line != 7 || got.Level != SeverityWarning {
+		t.Errorf("finding = %+v", got)
+	}
+}
+
+func TestRunHadolintHandlesToolOutput(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "empty", body: "exit 1"},
+		{name: "malformed", body: `printf 'not-json'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			writeFakeTool(t, "hadolint", tt.body)
+			findings, available := runHadolint("FROM example\n")
+			if !available || len(findings) != 0 {
+				t.Errorf("runHadolint() = (%+v, %v), want empty available result", findings, available)
+			}
+		})
+	}
+}
+
+func TestRunTrivyParsesLocalImage(t *testing.T) {
+	dir := t.TempDir()
+	writeToolAt(t, dir, "docker", "exit 0")
+	writeToolAt(t, dir, "trivy", `printf '%s' '{"Results":[{"Vulnerabilities":[{"VulnerabilityID":"CVE-1","Severity":"CRITICAL","Title":"issue","PkgName":"pkg"}]}]}'`)
+	t.Setenv("PATH", dir)
+
+	findings, available := runTrivy("example:latest")
+	if !available || len(findings) != 1 {
+		t.Fatalf("runTrivy() = (%+v, %v), want one available finding", findings, available)
+	}
+	if findings[0].Rule != "CVE-1" || findings[0].Level != SeverityError {
+		t.Errorf("finding = %+v", findings[0])
+	}
+}
+
+func TestRunTrivySkipsMissingImage(t *testing.T) {
+	dir := t.TempDir()
+	writeToolAt(t, dir, "docker", "exit 1")
+	writeToolAt(t, dir, "trivy", "exit 0")
+	t.Setenv("PATH", dir)
+
+	findings, available := runTrivy("missing:latest")
+	if !available || findings != nil {
+		t.Errorf("runTrivy() = (%+v, %v), want nil available result", findings, available)
+	}
+}
+
+func TestExecTrivyScanOutputCases(t *testing.T) {
+	tests := []struct {
+		name string
+		body string
+		ok   bool
+	}{
+		{name: "valid despite exit", body: `printf '{"Results":[]}'; exit 1`, ok: true},
+		{name: "empty failure", body: "exit 1"},
+		{name: "malformed", body: `printf 'bad-json'`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			path := writeToolAt(t, dir, "trivy", tt.body)
+			_, ok := execTrivyScan(path, "image:tag")
+			if ok != tt.ok {
+				t.Errorf("execTrivyScan() ok = %v, want %v", ok, tt.ok)
+			}
+		})
+	}
+}
+
+func writeToolAt(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"+body+"\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/dflint/trivy_test.go
+++ b/internal/dflint/trivy_test.go
@@ -1,0 +1,101 @@
+package dflint
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseVulnerabilities(t *testing.T) {
+	vulns := []trivyVuln{
+		{VulnerabilityID: "CVE-C1", Severity: "critical", Title: "critical issue", PkgName: "openssl"},
+		{VulnerabilityID: "CVE-H1", Severity: "HIGH", Title: "high issue"},
+		{VulnerabilityID: "CVE-L1", Severity: "LOW", Title: "low issue"},
+	}
+	output := trivyOutput{Results: []trivyResult{{Vulnerabilities: vulns}}}
+
+	findings := parseVulnerabilities(output)
+	if len(findings) != 3 {
+		t.Fatalf("parseVulnerabilities returned %d findings, want 3", len(findings))
+	}
+
+	wants := []struct {
+		rule    string
+		level   Severity
+		message string
+	}{
+		{"CVE-C1", SeverityError, "critical issue (openssl)"},
+		{"CVE-H1", SeverityWarning, "high issue"},
+		{"CVE-L1", SeverityInfo, "low issue"},
+	}
+	for i, want := range wants {
+		got := findings[i]
+		if got.Source != "trivy" || got.Rule != want.rule || got.Level != want.level || got.Message != want.message {
+			t.Errorf("finding[%d] = %+v, want rule=%q level=%q message=%q", i, got, want.rule, want.level, want.message)
+		}
+	}
+}
+
+func TestParseVulnerabilitiesCapsEachSeverity(t *testing.T) {
+	var vulns []trivyVuln
+	for i := 0; i < 7; i++ {
+		vulns = append(vulns,
+			trivyVuln{VulnerabilityID: "critical", Severity: "CRITICAL", Title: "critical"},
+			trivyVuln{VulnerabilityID: "high", Severity: "HIGH", Title: "high"},
+		)
+	}
+
+	findings := parseVulnerabilities(trivyOutput{Results: []trivyResult{{Vulnerabilities: vulns}}})
+	if len(findings) != 12 {
+		t.Fatalf("parseVulnerabilities returned %d findings, want 12", len(findings))
+	}
+	for _, want := range []string{"2 more CRITICAL", "2 more HIGH"} {
+		found := false
+		for _, finding := range findings {
+			if finding.Rule == "overflow" && strings.Contains(finding.Message, want) {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("missing overflow finding containing %q", want)
+		}
+	}
+}
+
+func TestMapToolSeverities(t *testing.T) {
+	tests := []struct {
+		name string
+		got  Severity
+		want Severity
+	}{
+		{"trivy critical", mapTrivySeverity("CRITICAL"), SeverityError},
+		{"trivy high", mapTrivySeverity("HIGH"), SeverityWarning},
+		{"trivy other", mapTrivySeverity("LOW"), SeverityInfo},
+		{"hadolint error", mapHadolintLevel("ERROR"), SeverityError},
+		{"hadolint warning", mapHadolintLevel("Warning"), SeverityWarning},
+		{"hadolint other", mapHadolintLevel("style"), SeverityInfo},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("severity = %q, want %q", tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFindingsDetail(t *testing.T) {
+	result := &LintResult{Findings: []Finding{
+		{Rule: "DL3006", Line: 4, Level: SeverityWarning, Message: "pin the image"},
+		{Rule: "overflow", Level: SeverityInfo, Message: "more findings"},
+	}}
+	got := result.FindingsDetail()
+	want := []string{
+		"[warning] DL3006 (line 4): pin the image",
+		"[info] overflow: more findings",
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("FindingsDetail()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/engine/builder_unix_test.go
+++ b/internal/engine/builder_unix_test.go
@@ -1,0 +1,95 @@
+//go:build !windows
+
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+)
+
+func unixBuilder(t *testing.T, skipSetup bool) (*Builder, *bytes.Buffer) {
+	t.Helper()
+	dir := t.TempDir()
+	for _, name := range []string{"Setup.sh", "GenerateProjectFiles.sh"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var output bytes.Buffer
+	r := &runner.Runner{DryRun: true, Stdout: &output, Stderr: &output}
+	return NewBuilder(BuildOptions{SourcePath: dir, MaxJobs: 3, SkipSetup: skipSetup}, r), &output
+}
+
+func TestBuilderBuildDryRun(t *testing.T) {
+	tests := []struct {
+		name      string
+		skipSetup bool
+		wantSetup bool
+	}{
+		{name: "all steps", wantSetup: true},
+		{name: "skip setup", skipSetup: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder, output := unixBuilder(t, tt.skipSetup)
+			result, err := builder.Build(context.Background())
+			if err != nil {
+				t.Fatalf("Build() error = %v", err)
+			}
+			if !result.Success || result.EnginePath != builder.opts.SourcePath {
+				t.Errorf("Build() result = %+v", result)
+			}
+			assertBuildTrace(t, output.String(), tt.wantSetup)
+		})
+	}
+}
+
+func assertBuildTrace(t *testing.T, output string, wantSetup bool) {
+	t.Helper()
+	for _, want := range []string{"GenerateProjectFiles.sh", "make -j3 ShaderCompileWorker", "make -j3 UnrealEditor"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "Setup.sh") != wantSetup {
+		t.Errorf("Setup.sh presence = %v, want %v:\n%s", strings.Contains(output, "Setup.sh"), wantSetup, output)
+	}
+}
+
+func TestBuilderScriptsMustExist(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(*Builder) error
+		want string
+	}{
+		{name: "setup", call: func(b *Builder) error { return b.Setup(context.Background()) }, want: "Setup.sh not found"},
+		{name: "generate", call: func(b *Builder) error { return b.GenerateProjectFiles(context.Background()) }, want: "GenerateProjectFiles.sh not found"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := NewBuilder(BuildOptions{SourcePath: t.TempDir()}, &runner.Runner{DryRun: true})
+			err := tt.call(builder)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error = %v, want containing %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuilderBuildReportsSetupFailure(t *testing.T) {
+	builder := NewBuilder(BuildOptions{SourcePath: t.TempDir()}, &runner.Runner{DryRun: true})
+	result, err := builder.Build(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "setup failed") {
+		t.Fatalf("Build() error = %v, want setup failure", err)
+	}
+	if result.Error == nil || !errors.Is(result.Error, err) {
+		t.Errorf("Build() result error = %v, returned error = %v", result.Error, err)
+	}
+}


### PR DESCRIPTION
## Summary

- add deterministic unit tests for command and internal package surfaces
- increase full-repository statement coverage from 44.4% to 50.0%
- keep AWS, Docker build, WSL process, and other E2E-bound behavior out of unit tests

## Scope

This PR contains only new Go test files. Production code and configuration are unchanged.

Coverage was added for CI workflow generation and service lifecycle, DDC commands, log discovery, resource output, MCP registration/read handlers, connect resolution, engine builder configuration, and Dockerfile lint/Trivy adapters and parsing.

## Validation

- `go test -race -coverprofile=coverage.out -covermode=atomic ./...` — 50.0%
- `go test ./...`
- randomized affected-package tests with `-shuffle=on -count=3`
- `go vet ./...`
- `golangci-lint run ./...` — zero findings
- `gocyclo -over 8` on all added test files — no findings
