### PR TITLE
test(commands): cover shared resolution and adapter helpers

### DIFF
--- a/cmd/ci/runner_windows_test.go
+++ b/cmd/ci/runner_windows_test.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package ci
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestRunnerCommandsRejectWindows(t *testing.T) {
+	tests := []struct {
+		name string
+		run  func() error
+		want string
+	}{
+		{name: "install", run: func() error { return runInstall(installCmd, nil) }, want: "runner install is only supported on Linux"},
+		{name: "status", run: func() error { return runStatus(statusCmd, nil) }, want: "runner status is only supported on Linux"},
+		{name: "uninstall", run: func() error { return runUninstall(uninstallCmd, nil) }, want: "runner uninstall is only supported on Linux"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.run()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("error = %v, want %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/cmd/globals/resolve_test.go
+++ b/cmd/globals/resolve_test.go
@@ -2,12 +2,76 @@ package globals
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/deploy"
 	"github.com/jpvelasco/ludus/internal/state"
 )
+
+func TestResolveTargetBinary(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured string
+		override   string
+		wantName   string
+	}{
+		{name: "configured binary", configured: "binary", wantName: "binary"},
+		{name: "override takes precedence", configured: "unknown", override: "binary", wantName: "binary"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{Deploy: config.DeployConfig{Target: tt.configured}}
+			target, err := ResolveTarget(context.Background(), cfg, tt.override)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got := target.Name(); got != tt.wantName {
+				t.Fatalf("Name() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}
+
+func TestResolveTargetUnknown(t *testing.T) {
+	cfg := &config.Config{Deploy: config.DeployConfig{Target: "unsupported"}}
+	target, err := ResolveTarget(context.Background(), cfg, "")
+	if err == nil {
+		t.Fatal("expected unknown target error")
+	}
+	if target != nil {
+		t.Fatalf("target = %#v, want nil", target)
+	}
+	if !strings.Contains(err.Error(), `unknown deploy target "unsupported"`) {
+		t.Fatalf("error = %q", err)
+	}
+}
+
+func TestResolveBinaryOutputDirectory(t *testing.T) {
+	tests := []struct {
+		name      string
+		outputDir string
+	}{
+		{name: "default directory"},
+		{name: "configured directory", outputDir: t.TempDir()},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			target, err := resolveBinary(&config.Config{
+				Deploy: config.DeployConfig{OutputDir: tt.outputDir},
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if target.Name() != "binary" {
+				t.Fatalf("Name() = %q, want binary", target.Name())
+			}
+		})
+	}
+}
 
 // TestResolveSessionTarget_ConfigTargetIsSessionManager verifies that when the
 // config target already implements SessionManager, it is returned directly

--- a/internal/anywhere/process_windows_test.go
+++ b/internal/anywhere/process_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package anywhere
+
+import "testing"
+
+func TestWindowsProcessPIDGuards(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		pid  int
+	}{
+		{name: "zero", pid: 0},
+		{name: "negative", pid: -1},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := StopServer(tt.pid); err != nil {
+				t.Fatalf("StopServer(%d) = %v", tt.pid, err)
+			}
+			if IsProcessAlive(tt.pid) {
+				t.Fatalf("IsProcessAlive(%d) = true, want false", tt.pid)
+			}
+		})
+	}
+}
+
+func TestWindowsPositivePIDLivenessIsUnknown(t *testing.T) {
+	if IsProcessAlive(1) {
+		t.Fatal("IsProcessAlive(1) = true, want false")
+	}
+}


### PR DESCRIPTION
## Summary
- cover binary target selection, override precedence, defaults, and unknown-target errors
- cover Windows CI runner platform guards
- cover Windows Anywhere PID input guards without launching processes

## Validation
- golangci-lint run ./...
- go vet ./...
- focused package tests
- go test ./...
- go build -v ./...
- .hooks/pre-commit
- git diff --check
- gocyclo on changed tests

Test-only change. No changes under internal/ec2fleet or internal/gamelift.