### PR TITLE
chore: bump Go version to 1.25.12

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jpvelasco/ludus
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1


### PR DESCRIPTION
Fixes two security vulnerabilities in Go stdlib:

- **CVE-2026-42505** (MEDIUM): crypto/tls — Information disclosure in Encrypted Client Hello
- **CVE-2026-39822** (HIGH): os.Root — Symlink following vulnerability allows directory traversal

Both resolved by upgrading to Go 1.25.12.