### PR TITLE
test(cli): cover root setup and status output

### DIFF
--- a/cmd/root/root_test.go
+++ b/cmd/root/root_test.go
@@ -1,0 +1,155 @@
+package root
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/state"
+	"github.com/spf13/cobra"
+)
+
+func TestRootCommandRegistration(t *testing.T) {
+	names := make(map[string]bool)
+	for _, command := range rootCmd.Commands() {
+		names[command.Name()] = true
+	}
+	for _, want := range []string{
+		"buildgraph", "ci", "config", "connect", "container", "ddc", "deploy",
+		"doctor", "engine", "game", "init", "logs", "mcp", "resources", "run",
+		"setup", "status",
+	} {
+		if !names[want] {
+			t.Errorf("root command missing %q", want)
+		}
+	}
+}
+
+func TestPersistentPreRunRejectsInvalidDDCMode(t *testing.T) {
+	configPath := writeRootConfig(t, "deploy:\n  target: binary\n")
+	setRootGlobals(t)
+	cfgFile = configPath
+	globals.DDCMode = "invalid"
+
+	err := rootCmd.PersistentPreRunE(namedRootCommand("mcp"), nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid DDC mode") {
+		t.Fatalf("PersistentPreRunE() error = %v, want invalid DDC mode", err)
+	}
+}
+
+func TestPersistentPreRunUsesProfileConfig(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	writeFile(t, filepath.Join(tempDir, "ludus-demo.yaml"), "deploy:\n  target: binary\n")
+	setRootGlobals(t)
+	globals.Profile = "demo"
+	globals.Verbose = true
+
+	stderr, err := captureRootStderr(t, func() error {
+		return rootCmd.PersistentPreRunE(namedRootCommand("mcp"), nil)
+	})
+	if err != nil {
+		t.Fatalf("PersistentPreRunE() error = %v", err)
+	}
+	if !strings.Contains(stderr, "Using profile config: ludus-demo.yaml") {
+		t.Errorf("stderr = %q, want profile config notice", stderr)
+	}
+	if globals.Cfg.Deploy.Target != "binary" {
+		t.Errorf("deploy target = %q, want binary", globals.Cfg.Deploy.Target)
+	}
+}
+
+func TestPersistentPreRunDetectsEngineVersion(t *testing.T) {
+	tempDir := t.TempDir()
+	buildDir := filepath.Join(tempDir, "Engine", "Build")
+	if err := os.MkdirAll(buildDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	writeFile(t, filepath.Join(buildDir, "Build.version"),
+		`{"MajorVersion":5,"MinorVersion":7,"PatchVersion":3}`)
+	configPath := writeRootConfig(t, "engine:\n  sourcePath: "+filepath.ToSlash(tempDir)+"\ndeploy:\n  target: binary\n")
+	setRootGlobals(t)
+	cfgFile = configPath
+	globals.Verbose = true
+
+	stderr, err := captureRootStderr(t, func() error {
+		return rootCmd.PersistentPreRunE(namedRootCommand("mcp"), nil)
+	})
+	if err != nil {
+		t.Fatalf("PersistentPreRunE() error = %v", err)
+	}
+	if globals.Cfg.Engine.Version != "5.7.3" {
+		t.Errorf("engine version = %q, want 5.7.3", globals.Cfg.Engine.Version)
+	}
+	if !strings.Contains(stderr, "Auto-detected engine version: 5.7.3") {
+		t.Errorf("stderr = %q, want auto-detection notice", stderr)
+	}
+}
+
+func namedRootCommand(name string) *cobra.Command {
+	command := &cobra.Command{Use: name}
+	command.SetContext(context.Background())
+	return command
+}
+
+func setRootGlobals(t *testing.T) {
+	t.Helper()
+	previousCfgFile := cfgFile
+	previousCfg := globals.Cfg
+	previousVerbose := globals.Verbose
+	previousProfile := globals.Profile
+	previousDDCMode := globals.DDCMode
+	cfgFile = ""
+	globals.Cfg = &config.Config{}
+	globals.Verbose = false
+	globals.Profile = ""
+	globals.DDCMode = ""
+	t.Cleanup(func() {
+		cfgFile = previousCfgFile
+		globals.Cfg = previousCfg
+		globals.Verbose = previousVerbose
+		globals.Profile = previousProfile
+		globals.DDCMode = previousDDCMode
+		state.SetProfile(previousProfile)
+	})
+}
+
+func writeRootConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "ludus.yaml")
+	writeFile(t, path, content)
+	return path
+}
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func captureRootStderr(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := os.Stderr
+	os.Stderr = writer
+	runErr := run()
+	os.Stderr = previous
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data), runErr
+}

