### PR TITLE
docs: update AGENTS.md and CLAUDE.md with deployment targets, macOS support, and testing constraints

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Ludus Development Guide
 
-This guide provides essential context for AI agents working with Ludus, a CLI tool that automates the end-to-end pipeline for deploying Unreal Engine 5 dedicated servers to AWS GameLift.
+This guide provides essential context for AI agents working with Ludus, a CLI tool that automates the end-to-end pipeline for building Unreal Engine 5 dedicated servers and deploying them to AWS GameLift, GameLift Anywhere, managed EC2 fleets, CloudFormation stacks, or binary output.
 
 ## Build, Test & Lint
 
@@ -11,7 +11,7 @@ go build -o ludus.exe -v .
 # Build (Linux/macOS)
 go build -o ludus -v .
 
-# Lint (golangci-lint v2 required)
+# Lint (golangci-lint v2 required; CI uses golangci-lint-action v9)
 golangci-lint run ./...
 
 # Test (all packages)
@@ -43,6 +43,7 @@ go mod tidy
 - `cmd/mcp/` — MCP server with 26 tools for AI orchestration
 - `internal/` — all business logic (unexported); most files stay close to one primary type, but some packages are deliberately split across sibling files by concern when complexity gets too high
 - Platform-specific files: `_windows.go` / `_unix.go` with `//go:build` tags
+- Current top-level command areas include `buildgraph`, `ci`, `config`, `connect`, `container`, `ddc`, `deploy`, `doctor`, `engine`, `game`, `logs`, `mcp`, `resources`, `setup`, and `status`
 
 ## Critical Features to Understand
 
@@ -51,6 +52,8 @@ go mod tidy
 - `--backend docker` (builds engine container images, needs Docker)
 - `--backend podman` (Docker alternative, on Windows or Linux)
 - `--backend wsl2` (native Linux I/O on Windows)
+- macOS is supported through container backends only (`docker` or `podman`); engine images use `linux/amd64`, while `--arch arm64` still cross-compiles Graviton server binaries inside that environment
+- On Windows, `--backend wsl2 --wsl-native` syncs engine sources to WSL2 ext4 for faster I/O; the plain WSL2 mode uses `/mnt/<drive>` paths
 
 ### Architecture Support
 - `--arch amd64` (default)
@@ -62,6 +65,11 @@ go mod tidy
 - `--ddc local` (legacy FileSystem cache, deprecated — recommend `zen`)
 - `--ddc none` (disabled)
 
+### Observability & Privacy
+- Build logs are written to `.ludus/logs/` by default with retention configured under `observability.logs`
+- Optional OpenTelemetry export is configured under `observability.otlp` and honors standard `OTEL_*` environment variables
+- Human-readable terminal output masks AWS account IDs by default via `privacy.maskAccountId`; JSON and MCP responses are never masked, and `--show-account-id` overrides masking per run
+
 ### Coverage
 
 - Coverage is uploaded to Codecov from the ubuntu test leg via OIDC.
@@ -70,12 +78,13 @@ go mod tidy
 
 ## Development Environment
 
-- Go 1.25.11 required (see `go.mod`; CI follows it)
+- Go 1.25.12 required (see `go.mod`; CI follows it)
 - Linux or Windows with Docker/Podman for container builds
+- macOS with Docker/Podman for container builds only
 - AWS CLI v2 configured with credentials
-- UE5 source with Lyra game assets (must be downloaded manually)
+- UE5 source with Lyra game assets (must be downloaded manually); README currently documents UE 5.8 support
 - 16+ GB RAM recommended (UE5 compilation is memory-hungry)
-- 300+ GB disk space for engine builds
+- 300+ GB disk space for native engine builds; container engine builds can need roughly 2 TB because UE images are very large
 
 ## Important Operational Details
 
@@ -89,11 +98,13 @@ go mod tidy
 - Build logs go to `.ludus/logs/` (project-local)
 - Cache in `.ludus/cache.json` (skip unchanged stages automatically)
 - State in `.ludus/state.json` (fleet IDs, ECR URIs, session data)
