### PR TITLE
test(mcp): cover deterministic status and session helpers

### DIFF
--- a/cmd/mcp/helpers_output_test.go
+++ b/cmd/mcp/helpers_output_test.go
@@ -1,10 +1,18 @@
 package mcp
 
 import (
+	"strings"
 	"testing"
 
 	mcpsdk "github.com/modelcontextprotocol/go-sdk/mcp"
 )
+
+func TestJSONstringReportsMarshalError(t *testing.T) {
+	got := jsonString(make(chan int))
+	if !strings.Contains(got, "unsupported type") {
+		t.Fatalf("jsonString error = %q", got)
+	}
+}
 
 func TestMergeOutput(t *testing.T) {
 	tests := []struct {

--- a/cmd/mcp/helpers_session_test.go
+++ b/cmd/mcp/helpers_session_test.go
@@ -1,0 +1,110 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/deploy"
+)
+
+type sessionTestTarget struct {
+	session *deploy.SessionInfo
+	err     error
+	calls   int
+}
+
+func (*sessionTestTarget) Name() string { return "test" }
+
+func (*sessionTestTarget) Capabilities() deploy.Capabilities {
+	return deploy.Capabilities{SupportsSession: true}
+}
+
+func (*sessionTestTarget) Deploy(context.Context, deploy.DeployInput) (*deploy.DeployResult, error) {
+	return nil, nil
+}
+
+func (*sessionTestTarget) Status(context.Context) (*deploy.DeployStatus, error) { return nil, nil }
+
+func (*sessionTestTarget) Destroy(context.Context) error { return nil }
+
+func (t *sessionTestTarget) CreateSession(context.Context, int) (*deploy.SessionInfo, error) {
+	t.calls++
+	return t.session, t.err
+}
+
+func (*sessionTestTarget) DescribeSession(context.Context, string) (string, error) { return "", nil }
+
+type sessionTestReceiver struct {
+	id   string
+	ip   string
+	port int
+}
+
+func (r *sessionTestReceiver) setSession(id, ip string, port int) {
+	r.id, r.ip, r.port = id, ip, port
+}
+
+func TestTryCreateSession(t *testing.T) {
+	tests := []struct {
+		name        string
+		withSession bool
+		target      deploy.Target
+		wantCalls   int
+		wantID      string
+	}{
+		{name: "disabled", target: &sessionTestTarget{}, wantCalls: 0},
+		{name: "unsupported", withSession: true, target: targetOnly{Target: &sessionTestTarget{}}, wantCalls: 0},
+		{name: "error", withSession: true, target: &sessionTestTarget{err: errors.New("unavailable")}, wantCalls: 1},
+		{name: "nil session", withSession: true, target: &sessionTestTarget{}, wantCalls: 1},
+		{name: "success", withSession: true, target: &sessionTestTarget{session: &deploy.SessionInfo{SessionID: "session-1", IPAddress: "192.0.2.10", Port: 7777}}, wantCalls: 1, wantID: "session-1"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			receiver := &sessionTestReceiver{}
+			tryCreateSession(context.Background(), tt.target, tt.withSession, receiver)
+			if got := sessionCreateCalls(tt.target); got != tt.wantCalls {
+				t.Errorf("CreateSession calls = %d, want %d", got, tt.wantCalls)
+			}
+			if receiver.id != tt.wantID {
+				t.Errorf("session ID = %q, want %q", receiver.id, tt.wantID)
+			}
+			if tt.wantID != "" && (receiver.ip != "192.0.2.10" || receiver.port != 7777) {
+				t.Errorf("session endpoint = %s:%d", receiver.ip, receiver.port)
+			}
+		})
+	}
+}
+
+type targetOnly struct{ deploy.Target }
+
+func sessionCreateCalls(target deploy.Target) int {
+	if manager, ok := target.(*sessionTestTarget); ok {
+		return manager.calls
+	}
+	return 0
+}
+
+func TestDeployResultsSetSession(t *testing.T) {
+	fleet := &deployFleetResult{}
+	stack := &deployStackResult{}
+	anywhere := &deployAnywhereResult{}
+	ec2 := &deployEC2Result{}
+
+	receivers := []sessionReceiver{fleet, stack, anywhere, ec2}
+	for _, receiver := range receivers {
+		receiver.setSession("session-2", "198.51.100.5", 7788)
+	}
+
+	got := []sessionTestReceiver{
+		{id: fleet.SessionID, ip: fleet.SessionIP, port: fleet.SessionPort},
+		{id: stack.SessionID, ip: stack.SessionIP, port: stack.SessionPort},
+		{id: anywhere.SessionID, ip: anywhere.SessionIP, port: anywhere.SessionPort},
+		{id: ec2.SessionID, ip: ec2.SessionIP, port: ec2.SessionPort},
+	}
+	for i, result := range got {
+		if result.id != "session-2" || result.ip != "198.51.100.5" || result.port != 7788 {
+			t.Errorf("result %d session = %+v", i, result)
+		}
+	}
+}

