### PR TITLE
[codex] increase game and pipeline test coverage

### DIFF
--- a/cmd/game/game_helpers_test.go
+++ b/cmd/game/game_helpers_test.go
@@ -1,0 +1,138 @@
+package game
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	gameBuilder "github.com/jpvelasco/ludus/internal/game"
+	"github.com/jpvelasco/ludus/internal/state"
+)
+
+func TestPrintBuildConfigGuidance(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  string
+		want string
+	}{
+		{name: "shipping", cfg: "Shipping", want: "Shipping (optimized"},
+		{name: "development", cfg: "Development", want: "Development (debug symbols"},
+		{name: "empty", cfg: "", want: ""},
+		{name: "custom", cfg: "Test", want: "Build config: Test"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := captureGameStdout(t, func() { printBuildConfigGuidance(tt.cfg) })
+			if !strings.Contains(got, tt.want) {
+				t.Errorf("output = %q, want substring %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestNextAfterServerBuild(t *testing.T) {
+	original := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = original })
+	tests := []struct {
+		target string
+		want   string
+	}{
+		{target: "gamelift", want: "ludus container build"},
+		{target: "STACK", want: "ludus container build"},
+		{target: "ec2", want: "ludus deploy ec2"},
+		{target: "anywhere", want: "ludus deploy anywhere"},
+		{target: "binary", want: "ludus deploy binary"},
+		{target: "", want: "ludus container build  (or: ludus deploy <target>)"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			globals.Cfg = &config.Config{}
+			globals.Cfg.Deploy.Target = tt.target
+			if got := nextAfterServerBuild(); got != tt.want {
+				t.Errorf("nextAfterServerBuild() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveGameBackendAndArch(t *testing.T) {
+	originalCfg, originalBackend, originalArch := globals.Cfg, backend, archFlag
+	t.Cleanup(func() {
+		globals.Cfg, backend, archFlag = originalCfg, originalBackend, originalArch
+	})
+	globals.Cfg = &config.Config{}
+	globals.Cfg.Engine.Backend = "docker"
+	globals.Cfg.Game.Arch = "amd64"
+	backend, archFlag = "", ""
+	if got := resolveBackend(); got != "docker" {
+		t.Errorf("configured backend = %q, want docker", got)
+	}
+	if got := resolveArch(); got != "amd64" {
+		t.Errorf("configured arch = %q, want amd64", got)
+	}
+	backend, archFlag = "podman", "aarch64"
+	if got := resolveBackend(); got != "podman" {
+		t.Errorf("flag backend = %q, want podman", got)
+	}
+	if got := resolveArch(); got != "arm64" {
+		t.Errorf("flag arch = %q, want arm64", got)
+	}
+}
+
+func TestSaveClientState(t *testing.T) {
+	t.Chdir(t.TempDir())
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile("") })
+	saveClientState(&gameBuilder.ClientBuildResult{
+		ClientBinary: "build/MyGame",
+		OutputDir:    "build",
+		Platform:     "Linux",
+	})
+	got, err := state.Load()
+	if err != nil {
+		t.Fatalf("state.Load() error = %v", err)
+	}
+	if got.Client == nil {
+		t.Fatal("client state is nil")
+	}
+	fields := map[string]struct {
+		got  string
+		want string
+	}{
+		"binary":   {got: got.Client.BinaryPath, want: "build/MyGame"},
+		"output":   {got: got.Client.OutputDir, want: "build"},
+		"platform": {got: got.Client.Platform, want: "Linux"},
+	}
+	for name, field := range fields {
+		if field.got != field.want {
+			t.Errorf("%s = %q, want %q", name, field.got, field.want)
+		}
+	}
+	if got.Client.BuiltAt == "" {
+		t.Error("BuiltAt is empty")
+	}
+}
+
+func captureGameStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe() error = %v", err)
+	}
+	os.Stdout = writer
+	t.Cleanup(func() { os.Stdout = previous })
+	fn()
+	if err := writer.Close(); err != nil {
+		t.Fatalf("writer.Close() error = %v", err)
+	}
+	os.Stdout = previous
+	output, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatalf("io.ReadAll() error = %v", err)
+	}
+	return string(output)
+}

