### PR TITLE
test(runtime): cover path configuration and state helpers

### DIFF
--- a/internal/ddc/ddc_path_test.go
+++ b/internal/ddc/ddc_path_test.go
@@ -127,3 +127,51 @@ func TestResolvePath_Default(t *testing.T) {
 		t.Errorf("ResolvePath(%q) = %q, want %q", "", got, want)
 	}
 }
+
+func TestResolveZenPath(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	absolute := filepath.Join(home, "custom", "zen")
+	tests := []struct {
+		name     string
+		override string
+		want     string
+		wantErr  bool
+	}{
+		{name: "default", want: filepath.Join(home, ".ludus", "zen")},
+		{name: "absolute override", override: absolute, want: absolute},
+		{name: "relative override", override: filepath.Join("relative", "zen"), wantErr: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ResolveZenPath(tt.override)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveZenPath(%q) error = %v, wantErr %v", tt.override, err, tt.wantErr)
+			}
+			if got != tt.want {
+				t.Errorf("ResolveZenPath(%q) = %q, want %q", tt.override, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDefaultZenPath(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	got, err := DefaultZenPath()
+	if err != nil {
+		t.Fatalf("DefaultZenPath() error = %v", err)
+	}
+	if want := filepath.Join(home, ".ludus", "zen"); got != want {
+		t.Errorf("DefaultZenPath() = %q, want %q", got, want)
+	}
+}
+
+func setTestHome(t *testing.T, home string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Setenv("USERPROFILE", home)
+		return
+	}
+	t.Setenv("HOME", home)
+}

--- a/internal/deploy/session_test.go
+++ b/internal/deploy/session_test.go
@@ -1,0 +1,86 @@
+package deploy
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jpvelasco/ludus/internal/state"
+)
+
+func TestSaveSessionState(t *testing.T) {
+	setupSessionTest(t)
+	before := time.Now().UTC().Add(-time.Second)
+	want := &SessionInfo{SessionID: "session-123", IPAddress: "192.0.2.10", Port: 7777}
+	SaveSessionState(want)
+	assertSavedSession(t, loadState(t).Session, want, before)
+}
+
+func assertSavedSession(t *testing.T, got *state.SessionState, want *SessionInfo, before time.Time) {
+	t.Helper()
+	if got == nil {
+		t.Fatal("session state is nil")
+	}
+	assertSessionFields(t, got, want)
+	assertCurrentTimestamp(t, got.CreatedAt, before)
+}
+
+func assertSessionFields(t *testing.T, got *state.SessionState, want *SessionInfo) {
+	t.Helper()
+	if got.SessionID != want.SessionID {
+		t.Errorf("session ID = %q, want %q", got.SessionID, want.SessionID)
+	}
+	if got.IPAddress != want.IPAddress {
+		t.Errorf("IP address = %q, want %q", got.IPAddress, want.IPAddress)
+	}
+	if got.Port != want.Port {
+		t.Errorf("port = %d, want %d", got.Port, want.Port)
+	}
+	if got.Status != "ACTIVE" {
+		t.Errorf("session status = %q, want ACTIVE", got.Status)
+	}
+}
+
+func assertCurrentTimestamp(t *testing.T, value string, before time.Time) {
+	t.Helper()
+	createdAt, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse CreatedAt %q: %v", value, err)
+	}
+	if createdAt.Before(before) || createdAt.After(time.Now().UTC().Add(time.Second)) {
+		t.Errorf("CreatedAt = %v, want current time", createdAt)
+	}
+}
+func TestClearFleetState(t *testing.T) {
+	setupSessionTest(t)
+	if err := state.UpdateFleet(&state.FleetState{FleetID: "fleet-123"}); err != nil {
+		t.Fatalf("seed fleet state: %v", err)
+	}
+	if err := state.UpdateSession(&state.SessionState{SessionID: "session-123"}); err != nil {
+		t.Fatalf("seed session state: %v", err)
+	}
+	ClearFleetState()
+	got := loadState(t)
+	if got.Fleet != nil {
+		t.Errorf("fleet state = %#v after clear, want nil", got.Fleet)
+	}
+	if got.Session != nil {
+		t.Errorf("session state = %#v after clear, want nil", got.Session)
+	}
+}
+
+func setupSessionTest(t *testing.T) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	previous := state.ActiveProfile()
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile(previous) })
+}
+
+func loadState(t *testing.T) *state.State {
+	t.Helper()
+	got, err := state.Load()
+	if err != nil {
+		t.Fatalf("state.Load: %v", err)
+	}
+	return got
+}