--- a/cmd/mcp/tools_init_test.go
+++ b/cmd/mcp/tools_init_test.go
@@ -1,0 +1,38 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestHandleInitSummarizesPrerequisiteChecks(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	previous := globals.Cfg
+	cfg := config.Defaults()
+	cfg.Engine.SourcePath = t.TempDir()
+	cfg.Game.ProjectPath = t.TempDir() + "/missing.uproject"
+	globals.Cfg = cfg
+	t.Cleanup(func() { globals.Cfg = previous })
+
+	result, _, err := handleInit(context.Background(), nil, initInput{})
+	if err != nil {
+		t.Fatalf("handleInit: %v", err)
+	}
+	var got initResult
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &got); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if len(got.Checks) == 0 {
+		t.Fatal("expected prerequisite checks")
+	}
+	if got.Passed+got.Failed+got.Warned != len(got.Checks) {
+		t.Errorf("summary counts = %d, checks = %d", got.Passed+got.Failed+got.Warned, len(got.Checks))
+	}
+	if got.Success != (got.Failed == 0) {
+		t.Errorf("success = %v with %d failed checks", got.Success, got.Failed)
+	}
+}

--- a/cmd/mcp/tools_status_test.go
+++ b/cmd/mcp/tools_status_test.go
@@ -1,0 +1,79 @@
+package mcp
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestHandleStatusReturnsPipelineAndSecurityResults(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+	previous := globals.Cfg
+	cfg := config.Defaults()
+	cfg.Deploy.Target = "binary"
+	cfg.Engine.SourcePath = t.TempDir()
+	cfg.Game.ProjectPath = t.TempDir() + "/Lyra.uproject"
+	globals.Cfg = cfg
+	t.Cleanup(func() { globals.Cfg = previous })
+
+	result, _, err := handleStatus(context.Background(), nil, statusInput{})
+	if err != nil {
+		t.Fatalf("handleStatus: %v", err)
+	}
+	var got statusResult
+	if err := json.Unmarshal([]byte(toolResultText(t, result)), &got); err != nil {
+		t.Fatalf("decode result: %v", err)
+	}
+	if len(got.Stages) != 7 {
+		t.Errorf("stage count = %d, want 7", len(got.Stages))
+	}
+	if len(got.Security) != 3 {
+		t.Errorf("security scan count = %d, want 3", len(got.Security))
+	}
+}
+
+func TestHandleStatusContinuesWhenTargetCannotResolve(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("PATH", t.TempDir())
+	previous := globals.Cfg
+	cfg := config.Defaults()
+	cfg.Deploy.Target = "unknown"
+	globals.Cfg = cfg
+	t.Cleanup(func() { globals.Cfg = previous })
+
+	result, _, err := handleStatus(context.Background(), nil, statusInput{})
+	if err != nil {
+		t.Fatalf("handleStatus: %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "target not resolved") {
+		t.Fatalf("result = %q, want unresolved target stage", text)
+	}
+}
+
+func TestRunSecurityScans(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	cfg := config.Defaults()
+	cfg.Game.ProjectName = "Lyra"
+	cfg.Game.ServerTarget = "LyraServer"
+	cfg.Container.ImageName = "example/server"
+	cfg.Container.Tag = "test"
+
+	scans := runSecurityScans(cfg)
+	if len(scans) != 3 {
+		t.Fatalf("scan count = %d, want 3", len(scans))
+	}
+	wants := []string{"Game Dockerfile", "Engine Dockerfile", "Container Image (example/server:test)"}
+	for i, want := range wants {
+		if scans[i].Target != want {
+			t.Errorf("scan %d target = %q, want %q", i, scans[i].Target, want)
+		}
+		if strings.TrimSpace(scans[i].Summary) == "" {
+			t.Errorf("scan %d has an empty summary", i)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- cover MCP session creation guards, failures, success, and result adapters
- cover prerequisite and pipeline status aggregation without external services
- cover generated Dockerfile/image security scan aggregation and JSON marshal failures

## Coverage
- cmd/mcp: 50.1% -> 55.0% locally

## Validation
- go test -count=1 ./...
- go vet ./...
- go build ./...
- golangci-lint run ./...
- gocyclo -over 8 on changed tests (no output)
- git diff --check

All repository changes are co-located *_test.go files only.