### PR TITLE
test: add coverage for internal/ec2fleet logic (2.3% -> 20.9%)

### DIFF
--- a/internal/ec2fleet/adapter_test.go
+++ b/internal/ec2fleet/adapter_test.go
@@ -6,6 +6,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 
 	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/state"
 )
 
 func TestTargetAdapter(t *testing.T) {
@@ -25,5 +26,60 @@ func TestTargetAdapter(t *testing.T) {
 	}
 	if !caps.SupportsSession || !caps.SupportsDeploy || !caps.SupportsDestroy {
 		t.Errorf("ec2 should support session/deploy/destroy, got %+v", caps)
+	}
+}
+
+func TestDestroyStateFromState(t *testing.T) {
+	tests := []struct {
+		name  string
+		state *state.State
+		want  destroyState
+	}{
+		{"Nil destroyState", &state.State{EC2Fleet: nil}, destroyState{}},
+		{"Populated destroyState",
+			&state.State{EC2Fleet: &state.EC2FleetState{
+				FleetID:  "Alpha-Fleet",
+				BuildID:  "1",
+				S3Bucket: "s3Bucket",
+				S3Key:    "s3Key",
+			}},
+			destroyState{
+				fleetID:  "Alpha-Fleet",
+				buildID:  "1",
+				s3Bucket: "s3Bucket",
+				s3Key:    "s3Key",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := destroyStateFromState(tt.state)
+			if got != tt.want {
+				t.Errorf("Invalid DestroyState: got %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDestroyState_Empty(t *testing.T) {
+	tests := []struct {
+		name   string
+		dState destroyState
+		want   bool
+	}{
+		{"Empty", destroyState{}, true},
+		{"Populated", destroyState{fleetID: "Alpha-Fleet", buildID: "1"}, false},
+		{"Partially populated", destroyState{fleetID: "Alpha-Fleet"}, false},
+		{"Other fields populated", destroyState{s3Bucket: "s3Bucket", s3Key: "s3Key"}, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.dState.empty()
+			if got != tt.want {
+				t.Errorf("Empty state mismatch: want %t, got %t", tt.want, got)
+			}
+		})
 	}
 }

--- a/internal/ec2fleet/build_test.go
+++ b/internal/ec2fleet/build_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"testing"
 
@@ -161,10 +162,12 @@ func TestAddFileToZip(t *testing.T) {
 			}
 
 			entry := r.File[0]
-			if entry.Name != tt.zipPath { // verify zip file path
+			expectedZipPath := filepath.ToSlash(tt.zipPath)
+			if entry.Name != expectedZipPath { // verify zip file path
 				t.Errorf("Naming mismatch: got %q, want %q", entry.Name, tt.zipPath)
 			}
-			if entry.Mode() != tt.wantMode {
+
+			if runtime.GOOS != "windows" && entry.Mode() != tt.wantMode {
 				t.Errorf("Permissions mismatch: got %v, want %v", entry.Mode(), tt.wantMode)
 			}
 		})

--- a/internal/ec2fleet/build_test.go
+++ b/internal/ec2fleet/build_test.go
@@ -1,0 +1,242 @@
+package ec2fleet
+
+import (
+	"archive/zip"
+	"io"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestResolveServerBinaryPath(t *testing.T) {
+	tests := []struct {
+		name, target, project, arch string
+		files                       []string
+		want                        string
+	}{
+		{"Shipping_Test Build", "ServerTarget", "TestBuild", "", []string{"ServerTarget-Linux-Test.target", "ServerTarget-Linux-Test"}, "./TestBuild/Binaries/Linux/ServerTarget-Linux-Test"},
+		{"Multi-Dot Skip", "ServerTarget", "TestBuild", "", []string{"ServerTarget-Linux-Test.config.json", "ServerTarget-Linux-Test"}, "./TestBuild/Binaries/Linux/ServerTarget-Linux-Test"},
+		{"Unconventional Suffix", "ServerTarget", "TestBuild", "", []string{"ServerTarget-Linux-DebugData"}, "./TestBuild/Binaries/Linux/ServerTarget-Linux-DebugData"},
+		{"Dev Path Fallback", "LyraServer", "DevBuild", "arm64", []string{}, "./DevBuild/Binaries/LinuxArm64/LyraServer"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Deployer{opts: DeployOptions{ServerTarget: tt.target, ProjectName: tt.project, Arch: tt.arch}}
+
+			buildDir := t.TempDir()
+			binDir := filepath.Join(buildDir, d.opts.packagedDirName(), "Binaries", config.BinariesPlatformDir(d.opts.Arch))
+			if err := os.MkdirAll(binDir, 0755); err != nil {
+				t.Fatalf("failed to create test directory structure: %v", err)
+			}
+			for _, filename := range tt.files {
+				filePath := filepath.Join(binDir, filename)
+				if err := os.WriteFile(filePath, []byte(""), 0644); err != nil {
+					t.Fatalf("failed to create mock file %s: %v", filename, err)
+				}
+			}
+
+			got := d.resolveServerBinaryPath(buildDir, d.opts.Arch)
+			if got != tt.want {
+				t.Errorf("want %s, got %v", tt.want, got)
+			}
+		})
+	}
+}
+
+// helper function to create temp file structure used in create zip
+func createTmpFilesys(t *testing.T, dir string, mockFiles []string) (string, string, string) {
+	t.Helper()
+	zPath := filepath.Join(dir, "test_archive.zip") // create zip/binary/server build paths
+	wBin := filepath.Join(dir, "wrapper-binary")
+	bDir := filepath.Join(dir, "build_contents")
+
+	if err := os.WriteFile(wBin, []byte("binary-data"), 0755); err != nil {
+		t.Fatalf("failed creating wrapper binary: %v", err)
+	}
+	if err := os.MkdirAll(bDir, 0755); err != nil {
+		t.Fatalf("failed creating build dir: %v", err)
+	}
+
+	for _, path := range mockFiles { // create nested folder structure if present
+		fullpath := filepath.Join(bDir, path)
+		if err := os.MkdirAll(filepath.Dir(fullpath), 0755); err != nil {
+			t.Fatalf("failed creating nested dir: %v", err)
+		}
+		if err := os.WriteFile(fullpath, []byte("file-data"), 0755); err != nil {
+			t.Fatalf("failed creating mock file: %v", err)
+		}
+	}
+	return zPath, wBin, bDir
+}
+
+func TestCreateBuildZip(t *testing.T) {
+	tests := []struct {
+		name, wrapperCfg string
+		mockFiles, want  []string
+	}{
+		{"Zip creation simple", "config-string", []string{"game-binary.exe"}, []string{"amazon-gamelift-servers-game-server-wrapper", "config.yaml", "game-binary.exe"}},
+		{"Zip creation nested structure", "config-string", []string{"Engine/Binaries/config.json"}, []string{"amazon-gamelift-servers-game-server-wrapper", "config.yaml", "Engine/", "Engine/Binaries/", "Engine/Binaries/config.json"}},
+		{"Empty server build dir", "config-string", []string{}, []string{"amazon-gamelift-servers-game-server-wrapper", "config.yaml"}},
+		{"multiple folders in server dir", "config-string", []string{"Engine/Binaries/config.json", "Engine/System/system.ini"}, []string{"amazon-gamelift-servers-game-server-wrapper", "config.yaml", "Engine/", "Engine/Binaries/", "Engine/Binaries/config.json", "Engine/System/", "Engine/System/system.ini"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			zPath, wBin, bDir := createTmpFilesys(t, tmp, tt.mockFiles) // create server build folder/files
+
+			if err := createBuildZip(zPath, bDir, wBin, tt.wrapperCfg); err != nil { // build zip file
+				t.Fatalf("Failed zip build: %v", err)
+			}
+
+			r, err := zip.OpenReader(zPath) // read zip file
+			if err != nil {
+				t.Fatalf("Failed opening tmp zipfile: %v", err)
+			}
+			defer r.Close()
+
+			var files []string
+			for _, f := range r.File {
+				files = append(files, f.Name)
+				if f.Name == "config.yaml" { // verify config.yaml contents
+					rc, _ := f.Open()
+					content, _ := io.ReadAll(rc)
+					rc.Close()
+					if string(content) != tt.wrapperCfg {
+						t.Errorf("config mismatch: got %q, want %q", string(content), tt.wrapperCfg)
+					}
+				}
+			}
+
+			if !slices.Equal(files, tt.want) { // confirm .zip file contents
+				t.Errorf("got %v, want %v", files, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddFileToZip(t *testing.T) {
+	tests := []struct {
+		name, newFile, zipPath string
+		createMode, wantMode   os.FileMode
+	}{
+		{"Shell script forces 0755", "script.sh", "script.sh", 0644, 0755},
+		{"Binary without ext forces 0755", "mybin", "bin/mybin", 0644, 0755},
+		{"Text file preserves 0644", "config.json", "cfg/config.json", 0644, 0644},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tmp := t.TempDir()
+			srcPath := filepath.Join(tmp, tt.newFile)
+			_ = os.WriteFile(srcPath, []byte("file-data"), tt.createMode)
+
+			zipFile := filepath.Join(tmp, "out.zip")
+			f, err := os.Create(zipFile)
+			if err != nil {
+				t.Fatalf("failed to create zip file: %v", err)
+			}
+
+			w := zip.NewWriter(f)
+			if err := addFileToZip(w, srcPath, tt.zipPath); err != nil { // create new zip file, writes to buffer
+				t.Fatalf("Error adding files to zip: %v", err)
+			}
+			w.Close()
+			f.Close()
+
+			r, err := zip.OpenReader(zipFile) // read zip from buffer
+			if err != nil {
+				t.Fatalf("Failed opening tmp zipfile: %v", err)
+			}
+			defer r.Close()
+
+			if len(r.File) != 1 { // ensure only the single file is added
+				t.Fatalf("expected 1 file entry, got %d", len(r.File))
+			}
+
+			entry := r.File[0]
+			if entry.Name != tt.zipPath { // verify zip file path
+				t.Errorf("Naming mismatch: got %q, want %q", entry.Name, tt.zipPath)
+			}
+			if entry.Mode() != tt.wantMode {
+				t.Errorf("Permissions mismatch: got %v, want %v", entry.Mode(), tt.wantMode)
+			}
+		})
+	}
+}
+
+func TestBuildInput(t *testing.T) {
+	d := Deployer{opts: DeployOptions{FleetName: "alpha-fleet"}}
+	got := d.buildInput("s3bucket", "s3key", "AWSARN")
+
+	checks := []struct{ field, got, want string }{
+		{"Name", aws.ToString(got.Name), "ludus-alpha-fleet"},
+		{"OS", string(got.OperatingSystem), string(gltypes.OperatingSystemAmazonLinux2023)},
+		{"SDK", aws.ToString(got.ServerSdkVersion), "5.4.0"},
+		{"Bucket", aws.ToString(got.StorageLocation.Bucket), "s3bucket"},
+		{"Key", aws.ToString(got.StorageLocation.Key), "s3key"},
+		{"RoleArn", aws.ToString(got.StorageLocation.RoleArn), "AWSARN"},
+	}
+
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s mismatch: got %q, want %q", c.field, c.got, c.want)
+		}
+	}
+
+	tagMap := make(map[string]string)
+	for _, tag := range got.Tags {
+		tagMap[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
+	if tagMap["ludus:fleet-name"] != "alpha-fleet" || tagMap["ludus:target"] != "ec2" {
+		t.Errorf("unexpected tags wired to CreateBuildInput: %v", tagMap)
+	}
+}
+
+func TestGenerateEC2WrapperConfig(t *testing.T) {
+	tests := []struct {
+		name, binaryPath, mapPath string
+		port                      int
+		want                      string
+	}{
+		{
+			name:       "Config formats correctly",
+			binaryPath: "Engine/Binaries/gamelift.ini",
+			mapPath:    "Engine/Binaries/config.json",
+			port:       5432,
+			want: `# Generated by ludus for GameLift Managed EC2
+log-config:
+  wrapper-log-level: debug
+  game-server-logs-dir: ./game-server-logs
+
+ports:
+  gamePort: 5432
+
+game-server-details:
+  executable-file-path: Engine/Binaries/gamelift.ini
+  game-server-args:
+    - arg: "-port"
+      val: "{{.GamePort}}"
+      pos: 0
+    - arg: "-Map=Engine/Binaries/config.json"
+      pos: 1
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := generateEC2WrapperConfig(tt.binaryPath, tt.mapPath, tt.port)
+			if got != tt.want {
+				t.Errorf("generateEC2WrapperConfig mismatch:\ngot:\n%s\nwant:\n%s", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/ec2fleet/deployer_fleet_test.go
+++ b/internal/ec2fleet/deployer_fleet_test.go
@@ -1,0 +1,91 @@
+package ec2fleet
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	gltypes "github.com/aws/aws-sdk-go-v2/service/gamelift/types"
+)
+
+func TestCreateFleetInput(t *testing.T) {
+	d := &Deployer{opts: DeployOptions{
+		FleetName:    "testing-fleet",
+		InstanceType: "Test-Instance",
+		ServerPort:   8000,
+	}}
+	buildId := "1"
+	roleArn := "testingARN"
+
+	got := d.createFleetInput(buildId, roleArn)
+
+	checks := []struct{ field, want, got string }{
+		{"Name", "testing-fleet", aws.ToString(got.Name)},
+		{"Desciption", "Ludus dedicated server EC2 fleet", aws.ToString(got.Description)},
+		{"BuildID", "1", aws.ToString(got.BuildId)},
+		{"EC2 Type", "Test-Instance", string(got.EC2InstanceType)},
+		{"FleetType", "ON_DEMAND", string(got.FleetType)},
+		{"RoleArn", "testingARN", aws.ToString(got.InstanceRoleArn)},
+		// Ignoring RuntimeConfiguration check as handled in another test function
+		{"EC2InboundPerm: FromPort", string(int32(8000)), string(aws.ToInt32(got.EC2InboundPermissions[0].FromPort))},
+		{"EC2InboundPerm: ToPort", string(int32(8000)), string(aws.ToInt32(got.EC2InboundPermissions[0].FromPort))},
+		{"EC2InboundPerm: IpRange", "0.0.0.0/0", aws.ToString(got.EC2InboundPermissions[0].IpRange)},
+		{"EC2InboundPerm: Protocol", "UDP", string(got.EC2InboundPermissions[0].Protocol)},
+	}
+
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s Mismatch - got %s, want %s", c.field, c.got, c.want)
+		}
+	}
+	// Check of GameLiftTags
+	tagMap := make(map[string]string)
+	for _, tag := range got.Tags {
+		tagMap[aws.ToString(tag.Key)] = aws.ToString(tag.Value)
+	}
+
+	if tagMap["ludus:fleet-name"] != "testing-fleet" || tagMap["ludus:target"] != "ec2" {
+		t.Errorf("unexpected tags wired to CreateBuildInput: %v", tagMap)
+	}
+}
+
+func TestFleetActivePollResult(t *testing.T) {
+	tests := []struct {
+		name     string
+		status   gltypes.FleetStatus
+		wantBool bool
+		wantErr  error
+	}{
+		{"FleetStatusActive", gltypes.FleetStatusActive, true, nil},
+		{"FleetStatusError", gltypes.FleetStatusError, false, errors.New("fleet entered ERROR state")},
+		{"FleetStatusOther", gltypes.FleetStatusBuilding, false, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotBool, gotErr := fleetActivePollResult(tt.status)
+			if tt.wantBool != gotBool || (gotErr != nil && tt.wantErr.Error() != gotErr.Error()) {
+				t.Errorf("Got bool: %t, err: %v; Want bool %v, err %v.", gotBool, gotErr, tt.wantBool, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRuntimeConfiguration(t *testing.T) {
+	d := &Deployer{opts: DeployOptions{ServerPort: 8000}}
+	got := d.runtimeConfiguration()
+
+	checks := []struct {
+		field, want, got string
+	}{
+		{"LaunchPath", "/local/game/amazon-gamelift-servers-game-server-wrapper", aws.ToString(got.ServerProcesses[0].LaunchPath)},
+		{"Parameters", "--port 8000", aws.ToString(got.ServerProcesses[0].Parameters)},
+		{"ConcurrentExecutions", string(int32(1)), string(aws.ToInt32(got.ServerProcesses[0].ConcurrentExecutions))},
+	}
+
+	for _, c := range checks {
+		if c.got != c.want {
+			t.Errorf("%s Mismatch - got %s, want %s", c.field, c.got, c.want)
+		}
+	}
+}

--- a/internal/ec2fleet/deployer_test.go
+++ b/internal/ec2fleet/deployer_test.go
@@ -23,3 +23,38 @@ func TestPackagedDirName(t *testing.T) {
 		})
 	}
 }
+
+func TestResourceTags(t *testing.T) {
+	tests := []struct {
+		name string
+		tags map[string]string
+		want map[string]string
+	}{
+		{"no new tags",
+			make(map[string]string),
+			map[string]string{"ludus:fleet-name": "testing-fleet", "ludus:target": "ec2"}},
+		{"overwrite fleet name",
+			map[string]string{"ludus:fleet-name": "alpha-fleet"},
+			map[string]string{"ludus:fleet-name": "testing-fleet", "ludus:target": "ec2"}},
+		{"overwrite fleet and merge",
+			map[string]string{"ludus:fleet-name": "alpha-fleet", "ludus:env-name": "linux"},
+			map[string]string{"ludus:fleet-name": "testing-fleet", "ludus:target": "ec2", "ludus:env-name": "linux"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := &Deployer{opts: DeployOptions{FleetName: "testing-fleet", Tags: tt.tags}}
+			got := d.resourceTags()
+
+			if len(tt.want) != len(got) {
+				t.Fatalf("Map length mismatch: got %d keys, want %d keys (%v)", len(got), len(tt.want), got)
+			}
+
+			for k, wantVal := range tt.want {
+				if gotVal, ok := got[k]; !ok || wantVal != gotVal {
+					t.Errorf("Key %v mismatch: want %s, got %s", k, wantVal, gotVal)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

`internal/ec2fleet`: 2.3% -> 20.9%

- deployer: `resourceTags`(no new, overwite, overwite and merge)
- build: `resolveServerBinaryPath` (Shippingbuild, multi-dot skip, missing suffix, dev path fallback), `createTestBuildZip` (simple, nested structure, empty server build, multi-folder), `addFileToZip` (shell script, missing extension, other file), `buildInput` (struct assembly check), `generateEC2WrapperConfig`(config formatting)
- deployer_fleet: `fleetActivePollResult` (active, error, other), `runtimeConfiguration` (Deployer RuntimeConfiguration check) `createFleetInput` (struct assembly)
- adapter: `destroyStateFromState` (nil vs populated), `DestroyState.empty` (empty, populated, partial, other)

## Changes

No changes to Production code; Tests only

## Testing

- [x] `golangci-lint run ./...` passes
- [x] `go test ./...` passes
- [x] `go vet` ./...
- [x] `go build` ./...
- [x] `gocyclo -over 8` on changed tests (no output)
- [x] `git diff` --check

Resolves #444 