### PR TITLE
test(mcp): cover async build lifecycle

### DIFF
--- a/cmd/mcp/buildmgr_logic_test.go
+++ b/cmd/mcp/buildmgr_logic_test.go
@@ -1,10 +1,17 @@
 package mcp
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"os"
+	"path/filepath"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
 )
 
 // entrySnapshot reads an entry's status and result under the manager lock.
@@ -148,5 +155,131 @@ func TestSyncBuffer_ConcurrentWrites(t *testing.T) {
 	wg.Wait()
 	if sb.Len() != 50 {
 		t.Errorf("Len = %d, want 50", sb.Len())
+	}
+}
+
+func TestBuildManager_FailedBuildAndStaleCancel(t *testing.T) {
+	bm := newBuildManager()
+	id, err := bm.Start(buildTypeEngineBuild, func(context.Context, *syncBuffer) (any, error) {
+		return nil, errors.New("compiler failed")
+	})
+	if err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	waitForStatus(t, bm, id, buildStatusFailed)
+
+	bm.mu.Lock()
+	entry := bm.entries[id]
+	gotError := entry.Error
+	bm.mu.Unlock()
+	if gotError != "compiler failed" {
+		t.Errorf("Error = %q, want compiler failed", gotError)
+	}
+	if err := bm.CancelBuild(id); err == nil {
+		t.Fatal("expected completed build cancellation to fail")
+	}
+}
+
+func TestBuildManager_ListNewestFirstAndAllowsDifferentTypes(t *testing.T) {
+	bm := newBuildManager()
+	release := make(chan struct{})
+	start := func(kind buildType) string {
+		t.Helper()
+		id, err := bm.Start(kind, func(context.Context, *syncBuffer) (any, error) {
+			<-release
+			return kind, nil
+		})
+		if err != nil {
+			t.Fatalf("Start(%s) error: %v", kind, err)
+		}
+		return id
+	}
+
+	firstID := start(buildTypeEngineBuild)
+	time.Sleep(time.Millisecond)
+	secondID := start(buildTypeGameBuild)
+	entries := bm.List()
+	if len(entries) != 2 {
+		t.Fatalf("List length = %d, want 2", len(entries))
+	}
+	if entries[0].ID != secondID || entries[1].ID != firstID {
+		t.Errorf("List IDs = [%s, %s], want [%s, %s]", entries[0].ID, entries[1].ID, secondID, firstID)
+	}
+	close(release)
+	waitForStatus(t, bm, firstID, buildStatusCompleted)
+	waitForStatus(t, bm, secondID, buildStatusCompleted)
+}
+
+func TestSyncBuffer_MirrorsSinkAndHandlesEdges(t *testing.T) {
+	var sink bytes.Buffer
+	sb := &syncBuffer{sink: &sink}
+	if _, err := sb.Write([]byte("one\ntwo")); err != nil {
+		t.Fatalf("Write error: %v", err)
+	}
+	if got := sink.String(); got != "one\ntwo" {
+		t.Errorf("sink = %q, want mirrored output", got)
+	}
+	if got := sb.tailLines(0); got != "" {
+		t.Errorf("tailLines(0) = %q, want empty", got)
+	}
+	if got := (&syncBuffer{}).tailLines(5); got != "" {
+		t.Errorf("empty tail = %q, want empty", got)
+	}
+}
+
+func TestOpenBuildLog(t *testing.T) {
+	origCfg, origNoLogs := globals.Cfg, globals.NoLogs
+	t.Cleanup(func() { globals.Cfg, globals.NoLogs = origCfg, origNoLogs })
+	t.Run("disabled", testOpenBuildLogDisabled)
+	t.Run("persists output", testOpenBuildLogPersists)
+	t.Run("invalid directory", testOpenBuildLogInvalidDir)
+}
+
+func testOpenBuildLogDisabled(t *testing.T) {
+	globals.NoLogs = true
+	globals.Cfg = &config.Config{}
+	if f := openBuildLog("disabled"); f != nil {
+		_ = f.Close()
+		t.Fatal("openBuildLog returned a file while logs disabled")
+	}
+}
+
+func testOpenBuildLogPersists(t *testing.T) {
+	globals.NoLogs = false
+	dir := t.TempDir()
+	globals.Cfg = &config.Config{Observability: config.ObservabilityConfig{
+		Logs: config.LogsConfig{Dir: dir, RetainRuns: 2},
+	}}
+	f := openBuildLog("game-build")
+	if f == nil {
+		t.Fatal("openBuildLog returned nil")
+	}
+	if _, err := f.WriteString("build output"); err != nil {
+		t.Fatalf("WriteString error: %v", err)
+	}
+	if err := f.Close(); err != nil {
+		t.Fatalf("Close error: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(dir, "game-build.log"))
+	if err != nil {
+		t.Fatalf("ReadFile error: %v", err)
+	}
+	if string(data) != "build output" {
+		t.Errorf("log contents = %q", data)
+	}
+}
+
+func testOpenBuildLogInvalidDir(t *testing.T) {
+	globals.NoLogs = false
+	file := filepath.Join(t.TempDir(), "file")
+	if err := os.WriteFile(file, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	globals.Cfg = &config.Config{Observability: config.ObservabilityConfig{
+		Logs: config.LogsConfig{Dir: filepath.Join(file, "child")},
+	}}
+	if f := openBuildLog("failed"); f != nil {
+		_ = f.Close()
+		t.Fatal("openBuildLog should fail for invalid directory")
 	}
 }

--- a/cmd/mcp/register_test.go
+++ b/cmd/mcp/register_test.go
@@ -1,16 +1,96 @@
 package mcp
 
 import (
+	"context"
+	"encoding/json"
 	"testing"
 
 	sdkmcp "github.com/modelcontextprotocol/go-sdk/mcp"
 )
 
-func TestRegisterTools(t *testing.T) {
-	server := sdkmcp.NewServer(&sdkmcp.Implementation{
-		Name:    "test",
-		Version: "test",
-	}, nil)
+var expectedToolNames = map[string]bool{
+	"ludus_init": true, "ludus_status": true,
+	"ludus_engine_setup": true, "ludus_engine_build": true, "ludus_engine_push": true,
+	"ludus_game_build": true, "ludus_game_client": true,
+	"ludus_container_build": true, "ludus_container_push": true,
+	"ludus_deploy_fleet": true, "ludus_deploy_stack": true, "ludus_deploy_anywhere": true,
+	"ludus_deploy_ec2": true, "ludus_deploy_session": true, "ludus_deploy_destroy": true,
+	"ludus_connect_info": true, "ludus_engine_build_start": true,
+	"ludus_game_build_start": true, "ludus_game_client_start": true, "ludus_build_status": true,
+	"ludus_buildgraph": true, "ludus_resources": true,
+	"ludus_ddc_status": true, "ludus_ddc_clean": true, "ludus_ddc_configure": true, "ludus_ddc_warm": true,
+}
 
+func TestRegisterToolsCompletenessAndSchemas(t *testing.T) {
+	ctx := context.Background()
+	server := sdkmcp.NewServer(&sdkmcp.Implementation{Name: "test", Version: "test"}, nil)
 	registerTools(server)
+	clientTransport, serverTransport := sdkmcp.NewInMemoryTransports()
+	serverSession, err := server.Connect(ctx, serverTransport, nil)
+	if err != nil {
+		t.Fatalf("server.Connect: %v", err)
+	}
+	client := sdkmcp.NewClient(&sdkmcp.Implementation{Name: "test-client", Version: "test"}, nil)
+	clientSession, err := client.Connect(ctx, clientTransport, nil)
+	if err != nil {
+		t.Fatalf("client.Connect: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = clientSession.Close()
+		_ = serverSession.Close()
+	})
+
+	result, err := clientSession.ListTools(ctx, nil)
+	if err != nil {
+		t.Fatalf("ListTools: %v", err)
+	}
+	assertRegisteredTools(t, result.Tools)
+}
+
+func assertRegisteredTools(t *testing.T, tools []*sdkmcp.Tool) {
+	t.Helper()
+	if len(tools) != len(expectedToolNames) {
+		t.Errorf("tool count = %d, want %d", len(tools), len(expectedToolNames))
+	}
+	seen := make(map[string]bool, len(tools))
+	for _, tool := range tools {
+		if seen[tool.Name] {
+			t.Errorf("duplicate tool %q", tool.Name)
+		}
+		seen[tool.Name] = true
+		assertToolMetadata(t, tool)
+	}
+	for name := range expectedToolNames {
+		if !seen[name] {
+			t.Errorf("missing tool %q", name)
+		}
+	}
+}
+
+func assertToolMetadata(t *testing.T, tool *sdkmcp.Tool) {
+	t.Helper()
+	if !expectedToolNames[tool.Name] {
+		t.Errorf("unexpected tool %q", tool.Name)
+	}
+	if tool.Description == "" {
+		t.Errorf("tool %q has no description", tool.Name)
+	}
+	data, err := json.Marshal(tool.InputSchema)
+	if err != nil {
+		t.Errorf("tool %q schema marshal: %v", tool.Name, err)
+		return
+	}
+	var schema map[string]any
+	if err := json.Unmarshal(data, &schema); err != nil {
+		t.Errorf("tool %q schema decode: %v", tool.Name, err)
+		return
+	}
+	if schema["type"] != "object" {
+		t.Errorf("tool %q schema type = %v, want object", tool.Name, schema["type"])
+	}
+	if properties, exists := schema["properties"]; exists {
+		if _, ok := properties.(map[string]any); !ok {
+			t.Errorf("tool %q schema properties = %T, want object", tool.Name, properties)
+		}
+	}
 }

--- a/cmd/mcp/tools_async_logic_test.go
+++ b/cmd/mcp/tools_async_logic_test.go
@@ -1,0 +1,145 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
+)
+
+func decodeToolJSON(t *testing.T, result *mcpsdk.CallToolResult, dst any) {
+	t.Helper()
+	if result == nil || len(result.Content) == 0 {
+		t.Fatal("expected tool content")
+	}
+	text, ok := result.Content[0].(*mcpsdk.TextContent)
+	if !ok {
+		t.Fatalf("content type = %T, want TextContent", result.Content[0])
+	}
+	if err := json.Unmarshal([]byte(text.Text), dst); err != nil {
+		t.Fatalf("decode tool JSON: %v", err)
+	}
+}
+
+func TestSnapshotConfigDeepCopiesReferences(t *testing.T) {
+	orig := globals.Cfg
+	t.Cleanup(func() { globals.Cfg = orig })
+	globals.Cfg = &config.Config{
+		AWS: config.AWSConfig{Tags: map[string]string{"env": "test"}},
+		Game: config.GameConfig{ContentValidation: &config.ContentValidationConfig{
+			ContentMarkerFile: "marker", PluginContentDirs: []string{"plugin"},
+		}},
+		CI: config.CIConfig{RunnerLabels: []string{"linux"}},
+	}
+
+	snap := snapshotConfig()
+	snap.AWS.Tags["env"] = "changed"
+	snap.Game.ContentValidation.ContentMarkerFile = "changed"
+	snap.Game.ContentValidation.PluginContentDirs[0] = "changed"
+	snap.CI.RunnerLabels[0] = "changed"
+
+	checks := map[string]string{
+		"tag":    globals.Cfg.AWS.Tags["env"],
+		"marker": globals.Cfg.Game.ContentValidation.ContentMarkerFile,
+		"plugin": globals.Cfg.Game.ContentValidation.PluginContentDirs[0],
+		"label":  globals.Cfg.CI.RunnerLabels[0],
+	}
+	for name, got := range checks {
+		if got == "changed" {
+			t.Errorf("%s shared storage with snapshot", name)
+		}
+	}
+}
+
+func TestHandleBuildStatusManagerUnavailable(t *testing.T) {
+	previous := builds
+	builds = nil
+	t.Cleanup(func() { builds = previous })
+	result, _, err := handleBuildStatus(context.Background(), nil, buildStatusInput{})
+	assertToolError(t, result, err, "not initialized")
+}
+
+func TestHandleBuildStatusModes(t *testing.T) {
+	withBuildManager(t)
+	started := make(chan struct{})
+	id, err := builds.Start(buildTypeEngineBuild, func(ctx context.Context, buf *syncBuffer) (any, error) {
+		_, _ = buf.Write([]byte(strings.Repeat("line\n", 105)))
+		close(started)
+		<-ctx.Done()
+		return nil, ctx.Err()
+	})
+	if err != nil {
+		t.Fatalf("Start error: %v", err)
+	}
+	<-started
+	t.Run("unknown", func(t *testing.T) { testBuildStatusUnknown(t) })
+	t.Run("list", func(t *testing.T) { testBuildStatusList(t, id) })
+	t.Run("detail truncates output", func(t *testing.T) { testBuildStatusDetail(t, id) })
+	t.Run("cancel", func(t *testing.T) { testBuildStatusCancel(t, id) })
+	t.Run("cancel stale", func(t *testing.T) { testBuildStatusStale(t, id) })
+}
+
+func testBuildStatusUnknown(t *testing.T) {
+	result, _, err := handleBuildStatus(context.Background(), nil, buildStatusInput{BuildID: "missing"})
+	assertToolError(t, result, err, "not found")
+}
+
+func testBuildStatusList(t *testing.T, id string) {
+	result, _, err := handleBuildStatus(context.Background(), nil, buildStatusInput{})
+	if err != nil {
+		t.Fatalf("handleBuildStatus error: %v", err)
+	}
+	var got buildListResult
+	decodeToolJSON(t, result, &got)
+	if len(got.Builds) != 1 || got.Builds[0].BuildID != id {
+		t.Fatalf("build list = %+v", got.Builds)
+	}
+	if got.Builds[0].OutputTail != "" {
+		t.Error("list response should omit output tail")
+	}
+}
+
+func testBuildStatusDetail(t *testing.T, id string) {
+	result, _, err := handleBuildStatus(context.Background(), nil, buildStatusInput{BuildID: id})
+	if err != nil {
+		t.Fatalf("handleBuildStatus error: %v", err)
+	}
+	var got buildStatusResult
+	decodeToolJSON(t, result, &got)
+	if strings.Count(got.OutputTail, "line") != 100 {
+		t.Errorf("output lines = %d, want 100", strings.Count(got.OutputTail, "line"))
+	}
+	if got.OutputBytes != 525 {
+		t.Errorf("OutputBytes = %d, want 525", got.OutputBytes)
+	}
+}
+
+func testBuildStatusCancel(t *testing.T, id string) {
+	result, _, err := handleBuildStatus(context.Background(), nil, buildStatusInput{BuildID: id, Cancel: true})
+	if err != nil || result.IsError {
+		t.Fatalf("cancel result error: %v, %+v", err, result)
+	}
+	waitForStatus(t, builds, id, buildStatusCancelled)
+}
+
+func testBuildStatusStale(t *testing.T, id string) {
+	result, _, err := handleBuildStatus(context.Background(), nil, buildStatusInput{BuildID: id, Cancel: true})
+	assertToolError(t, result, err, "not running")
+}
+
+func TestBuildEntryToResultCompletedDuration(t *testing.T) {
+	start := time.Now().Add(-2 * time.Second)
+	entry := &buildEntry{
+		ID: "done", Type: buildTypeGameBuild, Status: buildStatusCompleted,
+		StartedAt: start, EndedAt: start.Add(1500 * time.Millisecond), Output: &syncBuffer{},
+	}
+	got := buildEntryToResult(entry, true)
+	if got.ElapsedSeconds != 1.5 {
+		t.Errorf("ElapsedSeconds = %v, want 1.5", got.ElapsedSeconds)
+	}
+}


### PR DESCRIPTION
## Summary
- cover async build completion, failure, cancellation, duplicate prevention, ordering, and log persistence
- verify status handler list/detail/error/cancel modes and 100-line output truncation
- assert deep config snapshots and completeness/schema metadata for all 26 MCP tools

## Validation
- go test -count=1 ./...
- go vet ./...
- go build ./...
- golangci-lint run ./...
- gocyclo -over 8 on changed tests (no output)
- git diff --check

Local cmd/mcp coverage: 47.4% -> 50.1%.

All repository changes are co-located *_test.go files.