### PR TITLE
Add Octopus Review workflow

### DIFF
--- a/.github/workflows/octopus.yml
+++ b/.github/workflows/octopus.yml
@@ -1,0 +1,15 @@
+name: Octopus Review
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: octopusreview/action@c7156c0dc465c20e8b06da84b92b64f9ae8c7c36


### PR DESCRIPTION
## Summary

- add an advisory Octopus Review workflow for pull requests
- run reviews when a PR is opened or synchronized
- pin the Octopus action to an immutable commit SHA
- grant only read access to contents and write access to pull-request reviews

## Why

This enables automated, context-aware review on subsequent Ludus pull requests without making Octopus a required quality gate. The public-repository community tier is limited to five reviews per repository per day, so merge decisions remain independent of service availability or quota.

`pull_request_target` lets the workflow post reviews on pull requests from forks. The workflow does not check out or execute code from the pull-request head.

## Impact

After this workflow is merged into `main`, newly opened or updated pull requests will receive an advisory Octopus review when quota is available. This PR itself will not be reviewed by the new workflow because `pull_request_target` workflows run from the default branch.

## Validation

- verified the action SHA matches Octopus Review `v1`
- verified the workflow requests only `contents: read` and `pull-requests: write`
- verified the commit contains only `.github/workflows/octopus.yml`
- `git diff --check origin/main...HEAD`