### PR TITLE
test(mcp): cover deploy and game handler branches

### DIFF
--- a/cmd/mcp/tools_deploy_test.go
+++ b/cmd/mcp/tools_deploy_test.go
@@ -2,6 +2,7 @@ package mcp
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
@@ -9,6 +10,48 @@ import (
 	"github.com/jpvelasco/ludus/internal/deploy"
 	"github.com/jpvelasco/ludus/internal/state"
 )
+
+func TestHandleDeploySessionRejectsTargetWithoutSessions(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = &config.Config{Deploy: config.DeployConfig{Target: "binary"}}
+
+	result, _, err := handleDeploySession(context.Background(), nil, deploySessionInput{
+		MaxPlayers: -1,
+	})
+	if err != nil {
+		t.Fatalf("handleDeploySession: %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "does not support game sessions") {
+		t.Fatalf("result = %q, want unsupported-session error", text)
+	}
+}
+
+func TestRunDestroyForMCPRejectsUnknownTarget(t *testing.T) {
+	cfg := &config.Config{}
+	err := runDestroyForMCP(context.Background(), cfg, deployDestroyInput{Target: "unknown"})
+	if err == nil || !strings.Contains(err.Error(), "could not resolve deploy target") {
+		t.Fatalf("runDestroyForMCP error = %v, want target resolution failure", err)
+	}
+}
+
+func TestHandleDeployDestroyReportsResolutionFailure(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = &config.Config{}
+
+	result, _, err := handleDeployDestroy(context.Background(), nil, deployDestroyInput{Target: "unknown"})
+	if err != nil {
+		t.Fatalf("handleDeployDestroy: %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "destroy failed") {
+		t.Fatalf("result = %q, want destroy failure", text)
+	}
+}
 
 // TestHandleDeployFleet_UsesGameliftTarget verifies that handleDeployFleet
 // always resolves the gamelift target, never the config's deploy.target.

--- a/cmd/mcp/tools_game_options_test.go
+++ b/cmd/mcp/tools_game_options_test.go
@@ -4,6 +4,8 @@ import (
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/state"
+	"github.com/jpvelasco/ludus/internal/wsl"
 )
 
 func TestMakeGameBuildOptsWithDDC(t *testing.T) {
@@ -50,5 +52,37 @@ func TestMakeGameBuildOptsWithDDC(t *testing.T) {
 	}
 	if got.MaxJobs != 12 {
 		t.Errorf("MaxJobs = %d, want 12", got.MaxJobs)
+	}
+}
+
+func TestResolveWSL2DDCPath(t *testing.T) {
+	w := &wsl.WSL2{}
+
+	tests := []struct {
+		name        string
+		engineState *state.WSL2EngineState
+		mode        string
+		want        string
+	}{
+		{
+			name:        "state path wins",
+			engineState: &state.WSL2EngineState{DDCPath: "~/ludus/ddc"},
+			mode:        "local",
+			want:        "~/ludus/ddc",
+		},
+		{
+			name:        "non-local mode stays empty",
+			engineState: &state.WSL2EngineState{},
+			mode:        "zen",
+			want:        "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := resolveWSL2DDCPath(w, tt.engineState, tt.mode, "C:\\ddc"); got != tt.want {
+				t.Fatalf("resolveWSL2DDCPath() = %q, want %q", got, tt.want)
+			}
+		})
 	}
 }

--- a/cmd/mcp/tools_game_test.go
+++ b/cmd/mcp/tools_game_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/cache"
 	"github.com/jpvelasco/ludus/internal/config"
 )
 
