### PR TITLE
docs: refresh npm README for v0.9.0

### DIFF
--- a/npm/README.md
+++ b/npm/README.md
@@ -1,8 +1,8 @@
 # ludus-cli
 
-CLI tool that automates the end-to-end pipeline for deploying Unreal Engine 5 dedicated servers to AWS GameLift.
+**The fastest way to build, cook, and deploy Unreal Engine 5 dedicated servers.**
 
-Ludus handles the entire workflow that would otherwise require dozens of manual steps across multiple tools: UE5 source builds, game server compilation, Docker containerization, ECR push, and GameLift fleet deployment.
+One command. Multiple backends. Production-ready GameLift, EC2, or binary output — with full AI agent integration via MCP.
 
 ## Install
 
@@ -16,46 +16,58 @@ Upgrade to the latest version the same way:
 npm install -g ludus-cli@latest
 ```
 
-Or run directly:
+Or run directly without installing:
 
 ```bash
 npx ludus-cli --help
 ```
 
-The package downloads a small prebuilt binary on install. If your environment
+The package downloads the matching prebuilt binary on install. If your environment
 blocks install scripts (e.g. `--ignore-scripts`, pnpm, locked-down CI), `ludus`
-fetches the matching binary on first run instead — no extra steps. To manage the
-binary yourself (air-gapped setups), set `LUDUS_SKIP_AUTO_DOWNLOAD=1` and place
-the `ludus` binary under the package's `bin/` directory.
+self-heals by fetching the binary on first run — no extra steps. Air-gapped? Set
+`LUDUS_SKIP_AUTO_DOWNLOAD=1` and drop the `ludus` binary under the package's `bin/` directory.
 
 ### "allow-scripts" warning during install
 
-If npm's `allow-scripts` policy is enabled in your environment, you may see:
+If npm's `allow-scripts` policy is enabled, you may see:
 
 ```text
 npm warn allow-scripts   ludus-cli@x.y.z (postinstall: node install.js)
 ```
 
-This is **harmless** — the install still succeeds. `postinstall` is only the
-binary downloader, and `ludus` self-heals by fetching the binary on first run if
-the script was blocked. So you can ignore the warning and just run `ludus`. To
-silence it and let the download run at install time, allow-list the package with
-the command npm prints (e.g. `npm config set allow-scripts=ludus-cli --location=user`).
-
-## What it does
+This is **harmless** — the install still succeeds. The binary downloader runs on
+first use if the script was blocked. To silence the warning, allow-list the package:
 
 ```bash
