### PR TITLE
fix: retry GameLift definition conflicts

### DIFF
--- a/internal/gamelift/deployer.go
+++ b/internal/gamelift/deployer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/jpvelasco/ludus/internal/awsutil"
 	"github.com/jpvelasco/ludus/internal/deploy"
 	"github.com/jpvelasco/ludus/internal/glsession"
+	"github.com/jpvelasco/ludus/internal/retry"
 	"github.com/jpvelasco/ludus/internal/tags"
 )
 
@@ -47,17 +48,28 @@ type FleetStatus struct {
 
 // Deployer handles GameLift container fleet deployment.
 type Deployer struct {
-	opts      DeployOptions
-	glClient  *gamelift.Client
-	iamClient *iam.Client
+	opts                 DeployOptions
+	glClient             *gamelift.Client
+	cgdClient            containerGroupDefinitionClient
+	cgdCreateRetryConfig retry.Config
+	iamClient            *iam.Client
+}
+
+type containerGroupDefinitionClient interface {
+	CreateContainerGroupDefinition(context.Context, *gamelift.CreateContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.CreateContainerGroupDefinitionOutput, error)
+	DescribeContainerGroupDefinition(context.Context, *gamelift.DescribeContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.DescribeContainerGroupDefinitionOutput, error)
+	DeleteContainerGroupDefinition(context.Context, *gamelift.DeleteContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.DeleteContainerGroupDefinitionOutput, error)
 }
 
 // NewDeployer creates a new GameLift deployer using the provided AWS config.
 func NewDeployer(opts DeployOptions, awsCfg aws.Config) *Deployer {
+	glClient := gamelift.NewFromConfig(awsCfg)
 	return &Deployer{
-		opts:      opts,
-		glClient:  gamelift.NewFromConfig(awsCfg),
-		iamClient: iam.NewFromConfig(awsCfg),
+		opts:                 opts,
+		glClient:             glClient,
+		cgdClient:            glClient,
+		cgdCreateRetryConfig: retry.Default(),
+		iamClient:            iam.NewFromConfig(awsCfg),
 	}
 }
 
@@ -74,25 +86,34 @@ func (d *Deployer) resourceTags() map[string]string {
 // and creates fresh. This provides better idempotency without leaving stale snapshots.
 func (d *Deployer) CreateContainerGroupDefinition(ctx context.Context) (string, error) {
 	input := d.containerGroupDefinitionInput()
-	for attempt := 0; attempt < 2; attempt++ {
-		out, err := d.glClient.CreateContainerGroupDefinition(ctx, input)
-		if err == nil {
-			arn := aws.ToString(out.ContainerGroupDefinition.ContainerGroupDefinitionArn)
-			return d.waitAndReturn(ctx, arn)
+	var arn string
+	var fatalErr error
+	retryErr := retry.Do(ctx, d.cgdCreateRetryConfig, func() error {
+		var retryable bool
+		arn, retryable, fatalErr = d.createContainerGroupDefinitionAttempt(ctx, input)
+		if fatalErr == nil || !retryable {
+			return nil
 		}
-		if !awsutil.IsConflict(err) {
-			return "", fmt.Errorf("creating container group definition: %w", err)
-		}
-		arn, herr := d.handleConflictOnCreate(ctx, err, input)
-		if herr != nil {
-			return "", herr
-		}
-		if arn != "" {
-			return d.waitAndReturn(ctx, arn)
-		}
-		// Deleted stale definition; retry create.
+		return fatalErr
+	})
+	if retryErr != nil {
+		return "", fmt.Errorf("creating container group definition after retries: %w", retryErr)
 	}
-	return "", fmt.Errorf("creating container group definition: too many attempts after conflict")
+	if fatalErr != nil {
+		return "", fatalErr
+	}
+	return d.waitAndReturn(ctx, arn)
+}
+
+func (d *Deployer) createContainerGroupDefinitionAttempt(ctx context.Context, input *gamelift.CreateContainerGroupDefinitionInput) (arn string, retryable bool, err error) {
+	out, err := d.cgdClient.CreateContainerGroupDefinition(ctx, input)
+	if err == nil {
+		return aws.ToString(out.ContainerGroupDefinition.ContainerGroupDefinitionArn), false, nil
+	}
+	if !awsutil.IsConflict(err) {
+		return "", false, fmt.Errorf("creating container group definition: %w", err)
+	}
+	return d.handleConflictOnCreate(ctx, err, input)
 }
 
 // waitAndReturn waits for the container group definition to be ready and returns its ARN.
@@ -103,32 +124,31 @@ func (d *Deployer) waitAndReturn(ctx context.Context, arn string) (string, error
 	return arn, nil
 }
 
-// handleConflictOnCreate is called after a CreateContainerGroupDefinition conflict.
-// It returns:
-//   - (arn, nil) if an existing matching definition was found (caller should wait+return)
-//   - ("", nil) if a stale definition was deleted (caller should retry create)
-//   - ("", err) on fatal error (bad describe or unrecoverable delete)
-func (d *Deployer) handleConflictOnCreate(ctx context.Context, createErr error, input *gamelift.CreateContainerGroupDefinitionInput) (string, error) {
-	desc, derr := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
+// handleConflictOnCreate describes the existing same-named definition. A
+// matching definition is reused, a mismatch is deleted before retrying, and an
+// inconclusive describe is retried because GameLift may still be deleting the
+// definition that caused the conflict.
+func (d *Deployer) handleConflictOnCreate(ctx context.Context, createErr error, input *gamelift.CreateContainerGroupDefinitionInput) (arn string, retryable bool, err error) {
+	desc, derr := d.cgdClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
 		Name: aws.String(d.opts.ContainerGroupName),
 	})
 	if derr != nil {
-		return "", fmt.Errorf("creating container group definition: conflict on create but describe failed: %w (create err: %v)", derr, createErr)
+		return "", true, fmt.Errorf("creating container group definition: conflict on create but describe failed: %w (create err: %v)", derr, createErr)
 	}
 	if desc.ContainerGroupDefinition == nil {
-		return "", fmt.Errorf("creating container group definition: %w", createErr)
+		return "", true, fmt.Errorf("creating container group definition: conflict on create but describe returned no definition: %w", createErr)
 	}
 	if definitionMatches(desc.ContainerGroupDefinition, input) {
-		return aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn), nil
+		return aws.ToString(desc.ContainerGroupDefinition.ContainerGroupDefinitionArn), false, nil
 	}
 	// Mismatch: remove the stale one so the next create attempt can succeed.
-	_, delErr := d.glClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
+	_, delErr := d.cgdClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
 		Name: aws.String(d.opts.ContainerGroupName),
 	})
 	if delErr != nil && !awsutil.IsNotFound(delErr) {
-		return "", fmt.Errorf("existing container group definition does not match desired config and could not be removed: %w", delErr)
+		return "", false, fmt.Errorf("existing container group definition does not match desired config and could not be removed: %w", delErr)
 	}
-	return "", nil
+	return "", true, fmt.Errorf("retrying create after removing stale container group definition: %w", createErr)
 }
 
 // CreateFleet creates a new GameLift container fleet.

