### PR TITLE
test: cover GameLift deployer construction

### DIFF
--- a/internal/gamelift/deployer_create_test.go
+++ b/internal/gamelift/deployer_create_test.go
@@ -68,6 +68,29 @@ func (e *cgdAPIError) ErrorCode() string             { return e.code }
 func (e *cgdAPIError) ErrorMessage() string          { return e.code }
 func (e *cgdAPIError) ErrorFault() smithy.ErrorFault { return smithy.FaultUnknown }
 
+func TestNewDeployerInitializesDependencies(t *testing.T) {
+	opts := DeployOptions{
+		Region:             "us-west-2",
+		ContainerGroupName: "ludus-test",
+	}
+	deployer := NewDeployer(opts, aws.Config{Region: opts.Region})
+
+	checks := map[string]bool{
+		"options are preserved":             deployer.opts.Region == opts.Region && deployer.opts.ContainerGroupName == opts.ContainerGroupName,
+		"GameLift client is initialized":    deployer.glClient != nil,
+		"container client uses GameLift":    deployer.cgdClient == deployer.glClient,
+		"default retry policy is installed": deployer.cgdCreateRetryConfig == retry.Default(),
+		"IAM client is initialized":         deployer.iamClient != nil,
+	}
+	for name, ok := range checks {
+		t.Run(name, func(t *testing.T) {
+			if !ok {
+				t.Errorf("NewDeployer() check %q failed", name)
+			}
+		})
+	}
+}
+
 func TestCreateContainerGroupDefinitionRetriesConflictDuringDeletion(t *testing.T) {
 	client := &fakeCGDClient{
 		createResults: []cgdCreateResult{


### PR DESCRIPTION
## Summary

- add focused coverage for `NewDeployer`
- verify options, AWS clients, injectable GameLift client wiring, and the default retry policy

## Why

PR #450 introduced the injectable container-group client and retry configuration. Codecov identified the six executable lines in `NewDeployer` as the remaining uncovered portion of that change.

## Impact

Test-only follow-up; production behavior is unchanged. With this test, `NewDeployer` and every function touched by #450 report 100% local statement coverage.

## Validation

- `go test -count=1 -covermode=atomic -coverprofile=coverage-gamelift.out ./internal/gamelift`
- `go tool cover -func=coverage-gamelift.out` (`NewDeployer`: 100.0%)
- `go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 internal/gamelift/deployer_create_test.go`
- `go test ./...`
- `go vet ./...`
- `golangci-lint run ./...`
- `go build -v .`
- `git diff --check`