@@ -52,6 +53,8 @@ func TestGameBuildInputWSL2FieldsOmitEmpty(t *testing.T) {
 // WSL2 handler. On non-Windows / no-WSL2 CI, the handler returns a
 // WSL2-specific error — proving the dispatch took the right branch.
 func TestGameBuildWSL2Dispatch(t *testing.T) {
+	t.Chdir(t.TempDir())
+
 	origCfg := globals.Cfg
 	t.Cleanup(func() { globals.Cfg = origCfg })
 	globals.Cfg = &config.Config{
@@ -72,4 +75,128 @@ func TestGameBuildWSL2Dispatch(t *testing.T) {
 	// or at wsl.New() (no WSL2 available). Either way, the error message
 	// should reference WSL2, proving the dispatch reached the right branch.
 	assertResultContains(t, result, "WSL2")
+}
+
+func TestGameHandlersReturnCachedBuilds(t *testing.T) {
+	tests := []struct {
+		name  string
+		stage cache.StageKey
+		hash  func(*config.Config, string) string
+		call  func(context.Context) string
+	}{
+		{
+			name:  "server",
+			stage: cache.StageGameServer,
+			hash:  cache.GameServerKey,
+			call: func(ctx context.Context) string {
+				result, _, err := handleGameBuild(ctx, nil, gameBuildInput{})
+				if err != nil {
+					t.Fatalf("handleGameBuild: %v", err)
+				}
+				return toolResultText(t, result)
+			},
+		},
+		{
+			name:  "client",
+			stage: cache.StageGameClient,
+			hash: func(cfg *config.Config, engineHash string) string {
+				return cache.GameClientKey(cfg, engineHash, "Linux")
+			},
+			call: func(ctx context.Context) string {
+				result, _, err := handleGameClient(ctx, nil, gameClientInput{})
+				if err != nil {
+					t.Fatalf("handleGameClient: %v", err)
+				}
+				return toolResultText(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			withGameConfig(t, &config.Config{})
+
+			engineHash := cache.EngineKey(globals.Cfg)
+			buildCache := &cache.Cache{Entries: map[cache.StageKey]*cache.Entry{
+				tt.stage: {Hash: tt.hash(globals.Cfg, engineHash)},
+			}}
+			if err := cache.Save(buildCache); err != nil {
+				t.Fatalf("cache.Save: %v", err)
+			}
+
+			if text := tt.call(context.Background()); !strings.Contains(text, "cached") {
+				t.Fatalf("result = %q, want cached build", text)
+			}
+		})
+	}
+}
+
+func TestGameHandlersReportInvalidDDCMode(t *testing.T) {
+	tests := []struct {
+		name string
+		call func(context.Context) string
+	}{
+		{
+			name: "native server",
+			call: func(ctx context.Context) string {
+				result, _, err := handleGameBuild(ctx, nil, gameBuildInput{NoCache: true})
+				if err != nil {
+					t.Fatalf("handleGameBuild: %v", err)
+				}
+				return toolResultText(t, result)
+			},
+		},
+		{
+			name: "native client",
+			call: func(ctx context.Context) string {
+				result, _, err := handleGameClient(ctx, nil, gameClientInput{NoCache: true})
+				if err != nil {
+					t.Fatalf("handleGameClient: %v", err)
+				}
+				return toolResultText(t, result)
+			},
+		},
+		{
+			name: "container server",
+			call: func(ctx context.Context) string {
+				result, _, err := handleGameBuild(ctx, nil, gameBuildInput{Backend: "docker", NoCache: true})
+				if err != nil {
+					t.Fatalf("handleGameBuild container: %v", err)
+				}
+				return toolResultText(t, result)
+			},
+		},
+		{
+			name: "container client",
+			call: func(ctx context.Context) string {
+				result, _, err := handleGameClient(ctx, nil, gameClientInput{Backend: "podman", NoCache: true})
+				if err != nil {
+					t.Fatalf("handleGameClient container: %v", err)
+				}
+				return toolResultText(t, result)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			withGameConfig(t, &config.Config{Engine: config.EngineConfig{DockerImage: "engine:test"}})
+			origDDCMode := globals.DDCMode
+			t.Cleanup(func() { globals.DDCMode = origDDCMode })
+			globals.DDCMode = "invalid"
+
+			if text := tt.call(context.Background()); !strings.Contains(text, "invalid DDC mode") {
+				t.Fatalf("result = %q, want invalid DDC mode", text)
+			}
+		})
+	}
+}
+
+func withGameConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	globals.Cfg = cfg
 }


### PR DESCRIPTION
## Summary
- cover deterministic deploy session and destroy failure paths
- cover native/container game cache hits and DDC validation paths
- cover WSL2 DDC resolution and isolate the WSL dispatch test from local state

## Coverage
- cmd/mcp: 35.9% -> 41.4% locally

## Validation
- go test -count=1 ./...
- go vet ./...
- golangci-lint run ./...
- go build ./...
- gocyclo -over 8 on changed test files (no output)
- git diff --check

The repository hook was also decomposed into its constituent checks because the available Bash resolves to WSL, where Go is not installed.