+npm config set allow-scripts=ludus-cli --location=user
+```
+
+## Quickstart
+
+```bash
+# Install and configure
+npm install -g ludus-cli
+ludus setup
+
+# Validate your environment
+ludus init --verbose
+
+# Run the full pipeline — one command
 ludus run --verbose
 ```
 
-This single command orchestrates six stages:
+## What it does
+
+`ludus run` orchestrates the complete UE5 dedicated server pipeline:
 
 1. **Prerequisite validation** — OS, engine source, game content, Docker, AWS CLI, disk space, RAM
-2. **Engine build** — UE5 source compilation
-3. **Game server build** — Dedicated server packaging via RunUAT
+2. **Engine build** — UE5 source compilation (Setup.sh, project files, make)
+3. **Game server build** — Dedicated server packaging via RunUAT BuildCookRun
 4. **Container build** — Dockerfile generation and Docker image build
 5. **ECR push** — Docker image push to Amazon ECR
 6. **GameLift deploy** — Container fleet creation with IAM roles and polling
+
+Supports **UE 5.4 through 5.8**, with automatic toolchain resolution and cross-compilation.
 
 ## Deployment targets
 
@@ -67,18 +79,52 @@ This single command orchestrates six stages:
 | GameLift Anywhere | `ludus deploy anywhere` | No | No |
 | Binary export | `ludus deploy binary` | No | Yes |
 
+**GameLift Anywhere** is ideal for local development — register your machine with GameLift and create fleets in seconds instead of minutes. No Docker build or ECR push needed.
+
+## Build backends
+
+Choose how engine and game builds execute:
+
+| Backend | Description |
+|---------|-------------|
+| `native` (default) | Build directly on the host |
+| `docker` | Build inside Docker containers — portable, reproducible |
+| `podman` | Docker alternative — recommended on Windows for large engine images |
+| `wsl2` | Native Linux I/O on Windows — 3-10× faster with `--wsl-native` ext4 sync |
+
+## Key features
+
+### Zen DDC — up to 59% faster cooks
+Persistent shader and asset cache that survives container lifecycles. Enabled by default for UE 5.4+. A full Lyra cook drops from 37 minutes to 19 on a warm cache.
+
+### ARM64 / Graviton support
+Cross-compile from any platform to ARM64 and deploy to Graviton instances — 20-30% cheaper than x86. The `--arch arm64` flag threads through the entire pipeline, and Ludus auto-selects Graviton instance types for fleet deployment.
+
+### Build caching
+Input-hash based cache (`.ludus/cache.json`) skips unchanged stages automatically. Change one config value and only the affected stages rebuild.
+
+### Build observability
+Per-run build logs (`.ludus/logs/`) and optional OpenTelemetry (OTLP) trace export — one span per pipeline stage. Integrate with Grafana, Jaeger, or Tempo to see exactly where build time goes.
+
+### Privacy — AWS Account ID masking
+Your AWS account ID is masked in all terminal output by default (ECR URLs, ARNs, etc.) for safer screen sharing and recordings. Override with `--show-account-id` when needed.
+
+### Comprehensive diagnostics
+`ludus doctor` goes deeper than `init` — stale DLLs, toolchain mismatches, disk pressure, partial build state, AWS credential expiry, cache integrity, and Dockerfile linting (hadolint + trivy).
+
+### Resource management
+All AWS resources are tagged with `ManagedBy: ludus`. `ludus deploy destroy` tears down fleets safely, preserving durable ECR images and S3 buckets. Use `--purge` for a full wipe.
+
 ## AI Agent Integration (MCP)
 
-Ludus includes a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server exposing 21 tools. Any MCP-compatible AI agent can orchestrate the full pipeline programmatically.
+Ludus ships with a built-in [Model Context Protocol](https://modelcontextprotocol.io/) server exposing **26 tools**. Any MCP-compatible AI agent — Claude Code, Cursor, Kiro, VS Code Copilot — can orchestrate the full pipeline programmatically.
 
 **Claude Code:**
-
 ```bash
 claude mcp add ludus -- npx -y ludus-cli mcp
 ```
 
 **Claude Desktop / Kiro / Cursor:**
-
 ```json
 {
   "mcpServers": {
@@ -89,6 +135,20 @@ claude mcp add ludus -- npx -y ludus-cli mcp
   }
 }
 ```
+
+**VS Code Copilot:**
+```json
+{
+  "servers": {
+    "ludus": {
+      "command": "ludus",
+      "args": ["mcp"]
+    }
+  }
+}
+```
+
+Tools cover the full pipeline: init, engine build, game build, container build/push, all five deploy targets, game sessions, connections, DDC management, BuildGraph generation, and async build lifecycle (start, poll, cancel).
 
 ## Documentation
 


### PR DESCRIPTION
## What changed

Updated the npm landing page (
pm/README.md) to reflect all features shipped through v0.9.0. The previous version was missing several key capabilities and listed an outdated MCP tool count (21 vs. current 26).

## Highlights

- **UE 5.4–5.8 support** — call out version range and automatic toolchain resolution
- **Build backends table** — native, docker, podman, wsl2 with one-line descriptions
- **Key features section** — Zen DDC (59% faster cooks), ARM64/Graviton, build caching, OpenTelemetry observability, AWS Account ID masking, ludus doctor, resource management
- **GameLift Anywhere** — called out as the local dev story (fleets in seconds)
- **MCP section** — updated to 26 tools, added VS Code Copilot config, tool coverage summary
- **Keywords** — all package.json keywords preserved (dedicated-server tag holding #1)

## Why

The npm page is the primary landing surface for new users. It should sell the features, not just list them.