--- a/internal/gamelift/deployer_container.go
+++ b/internal/gamelift/deployer_container.go
@@ -106,7 +106,7 @@ func portRangeMatches(c, d gltypes.ContainerPortRange) bool {
 
 func (d *Deployer) waitForContainerGroupReady(ctx context.Context) error {
 	err := awsutil.Poll(ctx, pollInterval, maxPollWait, func() (bool, error) {
-		desc, err := d.glClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
+		desc, err := d.cgdClient.DescribeContainerGroupDefinition(ctx, &gamelift.DescribeContainerGroupDefinitionInput{
 			Name: aws.String(d.opts.ContainerGroupName),
 		})
 		if err != nil {
@@ -130,7 +130,7 @@ func (d *Deployer) waitForContainerGroupReady(ctx context.Context) error {
 func (d *Deployer) deleteContainerGroupDefinition(ctx context.Context) error {
 	fmt.Println("Deleting container group definition...")
 
-	_, err := d.glClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
+	_, err := d.cgdClient.DeleteContainerGroupDefinition(ctx, &gamelift.DeleteContainerGroupDefinitionInput{
 		Name: aws.String(d.opts.ContainerGroupName),
 	})
 	if err != nil {

--- a/internal/gamelift/deployer_create_test.go
+++ b/internal/gamelift/deployer_create_test.go
@@ -1,0 +1,151 @@
+package gamelift
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/gamelift"
+	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+	"github.com/aws/smithy-go"
+	"github.com/jpvelasco/ludus/internal/retry"
+)
+
+type cgdCreateResult struct {
+	out *gamelift.CreateContainerGroupDefinitionOutput
+	err error
+}
+
+type cgdDescribeResult struct {
+	out *gamelift.DescribeContainerGroupDefinitionOutput
+	err error
+}
+
+type fakeCGDClient struct {
+	createResults   []cgdCreateResult
+	describeResults []cgdDescribeResult
+	createCalls     int
+	describeCalls   int
+}
+
+func (f *fakeCGDClient) CreateContainerGroupDefinition(context.Context, *gamelift.CreateContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.CreateContainerGroupDefinitionOutput, error) {
+	result := f.createResults[f.createCalls]
+	f.createCalls++
+	return result.out, result.err
+}
+
+func (f *fakeCGDClient) DescribeContainerGroupDefinition(context.Context, *gamelift.DescribeContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.DescribeContainerGroupDefinitionOutput, error) {
+	result := f.describeResults[f.describeCalls]
+	f.describeCalls++
+	return result.out, result.err
+}
+
+func (*fakeCGDClient) DeleteContainerGroupDefinition(context.Context, *gamelift.DeleteContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.DeleteContainerGroupDefinitionOutput, error) {
+	return &gamelift.DeleteContainerGroupDefinitionOutput{}, nil
+}
+
+type cgdAPIError struct {
+	code string
+}
+
+func (e *cgdAPIError) Error() string                 { return e.code }
+func (e *cgdAPIError) ErrorCode() string             { return e.code }
+func (e *cgdAPIError) ErrorMessage() string          { return e.code }
+func (e *cgdAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultUnknown }
+
+func TestCreateContainerGroupDefinitionRetriesConflictDuringDeletion(t *testing.T) {
+	client := &fakeCGDClient{
+		createResults: []cgdCreateResult{
+			{err: &cgdAPIError{code: "ConflictException"}},
+			{out: createCGDOutput("arn:created")},
+		},
+		describeResults: []cgdDescribeResult{
+			{err: &cgdAPIError{code: "NotFoundException"}},
+			{out: readyCGDOutput("arn:created")},
+		},
+	}
+
+	arn, err := newTestCGDDeployer(client).CreateContainerGroupDefinition(context.Background())
+	if err != nil {
+		t.Fatalf("CreateContainerGroupDefinition() error = %v", err)
+	}
+	if arn != "arn:created" {
+		t.Fatalf("CreateContainerGroupDefinition() = %q, want arn:created", arn)
+	}
+	assertCGDCallCounts(t, client, 2, 2)
+}
+
+func TestCreateContainerGroupDefinitionExhaustsDeletionConflictRetries(t *testing.T) {
+	client := &fakeCGDClient{
+		createResults:   repeatCreateErrors(3, "ConflictException"),
+		describeResults: repeatDescribeErrors(3, "NotFoundException"),
+	}
+
+	_, err := newTestCGDDeployer(client).CreateContainerGroupDefinition(context.Background())
+	if err == nil {
+		t.Fatal("CreateContainerGroupDefinition() error = nil, want retry exhaustion")
+	}
+	if !strings.Contains(err.Error(), "creating container group definition after retries") {
+		t.Fatalf("CreateContainerGroupDefinition() error = %q, want retry exhaustion context", err)
+	}
+	assertCGDCallCounts(t, client, 3, 3)
+}
+
+func newTestCGDDeployer(client containerGroupDefinitionClient) *Deployer {
+	return &Deployer{
+		opts: DeployOptions{
+			ContainerGroupName: "ludus-test",
+		},
+		cgdClient: client,
+		cgdCreateRetryConfig: retry.Config{
+			MaxAttempts: 3,
+			BaseDelay:   time.Nanosecond,
+			MaxDelay:    time.Nanosecond,
+		},
+	}
+}
+
+func createCGDOutput(arn string) *gamelift.CreateContainerGroupDefinitionOutput {
+	return &gamelift.CreateContainerGroupDefinitionOutput{
+		ContainerGroupDefinition: &gltypes.ContainerGroupDefinition{
+			ContainerGroupDefinitionArn: aws.String(arn),
+		},
+	}
+}
+
+func readyCGDOutput(arn string) *gamelift.DescribeContainerGroupDefinitionOutput {
+	return &gamelift.DescribeContainerGroupDefinitionOutput{
+		ContainerGroupDefinition: &gltypes.ContainerGroupDefinition{
+			ContainerGroupDefinitionArn: aws.String(arn),
+			Status:                      gltypes.ContainerGroupDefinitionStatusReady,
+		},
+	}
+}
+
+func repeatCreateErrors(count int, code string) []cgdCreateResult {
+	results := make([]cgdCreateResult, count)
+	for i := range results {
+		results[i].err = &cgdAPIError{code: code}
+	}
+	return results
+}
+
+func repeatDescribeErrors(count int, code string) []cgdDescribeResult {
+	results := make([]cgdDescribeResult, count)
+	for i := range results {
+		results[i].err = &cgdAPIError{code: code}
+	}
+	return results
+}
+
+func assertCGDCallCounts(t *testing.T, client *fakeCGDClient, createWant, describeWant int) {
+	t.Helper()
+	if client.createCalls != createWant {
+		t.Errorf("CreateContainerGroupDefinition calls = %d, want %d", client.createCalls, createWant)
+	}
+	if client.describeCalls != describeWant {
+		t.Errorf("DescribeContainerGroupDefinition calls = %d, want %d", client.describeCalls, describeWant)
+	}
+}

--- a/internal/gamelift/deployer_create_test.go
+++ b/internal/gamelift/deployer_create_test.go
@@ -23,11 +23,18 @@ type cgdDescribeResult struct {
 	err error
 }
 
+type cgdDeleteResult struct {
+	out *gamelift.DeleteContainerGroupDefinitionOutput
+	err error
+}
+
 type fakeCGDClient struct {
 	createResults   []cgdCreateResult
 	describeResults []cgdDescribeResult
+	deleteResults   []cgdDeleteResult
 	createCalls     int
 	describeCalls   int
+	deleteCalls     int
 }
 
 func (f *fakeCGDClient) CreateContainerGroupDefinition(context.Context, *gamelift.CreateContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.CreateContainerGroupDefinitionOutput, error) {
@@ -42,8 +49,14 @@ func (f *fakeCGDClient) DescribeContainerGroupDefinition(context.Context, *gamel
 	return result.out, result.err
 }
 
-func (*fakeCGDClient) DeleteContainerGroupDefinition(context.Context, *gamelift.DeleteContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.DeleteContainerGroupDefinitionOutput, error) {
-	return &gamelift.DeleteContainerGroupDefinitionOutput{}, nil
+func (f *fakeCGDClient) DeleteContainerGroupDefinition(context.Context, *gamelift.DeleteContainerGroupDefinitionInput, ...func(*gamelift.Options)) (*gamelift.DeleteContainerGroupDefinitionOutput, error) {
+	call := f.deleteCalls
+	f.deleteCalls++
+	if call >= len(f.deleteResults) {
+		return &gamelift.DeleteContainerGroupDefinitionOutput{}, nil
+	}
+	result := f.deleteResults[call]
+	return result.out, result.err
 }
 
 type cgdAPIError struct {
@@ -74,7 +87,7 @@ func TestCreateContainerGroupDefinitionRetriesConflictDuringDeletion(t *testing.
 	if arn != "arn:created" {
 		t.Fatalf("CreateContainerGroupDefinition() = %q, want arn:created", arn)
 	}
-	assertCGDCallCounts(t, client, 2, 2)
+	assertCGDCallCounts(t, client, 2, 2, 0)
 }
 
 func TestCreateContainerGroupDefinitionExhaustsDeletionConflictRetries(t *testing.T) {
@@ -90,7 +103,103 @@ func TestCreateContainerGroupDefinitionExhaustsDeletionConflictRetries(t *testin
 	if !strings.Contains(err.Error(), "creating container group definition after retries") {
 		t.Fatalf("CreateContainerGroupDefinition() error = %q, want retry exhaustion context", err)
 	}
-	assertCGDCallCounts(t, client, 3, 3)
+	assertCGDCallCounts(t, client, 3, 3, 0)
+}
+
+func TestCreateContainerGroupDefinitionStopsOnNonConflict(t *testing.T) {
+	client := &fakeCGDClient{
+		createResults: []cgdCreateResult{{err: &cgdAPIError{code: "AccessDeniedException"}}},
+	}
+
+	_, err := newTestCGDDeployer(client).CreateContainerGroupDefinition(context.Background())
+	assertCGDErrorContains(t, err, "creating container group definition: AccessDeniedException")
+	assertCGDCallCounts(t, client, 1, 0, 0)
+}
+
+func TestCreateContainerGroupDefinitionReusesMatchingDefinition(t *testing.T) {
+	client := &fakeCGDClient{
+		createResults: []cgdCreateResult{{err: &cgdAPIError{code: "ConflictException"}}},
+		describeResults: []cgdDescribeResult{
+			{out: matchingCGDOutput("arn:existing")},
+			{out: matchingCGDOutput("arn:existing")},
+		},
+	}
+
+	arn, err := newTestCGDDeployer(client).CreateContainerGroupDefinition(context.Background())
+	assertCGDSuccess(t, arn, "arn:existing", err)
+	assertCGDCallCounts(t, client, 1, 2, 0)
+}
+
+func TestCreateContainerGroupDefinitionReplacesMismatch(t *testing.T) {
+	client := &fakeCGDClient{
+		createResults: []cgdCreateResult{
+			{err: &cgdAPIError{code: "ConflictException"}},
+			{out: createCGDOutput("arn:replacement")},
+		},
+		describeResults: []cgdDescribeResult{
+			{out: readyCGDOutput("arn:stale")},
+			{out: readyCGDOutput("arn:replacement")},
+		},
+	}
+
+	arn, err := newTestCGDDeployer(client).CreateContainerGroupDefinition(context.Background())
+	assertCGDSuccess(t, arn, "arn:replacement", err)
+	assertCGDCallCounts(t, client, 2, 2, 1)
+}
+
+func TestCreateContainerGroupDefinitionStopsOnDeleteFailure(t *testing.T) {
+	client := &fakeCGDClient{
+		createResults:   []cgdCreateResult{{err: &cgdAPIError{code: "ConflictException"}}},
+		describeResults: []cgdDescribeResult{{out: readyCGDOutput("arn:stale")}},
+		deleteResults: []cgdDeleteResult{
+			{err: &cgdAPIError{code: "AccessDeniedException"}},
+		},
+	}
+
+	_, err := newTestCGDDeployer(client).CreateContainerGroupDefinition(context.Background())
+	assertCGDErrorContains(t, err, "could not be removed: AccessDeniedException")
+	assertCGDCallCounts(t, client, 1, 1, 1)
+}
+
+func TestCreateContainerGroupDefinitionRetriesNilDescription(t *testing.T) {
+	client := &fakeCGDClient{
+		createResults: []cgdCreateResult{
+			{err: &cgdAPIError{code: "ConflictException"}},
+			{out: createCGDOutput("arn:created")},
+		},
+		describeResults: []cgdDescribeResult{
+			{out: &gamelift.DescribeContainerGroupDefinitionOutput{}},
+			{out: readyCGDOutput("arn:created")},
+		},
+	}
+
+	arn, err := newTestCGDDeployer(client).CreateContainerGroupDefinition(context.Background())
+	assertCGDSuccess(t, arn, "arn:created", err)
+	assertCGDCallCounts(t, client, 2, 2, 0)
+}
+
+func TestCreateContainerGroupDefinitionReturnsWaitError(t *testing.T) {
+	client := &fakeCGDClient{
+		createResults:   []cgdCreateResult{{out: createCGDOutput("arn:created")}},
+		describeResults: []cgdDescribeResult{{err: &cgdAPIError{code: "InternalServiceException"}}},
+	}
+
+	arn, err := newTestCGDDeployer(client).CreateContainerGroupDefinition(context.Background())
+	if arn != "arn:created" {
+		t.Errorf("CreateContainerGroupDefinition() ARN = %q, want arn:created", arn)
+	}
+	assertCGDErrorContains(t, err, "polling container group definition status")
+	assertCGDCallCounts(t, client, 1, 1, 0)
+}
+
+func TestDeleteContainerGroupDefinitionUsesCGDClient(t *testing.T) {
+	client := &fakeCGDClient{}
+	deployer := newTestCGDDeployer(client)
+
+	if err := deployer.deleteContainerGroupDefinition(context.Background()); err != nil {
+		t.Fatalf("deleteContainerGroupDefinition() error = %v", err)
+	}
+	assertCGDCallCounts(t, client, 0, 0, 1)
 }
 
 func newTestCGDDeployer(client containerGroupDefinitionClient) *Deployer {
@@ -124,6 +233,30 @@ func readyCGDOutput(arn string) *gamelift.DescribeContainerGroupDefinitionOutput
 	}
 }
 
+func matchingCGDOutput(arn string) *gamelift.DescribeContainerGroupDefinitionOutput {
+	return &gamelift.DescribeContainerGroupDefinitionOutput{
+		ContainerGroupDefinition: &gltypes.ContainerGroupDefinition{
+			ContainerGroupDefinitionArn: aws.String(arn),
+			GameServerContainerDefinition: &gltypes.GameServerContainerDefinition{
+				ImageUri:         aws.String(""),
+				ServerSdkVersion: aws.String("5.4.0"),
+				PortConfiguration: &gltypes.ContainerPortConfiguration{
+					ContainerPortRanges: []gltypes.ContainerPortRange{
+						{
+							FromPort: aws.Int32(0),
+							ToPort:   aws.Int32(0),
+							Protocol: gltypes.IpProtocolUdp,
+						},
+					},
+				},
+			},
+			TotalMemoryLimitMebibytes: aws.Int32(1024),
+			TotalVcpuLimit:            aws.Float64(1.0),
+			Status:                    gltypes.ContainerGroupDefinitionStatusReady,
+		},
+	}
+}
+
 func repeatCreateErrors(count int, code string) []cgdCreateResult {
 	results := make([]cgdCreateResult, count)
 	for i := range results {
@@ -140,12 +273,35 @@ func repeatDescribeErrors(count int, code string) []cgdDescribeResult {
 	return results
 }
 
-func assertCGDCallCounts(t *testing.T, client *fakeCGDClient, createWant, describeWant int) {
+func assertCGDSuccess(t *testing.T, got, want string, err error) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("CreateContainerGroupDefinition() error = %v", err)
+	}
+	if got != want {
+		t.Fatalf("CreateContainerGroupDefinition() = %q, want %q", got, want)
+	}
+}
+
+func assertCGDErrorContains(t *testing.T, err error, want string) {
+	t.Helper()
+	if err == nil {
+		t.Fatalf("error = nil, want error containing %q", want)
+	}
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("error = %q, want error containing %q", err, want)
+	}
+}
+
+func assertCGDCallCounts(t *testing.T, client *fakeCGDClient, createWant, describeWant, deleteWant int) {
 	t.Helper()
 	if client.createCalls != createWant {
 		t.Errorf("CreateContainerGroupDefinition calls = %d, want %d", client.createCalls, createWant)
 	}
 	if client.describeCalls != describeWant {
 		t.Errorf("DescribeContainerGroupDefinition calls = %d, want %d", client.describeCalls, describeWant)
+	}
+	if client.deleteCalls != deleteWant {
+		t.Errorf("DeleteContainerGroupDefinition calls = %d, want %d", client.deleteCalls, deleteWant)
 	}
 }


### PR DESCRIPTION
## Summary

- retry the full GameLift container-group definition create operation with Ludus's standard exponential backoff when a create conflict cannot be resolved by an immediate describe
- preserve idempotent reuse for matching definitions and delete-and-recreate behavior for mismatched definitions
- add focused tests for recovery from the conflict/NotFound deletion window and for bounded retry exhaustion

## Root cause

GameLift can temporarily reject creation with `ConflictException` while simultaneously returning `NotFoundException` when the same-named definition is finishing deletion. Ludus treated the single failed describe as fatal, even though retrying the create operation shortly afterward succeeds.

## Impact

Deploys now tolerate that eventual-consistency window for three attempts with backoff, while non-conflict create failures and unrecoverable delete failures still stop immediately.

## Validation

- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 internal/gamelift/deployer_create_test.go`
- `git diff --check`

Fixes #418
