### PR TITLE
test(mcp): cover engine DDC and container handlers

### DIFF
--- a/cmd/mcp/tools_container_test.go
+++ b/cmd/mcp/tools_container_test.go
@@ -1,0 +1,99 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func TestHandleContainerBuildDryRun(t *testing.T) {
+	tests := []struct {
+		name  string
+		input containerBuildInput
+		cfg   config.Config
+		want  string
+	}{
+		{
+			name:  "input overrides",
+			input: containerBuildInput{Tag: "candidate", Arch: "amd64", Backend: "podman", NoCache: true, DryRun: true},
+			cfg: config.Config{
+				Game:      config.GameConfig{ProjectName: "Lyra", ProjectPath: "project/Lyra.uproject"},
+				Container: config.ContainerConfig{ImageName: "server", Tag: "configured", ServerPort: 7777},
+			},
+			want: "server:candidate",
+		},
+		{
+			name:  "configured tag",
+			input: containerBuildInput{Backend: "docker", DryRun: true},
+			cfg: config.Config{
+				Game:      config.GameConfig{ProjectName: "Lyra", ProjectPath: "project/Lyra.uproject"},
+				Container: config.ContainerConfig{ImageName: "server", Tag: "stable", ServerPort: 7777},
+			},
+			want: "server:stable",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withContainerTestConfig(t, &tt.cfg)
+			result, _, err := handleContainerBuild(context.Background(), nil, tt.input)
+			if err != nil {
+				t.Fatalf("handleContainerBuild() error = %v", err)
+			}
+			if result.IsError {
+				t.Fatalf("handleContainerBuild() returned error: %+v", result)
+			}
+			got := decodeContainerResult(t, result)
+			if !got.Success || got.ImageTag != tt.want {
+				t.Errorf("result = %+v, want success with image %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestHandleContainerBuildMissingDirectory(t *testing.T) {
+	withContainerTestConfig(t, &config.Config{})
+
+	result, _, err := handleContainerBuild(context.Background(), nil, containerBuildInput{DryRun: true})
+	if err != nil {
+		t.Fatalf("handleContainerBuild() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleContainerBuild() should return an error result")
+	}
+	if got := decodeContainerResult(t, result); !strings.Contains(got.Error, "server build directory not specified") {
+		t.Errorf("error = %q, want missing server build directory", got.Error)
+	}
+}
+
+func withContainerTestConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	origCfg, origDryRun := globals.Cfg, globals.DryRun
+	t.Cleanup(func() {
+		globals.Cfg = origCfg
+		globals.DryRun = origDryRun
+	})
+	t.Chdir(t.TempDir())
+	globals.Cfg = cfg
+	globals.DryRun = false
+}
+
+func decodeContainerResult(t *testing.T, result *mcpsdk.CallToolResult) containerResult {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("expected result content")
+	}
+	text, ok := result.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("content type = %T, want *mcp.TextContent", result.Content[0])
+	}
+	var got containerResult
+	if err := json.Unmarshal([]byte(text.Text), &got); err != nil {
+		t.Fatalf("unmarshal container result: %v", err)
+	}
+	return got
+}

--- a/cmd/mcp/tools_container_test.go
+++ b/cmd/mcp/tools_container_test.go
@@ -3,6 +3,7 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -20,9 +21,9 @@ func TestHandleContainerBuildDryRun(t *testing.T) {
 	}{
 		{
 			name:  "input overrides",
-			input: containerBuildInput{Tag: "candidate", Arch: "amd64", Backend: "podman", NoCache: true, DryRun: true},
+			input: containerBuildInput{Tag: "candidate", Arch: runtime.GOARCH, Backend: "podman", NoCache: true, DryRun: true},
 			cfg: config.Config{
-				Game:      config.GameConfig{ProjectName: "Lyra", ProjectPath: "project/Lyra.uproject"},
+				Game:      config.GameConfig{ProjectName: "Lyra", ProjectPath: "project/Lyra.uproject", Arch: runtime.GOARCH},
 				Container: config.ContainerConfig{ImageName: "server", Tag: "configured", ServerPort: 7777},
 			},
 			want: "server:candidate",

--- a/cmd/mcp/tools_container_test.go
+++ b/cmd/mcp/tools_container_test.go
@@ -32,7 +32,7 @@ func TestHandleContainerBuildDryRun(t *testing.T) {
 			name:  "configured tag",
 			input: containerBuildInput{Backend: "docker", DryRun: true},
 			cfg: config.Config{
-				Game:      config.GameConfig{ProjectName: "Lyra", ProjectPath: "project/Lyra.uproject"},
+				Game:      config.GameConfig{ProjectName: "Lyra", ProjectPath: "project/Lyra.uproject", Arch: runtime.GOARCH},
 				Container: config.ContainerConfig{ImageName: "server", Tag: "stable", ServerPort: 7777},
 			},
 			want: "server:stable",

--- a/cmd/mcp/tools_ddc_test.go
+++ b/cmd/mcp/tools_ddc_test.go
@@ -5,12 +5,14 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/cmd/globals"
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/ddc"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+	"github.com/spf13/viper"
 )
 
 func TestValidateConfigureMode(t *testing.T) {
@@ -262,4 +264,140 @@ func TestHandleDDCClean(t *testing.T) {
 	if len(entries) != 0 {
 		t.Errorf("DDC dir should be empty, has %d entries", len(entries))
 	}
+}
+
+func TestPersistDDCConfig(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     ddcConfigureInput
+		validated string
+		wantMode  string
+		wantPath  string
+	}{
+		{name: "mode", input: ddcConfigureInput{Mode: "none"}, validated: "none", wantMode: "none", wantPath: "old-path"},
+		{name: "path", input: ddcConfigureInput{LocalPath: "new-path"}, wantMode: "local", wantPath: "new-path"},
+		{name: "both", input: ddcConfigureInput{Mode: "none", LocalPath: "new-path"}, validated: "none", wantMode: "none", wantPath: "new-path"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.input.LocalPath != "" {
+				tt.input.LocalPath = filepath.Join(t.TempDir(), "new-ddc")
+				tt.wantPath = tt.input.LocalPath
+			}
+			prepareDDCViperConfig(t)
+			changed, err := persistDDCConfig(tt.input, tt.validated)
+			if err != nil {
+				t.Fatalf("persistDDCConfig() error = %v", err)
+			}
+			if !changed {
+				t.Fatal("persistDDCConfig() changed = false, want true")
+			}
+			if globals.Cfg.DDC.Mode != tt.wantMode || globals.Cfg.DDC.LocalPath != tt.wantPath {
+				t.Errorf("DDC config = %+v, want mode %q path %q", globals.Cfg.DDC, tt.wantMode, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestPersistDDCConfigNoChanges(t *testing.T) {
+	prepareDDCViperConfig(t)
+	changed, err := persistDDCConfig(ddcConfigureInput{}, "")
+	if err != nil || changed {
+		t.Errorf("persistDDCConfig() = (%v, %v), want (false, nil)", changed, err)
+	}
+}
+
+func TestPersistDDCConfigWriteFailureRollsBack(t *testing.T) {
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	viper.Set("ddc.mode", "local")
+	viper.Set("ddc.localPath", "old-path")
+	globals.Cfg = &config.Config{DDC: config.DDCConfig{Mode: "local", LocalPath: "old-path"}}
+
+	changed, err := persistDDCConfig(ddcConfigureInput{Mode: "none", LocalPath: "new-path"}, "none")
+	if err == nil || changed {
+		t.Fatalf("persistDDCConfig() = (%v, %v), want write error", changed, err)
+	}
+	if got := viper.GetString("ddc.mode"); got != "local" {
+		t.Errorf("viper mode = %q, want rollback to local", got)
+	}
+	if got := viper.GetString("ddc.localPath"); got != "old-path" {
+		t.Errorf("viper path = %q, want rollback to old-path", got)
+	}
+}
+
+func TestHandleDDCConfigureInvalidMode(t *testing.T) {
+	result, _, err := handleDDCConfigure(context.Background(), nil, ddcConfigureInput{Mode: "remote"})
+	if err != nil {
+		t.Fatalf("handleDDCConfigure() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleDDCConfigure() should return an error result")
+	}
+}
+
+func TestHandleDDCConfigurePersistsChanges(t *testing.T) {
+	prepareDDCViperConfig(t)
+	origMode := globals.DDCMode
+	t.Cleanup(func() { globals.DDCMode = origMode })
+	globals.DDCMode = ""
+	path := filepath.Join(t.TempDir(), "configured-ddc")
+
+	result, _, err := handleDDCConfigure(context.Background(), nil, ddcConfigureInput{Mode: "local", LocalPath: path})
+	if err != nil {
+		t.Fatalf("handleDDCConfigure() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleDDCConfigure() returned error: %+v", result)
+	}
+	got := decodeDDCResult[ddcConfigureResult](t, result)
+	if got.Mode != ddc.ModeLocal || got.Path != path || !got.Persisted {
+		t.Errorf("configure result = %+v, want local path %q persisted", got, path)
+	}
+}
+
+func TestHandleDDCWarmDryRun(t *testing.T) {
+	origMode, origCfg := globals.DDCMode, globals.Cfg
+	t.Cleanup(func() {
+		globals.DDCMode = origMode
+		globals.Cfg = origCfg
+	})
+	globals.DDCMode = ddc.ModeLocal
+	globals.Cfg = &config.Config{
+		DDC:    config.DDCConfig{LocalPath: t.TempDir()},
+		Engine: config.EngineConfig{Backend: "docker", DockerImage: "engine:5.7"},
+		Game:   config.GameConfig{ProjectName: "Lyra"},
+	}
+
+	result, _, err := handleDDCWarm(context.Background(), nil, ddcWarmInput{DryRun: true})
+	if err != nil {
+		t.Fatalf("handleDDCWarm() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleDDCWarm() returned error: %+v", result)
+	}
+	got := decodeDDCResult[ddcWarmResult](t, result)
+	if !got.Success || !strings.Contains(got.Message, "engine:5.7") || !strings.Contains(got.Message, "Lyra") {
+		t.Errorf("warm result = %+v, want dry-run details", got)
+	}
+}
+
+func prepareDDCViperConfig(t *testing.T) {
+	t.Helper()
+	origCfg := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = origCfg })
+	viper.Reset()
+	t.Cleanup(viper.Reset)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "ludus.yaml")
+	if err := os.WriteFile(path, []byte("ddc:\n  mode: local\n  localPath: old-path\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	viper.SetConfigFile(path)
+	if err := viper.ReadInConfig(); err != nil {
+		t.Fatal(err)
+	}
+	globals.Cfg = &config.Config{DDC: config.DDCConfig{Mode: "local", LocalPath: "old-path"}}
 }

--- a/cmd/mcp/tools_engine_test.go
+++ b/cmd/mcp/tools_engine_test.go
@@ -145,7 +145,7 @@ func TestEngineBuildSkipSetupDryRun(t *testing.T) {
 
 func TestHandleEngineSetupDryRun(t *testing.T) {
 	engineDir := t.TempDir()
-	if err := os.WriteFile(filepath.Join(engineDir, "Setup.bat"), nil, 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(engineDir, engineSetupScript()), nil, 0644); err != nil {
 		t.Fatal(err)
 	}
 	withEngineTestConfig(t, &config.Config{Engine: config.EngineConfig{SourcePath: engineDir}})
@@ -174,7 +174,14 @@ func TestHandleEngineSetupMissingSource(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("handleEngineSetup() should return an error result")
 	}
-	assertResultContains(t, result, "Setup.bat not found")
+	assertResultContains(t, result, engineSetupScript()+" not found")
+}
+
+func engineSetupScript() string {
+	if runtime.GOOS == "windows" {
+		return "Setup.bat"
+	}
+	return "Setup.sh"
 }
 
 func TestHandleContainerEngineBuildMissingSource(t *testing.T) {

--- a/cmd/mcp/tools_engine_test.go
+++ b/cmd/mcp/tools_engine_test.go
@@ -3,6 +3,9 @@ package mcp
 import (
 	"context"
 	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -10,6 +13,18 @@ import (
 	"github.com/jpvelasco/ludus/internal/config"
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+func withEngineTestConfig(t *testing.T, cfg *config.Config) {
+	t.Helper()
+	origCfg, origDryRun := globals.Cfg, globals.DryRun
+	t.Cleanup(func() {
+		globals.Cfg = origCfg
+		globals.DryRun = origDryRun
+	})
+	t.Chdir(t.TempDir())
+	globals.Cfg = cfg
+	globals.DryRun = false
+}
 
 func TestEngineBuildInputWSL2Fields(t *testing.T) {
 	input := engineBuildInput{
@@ -60,6 +75,9 @@ func TestEngineBuildInputWSL2FieldsOmitEmpty(t *testing.T) {
 // WSL2 handler (not the native path). On non-Windows / no-WSL2 CI, the handler
 // returns a WSL2-specific error — proving the dispatch took the right branch.
 func TestEngineBuildWSL2Dispatch(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("dispatch reaches the real wsl.exe probe on Windows")
+	}
 	origCfg := globals.Cfg
 	t.Cleanup(func() { globals.Cfg = origCfg })
 	globals.Cfg = &config.Config{
@@ -106,11 +124,9 @@ func TestEngineBuildInputSkipSetup(t *testing.T) {
 // engine.BuildOptions.SkipSetup). A dry-run native build prints the commands
 // without executing them, so this is safe on CI with no engine tree.
 func TestEngineBuildSkipSetupDryRun(t *testing.T) {
-	origCfg := globals.Cfg
-	t.Cleanup(func() { globals.Cfg = origCfg })
-	globals.Cfg = &config.Config{
+	withEngineTestConfig(t, &config.Config{
 		Engine: config.EngineConfig{SourcePath: t.TempDir(), Backend: "native"},
-	}
+	})
 
 	result, _, err := handleEngineBuild(context.Background(), nil, engineBuildInput{
 		Backend:   "native",
@@ -125,6 +141,81 @@ func TestEngineBuildSkipSetupDryRun(t *testing.T) {
 		t.Fatal("expected non-nil result")
 	}
 	assertResultContains(t, result, "Skipping Setup")
+}
+
+func TestHandleEngineSetupDryRun(t *testing.T) {
+	engineDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(engineDir, "Setup.bat"), nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	withEngineTestConfig(t, &config.Config{Engine: config.EngineConfig{SourcePath: engineDir}})
+
+	result, _, err := handleEngineSetup(context.Background(), nil, engineSetupInput{DryRun: true})
+	if err != nil {
+		t.Fatalf("handleEngineSetup() error = %v", err)
+	}
+	if result.IsError {
+		t.Fatalf("handleEngineSetup() returned error result: %+v", result)
+	}
+	got := decodeEngineResult(t, result)
+	if !got.Success || got.EnginePath != engineDir {
+		t.Errorf("result = %+v, want successful engine path %q", got, engineDir)
+	}
+}
+
+func TestHandleEngineSetupMissingSource(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	withEngineTestConfig(t, &config.Config{Engine: config.EngineConfig{SourcePath: missing}})
+
+	result, _, err := handleEngineSetup(context.Background(), nil, engineSetupInput{})
+	if err != nil {
+		t.Fatalf("handleEngineSetup() error = %v", err)
+	}
+	if !result.IsError {
+		t.Fatal("handleEngineSetup() should return an error result")
+	}
+	assertResultContains(t, result, "Setup.bat not found")
+}
+
+func TestHandleContainerEngineBuildMissingSource(t *testing.T) {
+	tests := []struct {
+		name    string
+		backend string
+		want    string
+	}{
+		{name: "docker", backend: "docker", want: "engine build failed: engine source path not specified"},
+		{name: "podman", backend: "podman", want: "engine build failed: engine source path not specified"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := config.Config{Engine: config.EngineConfig{SourcePath: ""}}
+			t.Chdir(t.TempDir())
+			result, _, err := handleContainerEngineBuild(context.Background(), &cfg, engineBuildInput{NoCache: true}, tt.backend)
+			if err != nil {
+				t.Fatalf("handleContainerEngineBuild() error = %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("handleContainerEngineBuild() should return an error result")
+			}
+			assertResultContains(t, result, tt.want)
+		})
+	}
+}
+
+func decodeEngineResult(t *testing.T, result *mcpsdk.CallToolResult) engineResult {
+	t.Helper()
+	if len(result.Content) == 0 {
+		t.Fatal("expected result content")
+	}
+	text, ok := result.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("content type = %T, want *mcp.TextContent", result.Content[0])
+	}
+	var got engineResult
+	if err := json.Unmarshal([]byte(text.Text), &got); err != nil {
+		t.Fatalf("unmarshal engine result: %v", err)
+	}
+	return got
 }
 
 // assertResultContains checks that a CallToolResult's text content contains substr.


### PR DESCRIPTION
## Summary
- cover MCP container build defaults, overrides, dry-run results, and preflight errors
- cover DDC config persistence, rollback, validation, and warmup dry-run formatting
- cover engine setup and container-backend failure paths without external execution
- prevent the WSL dispatch test from probing real wsl.exe on Windows

## Validation
- go test -count=1 ./...
- go vet ./...
- go build ./...
- golangci-lint run ./...
- gocyclo -over 8 on all changed test files (no output)
- git diff --check

The pre-commit hook's checks were run directly because the local Bash entrypoint is WSL-only and has no Go toolchain. This PR contains test files only.