--- a/internal/dockerbuild/runtime_paths_test.go
+++ b/internal/dockerbuild/runtime_paths_test.go
@@ -1,0 +1,32 @@
+package dockerbuild
+
+import "testing"
+
+func TestIsWSL2Backend(t *testing.T) {
+	tests := []struct {
+		backend string
+		want    bool
+	}{
+		{backend: BackendWSL2, want: true},
+		{backend: BackendDocker},
+		{backend: BackendNative},
+		{backend: ""},
+		{backend: "WSL2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.backend, func(t *testing.T) {
+			if got := IsWSL2Backend(tt.backend); got != tt.want {
+				t.Errorf("IsWSL2Backend(%q) = %v, want %v", tt.backend, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestContainerCLI_UsesPath(t *testing.T) {
+	path := t.TempDir()
+	executable := writeTestExecutable(t, path, BackendDocker)
+	t.Setenv("PATH", path)
+	if got := ContainerCLI(BackendDocker); got != executable {
+		t.Errorf("ContainerCLI(docker) = %q, want %q", got, executable)
+	}
+}

--- a/internal/dockerbuild/runtime_unix_test.go
+++ b/internal/dockerbuild/runtime_unix_test.go
@@ -1,0 +1,24 @@
+//go:build !windows
+
+package dockerbuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	return path
+}
+
+func TestResolvePodmanFallback_NonWindows(t *testing.T) {
+	if got := ResolvePodmanFallback(); got != "" {
+		t.Errorf("ResolvePodmanFallback() = %q, want empty", got)
+	}
+}

--- a/internal/dockerbuild/runtime_windows_test.go
+++ b/internal/dockerbuild/runtime_windows_test.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package dockerbuild
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeTestExecutable(t *testing.T, dir, name string) string {
+	t.Helper()
+	path := filepath.Join(dir, name+".exe")
+	if err := os.WriteFile(path, []byte("test"), 0o755); err != nil {
+		t.Fatalf("write executable: %v", err)
+	}
+	return path
+}

--- a/internal/state/state_update_test.go
+++ b/internal/state/state_update_test.go
@@ -177,3 +177,26 @@ func TestUpdateClient(t *testing.T) {
 		t.Fatal("client not updated")
 	}
 }
+
+func TestWSL2Engine(t *testing.T) {
+	setupTest(t)
+	want := &WSL2EngineState{
+		EnginePath: "~/ludus/engine/5.8",
+		IsNative:   true,
+		DDCPath:    "~/ludus/ddc",
+		SyncTime:   "2026-07-24T01:02:03Z",
+		BuiltAt:    "2026-07-24T04:05:06Z",
+	}
+	if err := UpdateWSL2Engine(want); err != nil {
+		t.Fatalf("UpdateWSL2Engine: %v", err)
+	}
+	if got := mustLoad(t).WSL2Engine; got == nil || *got != *want {
+		t.Fatalf("WSL2 engine = %#v, want %#v", got, want)
+	}
+	if err := ClearWSL2Engine(); err != nil {
+		t.Fatalf("ClearWSL2Engine: %v", err)
+	}
+	if got := mustLoad(t).WSL2Engine; got != nil {
+		t.Errorf("WSL2 engine = %#v after clear, want nil", got)
+	}
+}

--- a/internal/tracing/tracing_test.go
+++ b/internal/tracing/tracing_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"testing"
 
+	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
 )
 
@@ -66,5 +67,51 @@ func TestTracer_RecordsSpan(t *testing.T) {
 	}
 	if spans[0].Name() != "test-stage" {
 		t.Errorf("span name = %q, want %q", spans[0].Name(), "test-stage")
+	}
+}
+
+func TestExporterOptions(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  Config
+		want int
+	}{
+		{name: "defaults", cfg: Config{}, want: 0},
+		{name: "endpoint", cfg: Config{Endpoint: "collector:4318"}, want: 1},
+		{name: "insecure", cfg: Config{Insecure: true}, want: 1},
+		{name: "headers", cfg: Config{Headers: map[string]string{"api-key": "secret"}}, want: 1},
+		{name: "all", cfg: Config{Endpoint: "collector:4318", Insecure: true, Headers: map[string]string{"api-key": "secret"}}, want: 3},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := len(exporterOptions(tt.cfg)); got != tt.want {
+				t.Errorf("len(exporterOptions()) = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildResource(t *testing.T) {
+	for _, version := range []string{"1.2.3", ""} {
+		if got := buildResource(version); got == nil {
+			t.Errorf("buildResource(%q) returned nil", version)
+		}
+	}
+}
+func TestInit_EnabledConfiguresProvider(t *testing.T) {
+	for _, key := range []string{"OTEL_TRACES_EXPORTER", "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"} {
+		t.Setenv(key, "")
+	}
+	previous := otel.GetTracerProvider()
+	t.Cleanup(func() { otel.SetTracerProvider(previous) })
+	shutdown, err := Init(context.Background(), Config{Enabled: true, Endpoint: "127.0.0.1:4318", Insecure: true, Version: "test"})
+	if err != nil {
+		t.Fatalf("Init(enabled) error = %v", err)
+	}
+	if otel.GetTracerProvider() == previous {
+		t.Error("Init(enabled) did not install a tracer provider")
+	}
+	if err := shutdown(context.Background()); err != nil {
+		t.Errorf("shutdown error = %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- cover tracing resource/exporter setup without sending telemetry
- cover Zen DDC path resolution and container runtime selection helpers
- cover WSL2 engine and deployment-session state persistence

## Validation
- golangci-lint run ./...
- go vet ./...
- go test ./internal/tracing ./internal/ddc ./internal/dockerbuild ./internal/state ./internal/deploy
- go test ./...
- go build -v ./...
- .hooks/pre-commit
- git diff --check
- changed-test gocyclo (-over 8 produced no output)

All changes are test-only and exclude internal/ec2fleet and internal/gamelift.