--- a/cmd/status/status_test.go
+++ b/cmd/status/status_test.go
@@ -1,0 +1,148 @@
+package status
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	internalstatus "github.com/jpvelasco/ludus/internal/status"
+	"github.com/spf13/cobra"
+)
+
+func TestRunStatusHumanOutput(t *testing.T) {
+	tempDir := t.TempDir()
+	t.Chdir(tempDir)
+	outputDir := filepath.Join(tempDir, "export")
+	if err := os.Mkdir(outputDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outputDir, "server"), []byte("binary"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	setStatusGlobals(t, &config.Config{
+		Game:   config.GameConfig{ProjectName: "Example"},
+		Deploy: config.DeployConfig{Target: "binary", OutputDir: outputDir},
+	}, false)
+
+	stdout, stderr, err := captureStatusOutput(t, func() error {
+		return runStatus(commandWithContext(), nil)
+	})
+	if err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+	for _, want := range []string{"Pipeline Status", "[OK]", "Binary Deployment", "[FAIL]", "Engine Source"} {
+		if !strings.Contains(stdout, want) {
+			t.Errorf("stdout missing %q:\n%s", want, stdout)
+		}
+	}
+	if stderr != "" {
+		t.Errorf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestRunStatusJSONOutput(t *testing.T) {
+	t.Chdir(t.TempDir())
+	setStatusGlobals(t, &config.Config{
+		Game:   config.GameConfig{ProjectName: "Example"},
+		Deploy: config.DeployConfig{Target: "binary", OutputDir: "missing"},
+	}, true)
+
+	stdout, stderr, err := captureStatusOutput(t, func() error {
+		return runStatus(commandWithContext(), nil)
+	})
+	if err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+
+	var stages []internalstatus.StageStatus
+	if err := json.Unmarshal([]byte(stdout), &stages); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\noutput: %s", err, stdout)
+	}
+	if len(stages) != 7 {
+		t.Errorf("len(stages) = %d, want 7", len(stages))
+	}
+	if stderr != "" {
+		t.Errorf("stderr = %q, want empty", stderr)
+	}
+}
+
+func TestRunStatusReportsTargetResolutionWarning(t *testing.T) {
+	t.Chdir(t.TempDir())
+	setStatusGlobals(t, &config.Config{
+		Deploy: config.DeployConfig{Target: "unsupported"},
+	}, false)
+
+	stdout, stderr, err := captureStatusOutput(t, func() error {
+		return runStatus(commandWithContext(), nil)
+	})
+	if err != nil {
+		t.Fatalf("runStatus() error = %v", err)
+	}
+	if !strings.Contains(stderr, `unknown deploy target "unsupported"`) {
+		t.Errorf("stderr = %q, want target resolution warning", stderr)
+	}
+	if !strings.Contains(stdout, "target not resolved") {
+		t.Errorf("stdout = %q, want unresolved target detail", stdout)
+	}
+}
+
+func commandWithContext() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+func setStatusGlobals(t *testing.T, cfg *config.Config, jsonOutput bool) {
+	t.Helper()
+	previousCfg := globals.Cfg
+	previousJSON := globals.JSONOutput
+	globals.Cfg = cfg
+	globals.JSONOutput = jsonOutput
+	t.Cleanup(func() {
+		globals.Cfg = previousCfg
+		globals.JSONOutput = previousJSON
+	})
+}
+
+func captureStatusOutput(t *testing.T, run func() error) (string, string, error) {
+	t.Helper()
+	stdoutReader, stdoutWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	stderrReader, stderrWriter, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previousStdout, previousStderr := os.Stdout, os.Stderr
+	os.Stdout, os.Stderr = stdoutWriter, stderrWriter
+
+	runErr := run()
+	os.Stdout, os.Stderr = previousStdout, previousStderr
+	if err := stdoutWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if err := stderrWriter.Close(); err != nil {
+		t.Fatal(err)
+	}
+	stdout := readStatusPipe(t, stdoutReader)
+	stderr := readStatusPipe(t, stderrReader)
+	return stdout, stderr, runErr
+}
+
+func readStatusPipe(t *testing.T, reader *os.File) string {
+	t.Helper()
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary
- cover root command registration and deterministic pre-run configuration paths
- cover human and JSON status output, binary deployment status, and target resolution warnings
- keep all scenarios filesystem-local with no AWS or container requirements

## Coverage
- cmd/root: 0.0% -> 54.3%
- cmd/status: 0.0% -> 100.0%
- local aggregate: 50.2%

## Validation
- go test -count=1 ./...
- go vet ./...
- go build ./...
- golangci-lint run ./...
- gocyclo -over 8 cmd/root/root_test.go cmd/status/status_test.go
- git diff --check