--- a/cmd/game/game_helpers_test.go
+++ b/cmd/game/game_helpers_test.go
@@ -26,6 +26,12 @@ func TestPrintBuildConfigGuidance(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			got := captureGameStdout(t, func() { printBuildConfigGuidance(tt.cfg) })
+			if tt.want == "" {
+				if got != "" {
+					t.Errorf("output = %q, want no output", got)
+				}
+				return
+			}
 			if !strings.Contains(got, tt.want) {
 				t.Errorf("output = %q, want substring %q", got, tt.want)
 			}

--- a/cmd/mcp/tools_game_options_test.go
+++ b/cmd/mcp/tools_game_options_test.go
@@ -1,0 +1,54 @@
+package mcp
+
+import (
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestMakeGameBuildOptsWithDDC(t *testing.T) {
+	cfg := &config.Config{}
+	cfg.Engine.SourcePath = "/engine"
+	cfg.Game.ProjectPath = "/game/MyGame.uproject"
+	cfg.Game.ProjectName = "MyGame"
+	cfg.Game.ServerTarget = "MyServer"
+	cfg.Game.ClientTarget = "MyClient"
+	cfg.Game.GameTarget = "MyGame"
+	cfg.Game.Platform = "Linux"
+	cfg.Game.Arch = "arm64"
+	cfg.Game.ServerMap = "/Game/Maps/Arena"
+
+	got := makeGameBuildOptsWithDDC(
+		cfg, true, "Win64", "Shipping", 12, "5.6", "local", "/ddc",
+	)
+	fields := map[string]struct {
+		got  string
+		want string
+	}{
+		"engine path":     {got.EnginePath, "/engine"},
+		"project path":    {got.ProjectPath, "/game/MyGame.uproject"},
+		"project name":    {got.ProjectName, "MyGame"},
+		"server target":   {got.ServerTarget, "MyServer"},
+		"client target":   {got.ClientTarget, "MyClient"},
+		"game target":     {got.GameTarget, "MyGame"},
+		"platform":        {got.Platform, "Linux"},
+		"arch":            {got.Arch, "arm64"},
+		"client platform": {got.ClientPlatform, "Win64"},
+		"server map":      {got.ServerMap, "/Game/Maps/Arena"},
+		"engine version":  {got.EngineVersion, "5.6"},
+		"server config":   {got.ServerConfig, "Shipping"},
+		"ddc mode":        {got.DDCMode, "local"},
+		"ddc path":        {got.DDCPath, "/ddc"},
+	}
+	for name, field := range fields {
+		if field.got != field.want {
+			t.Errorf("%s = %q, want %q", name, field.got, field.want)
+		}
+	}
+	if !got.SkipCook {
+		t.Error("SkipCook = false, want true")
+	}
+	if got.MaxJobs != 12 {
+		t.Errorf("MaxJobs = %d, want 12", got.MaxJobs)
+	}
+}

--- a/cmd/pipeline/stages_cache_test.go
+++ b/cmd/pipeline/stages_cache_test.go
@@ -1,0 +1,33 @@
+package pipeline
+
+import (
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/cache"
+)
+
+func TestRecordCache(t *testing.T) {
+	original := globals.DryRun
+	t.Cleanup(func() { globals.DryRun = original })
+	t.Chdir(t.TempDir())
+	const stage = cache.StageKey("game-server")
+
+	t.Run("records normal build", func(t *testing.T) {
+		globals.DryRun = false
+		c := newTestCache()
+		(&pipelineCtx{buildCache: c}).recordCache(stage, "hash1")
+		if !c.IsHit(stage, "hash1") {
+			t.Error("cache entry was not recorded")
+		}
+	})
+
+	t.Run("ignores dry run", func(t *testing.T) {
+		globals.DryRun = true
+		c := newTestCache()
+		(&pipelineCtx{buildCache: c}).recordCache(stage, "hash1")
+		if c.IsHit(stage, "hash1") {
+			t.Error("dry-run cache entry was recorded")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- add unit coverage for game build guidance, deployment hints, backend and architecture resolution
- verify client build state persistence
- cover pipeline cache recording and dry-run behavior
- verify MCP game build-option mapping

## Impact

Test-only change. Production code and runtime behavior are unchanged.

Repository statement coverage increases from 46.9% to 47.1%. The largest package gain is `cmd/game`, from 11.8% to 18.8%.

## Validation

- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 cmd/game/game_helpers_test.go cmd/mcp/tools_game_options_test.go cmd/pipeline/stages_cache_test.go`
- `git diff --check`