+- Named profiles use `.ludus/profiles/<name>.json` for state isolation
+- Do not hand-roll account ID masking; use the existing globals/masking helpers so terminal output stays masked while JSON/MCP remains unmasked
 
 ## Communication Model
 
 Ludus uses the [Model Context Protocol](https://modelcontextprotocol.io/).
-The MCP server is started with `ludus mcp` and exposes 26 tools for AI orchestration.
+The MCP server is started with `ludus mcp` and exposes 26 tools for AI orchestration. Use the async `_start` tools for long native or WSL2 engine/game builds and poll with `ludus_build_status`; async container builds are not supported yet.
 
 ## Command Execution Patterns
 
@@ -102,6 +113,8 @@ The MCP server is started with `ludus mcp` and exposes 26 tools for AI orchestra
 - Commands with long-running operations provide `*_start` variants for async operations
 - Environment variables and CLI flags are merged with config precedence:
   `ludus.yaml` → `--flag` → `mcp-parameter`
+- Architecture aliases normalize through config helpers (`amd64`/`x86_64`, `arm64`/`aarch64`); use those helpers instead of local string switches
+- Container-runtime selection must distinguish engine/game build backends (`native`, `docker`, `podman`, `wsl2`) from image-build runtimes (`docker`, `podman`)
 
 ## Testing Constraints
 
@@ -110,5 +123,6 @@ The MCP server is started with `ludus mcp` and exposes 26 tools for AI orchestra
 - Use `t.TempDir()` for temporary directories, `t.Setenv()` for environment variable overrides, and `t.Chdir()` for working directory changes.
 - AWS/Docker/`wsl.exe`/subprocess-bound code (`gamelift`, `ec2fleet`, `stack`, `wrapper`, `wsl`, and most deploy logic) is E2E-covered; unit tests there should cover only the pure surface such as adapter `Name`/`Capabilities`, argument assembly, and parameter parsing.
 - Keep each test function under cyclomatic complexity 8. Codacy's Lizard check counts test files and fails PRs otherwise; convert flat assertion chains to map/table loops and extract `t.Run` bodies into named helpers. Verify with `go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 <file>` printing nothing.
+- Codacy also tracks NLOC and parameter-count patterns; keep helpers small, avoid broad fixture builders, and do not hide test files from analysis.
 - Read mutex-guarded struct fields under the same lock in tests. CI runs `-race` on ubuntu and macOS, so unlocked reads of fields that a goroutine writes under a lock can fail CI even if they pass locally; a channel signal is not a happens-before edge for a lock-protected write.
 - Unit test files stay co-located with source files.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,7 +9,7 @@ See also [AGENTS.md](AGENTS.md) for full coding guidelines, [ARCHITECTURE.md](AR
 ```bash
 go build -o ludus.exe -v .                                          # Build (Windows)
 go build -o ludus -v .                                               # Build (Linux/macOS)
-golangci-lint run ./...                                              # Lint (v2 required)
+golangci-lint run ./...                                              # Lint (v2 required; CI uses golangci-lint-action v9)
 go test ./...                                                        # All tests
 go test -race ./...                                                  # All tests with race detector (Linux only)
 go test -v ./internal/toolchain                                      # Single package
@@ -30,7 +30,7 @@ Coverage is uploaded from the ubuntu test leg via **OIDC** (`use_oidc: true`, `f
 
 ## Architecture
 
-Go CLI (Cobra + Viper) that orchestrates UE5 dedicated server deployment to AWS GameLift. Module: `github.com/jpvelasco/ludus`, Go 1.25.
+Go CLI (Cobra + Viper) that orchestrates UE5 dedicated server deployment to AWS GameLift, GameLift Anywhere, managed EC2 fleets, CloudFormation stacks, or binary output. Module: `github.com/jpvelasco/ludus`, Go 1.25.12 (see `go.mod`; CI follows it).
 
 ### Pipeline
 
@@ -97,7 +97,7 @@ Several packages keep one concern per file rather than one giant file (Codacy's 
 
 ### MCP Server
 
-`cmd/mcp/` exposes 26 tools via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout). Long-running builds have async variants returning build IDs.
+`cmd/mcp/` exposes 26 tools via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout). Long-running native/WSL2 engine and game builds have async `_start` variants returning build IDs, polled via `ludus_build_status`; container builds have no async variant yet.
 
 ### GameLift Wrapper
 
@@ -135,7 +135,9 @@ Profiles (`--profile <name>`) isolate both: config from `ludus-<name>.yaml`, sta
 
 ### Cross-Architecture Support
 
-The `--arch` flag threads through the entire pipeline: game build → container build → deploy. Architecture mismatches are caught automatically (e.g. arm64 build with x86 instance type auto-switches to Graviton). See `internal/config/` for `NormalizeArch`, `ServerPlatformDir`, `BinariesPlatformDir`.
+The `--arch` flag threads through the entire pipeline: game build → container build → deploy. Architecture mismatches are caught automatically (e.g. arm64 build with x86 instance type auto-switches to Graviton). See `internal/config/` for `NormalizeArch`, `ServerPlatformDir`, `BinariesPlatformDir`. Arch aliases (`amd64`/`x86_64`, `arm64`/`aarch64`) normalize through these helpers — don't hand-roll the string comparison.
+
+macOS is supported only through container backends (`docker`/`podman`); there is no native engine build path on macOS. Engine container images are forced to `linux/amd64` under QEMU (Epic ships only an x86_64 Linux toolchain), even when the host is Apple Silicon. `--arch arm64` game builds still cross-compile Graviton server binaries inside that emulated amd64 environment — the engine image itself stays amd64.
 
 ## Code Conventions
 
@@ -144,7 +146,7 @@ Full style guide in [AGENTS.md](AGENTS.md). Key points for quick reference:
 - **Errors**: `fmt.Errorf("context: %w", err)`. No sentinel errors, no custom types. AWS errors via `smithy.APIError` + `errors.As()`. `internal/diagnose/` matches error patterns to user-facing hints — add new patterns there rather than embedding hint strings in command code.
 - **Output**: `fmt.Println`/`fmt.Printf` for status. No logging library. JSON conditional on `globals.JSONOutput`. Human-readable stdout is filtered through `internal/output` (account-ID masking) when `privacy.maskAccountId` is on and `--show-account-id` is not set — installed once in root `PersistentPreRunE`, skipped for `--json` and `mcp`. Mask new sensitive identifiers by adding a pattern to `internal/output/sanitize.go`, not at call sites.
 - **Shell execution**: Always through `runner.Runner`, never raw `exec.Command`.
-- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. AWS/Docker/`wsl.exe`/subprocess-bound code (gamelift, ec2fleet, stack, wrapper, wsl, most deploy logic) relies on E2E coverage — unit tests there cover only the pure surface (adapters' `Name`/`Capabilities`, arg assembly, param parsing). Two hard constraints: (1) keep each test function under **cyclomatic complexity 8** or Codacy's Lizard check fails the PR — convert flat assertion chains to map/table loops and extract `t.Run` bodies into named helpers (`go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 <file>` must print nothing); (2) read mutex-guarded struct fields **under the same lock** in tests — CI runs `-race` on ubuntu/macos (not Windows, which lacks CGO), and a channel signal alone is not a happens-before edge with a lock-protected write.
+- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. AWS/Docker/`wsl.exe`/subprocess-bound code (gamelift, ec2fleet, stack, wrapper, wsl, most deploy logic) relies on E2E coverage — unit tests there cover only the pure surface (adapters' `Name`/`Capabilities`, arg assembly, param parsing). Two hard constraints: (1) keep each test function under **cyclomatic complexity 8** or Codacy's Lizard check fails the PR — convert flat assertion chains to map/table loops and extract `t.Run` bodies into named helpers (`go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 <file>` must print nothing); Lizard also tracks NLOC and parameter count, so keep helpers small and avoid broad fixture builders rather than hiding test files from analysis; (2) read mutex-guarded struct fields **under the same lock** in tests — CI runs `-race` on ubuntu/macos (not Windows, which lacks CGO), and a channel signal alone is not a happens-before edge with a lock-protected write.
 - **Platform code**: `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
 - **Imports**: Two groups separated by a blank line — stdlib first, then third-party and project imports together (alphabetically sorted). Aliases only to resolve conflicts (e.g. `gltypes`, `cftypes`).
 - **Naming**: Acronyms fully uppercase (`ID`, `URI`, `ARN`, `ECR`). Constructors `New*` returning a pointer. Single-letter pointer receivers matching type initial (`b *Builder`, `d *Deployer`). `context.Context` is the first parameter for all I/O or long-running methods.

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/jpvelasco/ludus
 
-go 1.25.11
+go 1.25.12
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.42.1


### PR DESCRIPTION
## Summary

Update `AGENTS.md` and `CLAUDE.md` with missing context that improves AI agent accuracy when working in this repo.

### Changes

**AGENTS.md**
- Expand deployment target list beyond GameLift to include Anywhere, EC2 fleets, CloudFormation stacks, and binary output
- Add macOS support details (container backends only, QEMU amd64 engine images)
- Add WSL2 `--wsl-native` sync mode details
- Add new `Observability & Privacy` section (build logs, OTLP, account ID masking)
- Add Codacy NLOC/parameter-count tracking guidance to testing constraints
- Add arch alias normalization guidance and container-runtime distinction notes
- Add profile state isolation and MCP async build details
- Bump Go version reference to 1.25.12, add golangci-lint-action v9 note
- Update disk space estimate for container engine builds (~2 TB)

**CLAUDE.md**
- Mirror deployment target expansion and Go version bump
- Add arch alias normalization and macOS cross-architecture details
- Add Codacy NLOC/parameter-count constraint to testing conventions
- Refine MCP async build description (native/WSL2 only, not container)
