### PR TITLE
test: cover remaining deterministic branches

### DIFF
--- a/cmd/globals/runner_test.go
+++ b/cmd/globals/runner_test.go
@@ -105,3 +105,37 @@ func TestNewRunner_SingleLogAcrossCalls(t *testing.T) {
 		t.Errorf("expected a single shared log file across NewRunner calls, got %d", len(entries))
 	}
 }
+func TestLogsDir(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		want string
+	}{
+		{name: "nil config", want: ".ludus/logs"},
+		{name: "default config", cfg: config.Defaults(), want: ".ludus/logs"},
+		{name: "configured directory", cfg: configWithLogsDir("artifacts/logs"), want: "artifacts/logs"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			previous := Cfg
+			t.Cleanup(func() { Cfg = previous })
+			Cfg = tt.cfg
+			if got := LogsDir(); got != tt.want {
+				t.Errorf("LogsDir() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func configWithLogsDir(dir string) *config.Config {
+	cfg := config.Defaults()
+	cfg.Observability.Logs.Dir = dir
+	return cfg
+}
+
+func TestSectionLogWithoutActiveLog(t *testing.T) {
+	resetRunnerState(t)
+	defer resetRunnerState(t)
+
+	SectionLog("build")
+}

--- a/internal/wrapper/wrapper_test.go
+++ b/internal/wrapper/wrapper_test.go
@@ -157,3 +157,17 @@ func TestEnsureBinaryDefaults(t *testing.T) {
 		t.Errorf("EnsureBinary(\"\", \"\") = %q, want %q (linux/amd64 default)", got, binaryPath)
 	}
 }
+func TestIsBinaryCached(t *testing.T) {
+	cacheDir := setupTestHome(t)
+
+	if IsBinaryCached("linux", "arm64") {
+		t.Fatal("IsBinaryCached() = true before binary exists")
+	}
+	seedFakeBinary(t, cacheDir, "linux", "arm64")
+	if !IsBinaryCached("linux", "arm64") {
+		t.Fatal("IsBinaryCached() = false after binary was cached")
+	}
+	if IsBinaryCached("windows", "arm64") {
+		t.Fatal("IsBinaryCached() matched a different target OS")
+	}
+}

--- a/internal/wsl/paths_test.go
+++ b/internal/wsl/paths_test.go
@@ -1,6 +1,10 @@
 package wsl
 
-import "testing"
+import (
+	"context"
+	"slices"
+	"testing"
+)
 
 // TestToWSLPath verifies Windows→WSL path conversion.
 // These tests must pass on Windows, Linux, and macOS: the implementation uses
@@ -113,5 +117,20 @@ func TestIsNativePath(t *testing.T) {
 				t.Errorf("IsNativePath(%q) = %v, want %v", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+func TestCoordinatorPathHelpers(t *testing.T) {
+	w := &WSL2{}
+	if got := w.ToWSLPath(`F:\Source\Game`); got != "/mnt/f/Source/Game" {
+		t.Errorf("ToWSLPath() = %q, want %q", got, "/mnt/f/Source/Game")
+	}
+
+	paths := []string{"/mnt/f/Source", "/var/cache/ludus"}
+	got, err := w.ExpandHomePaths(context.Background(), paths...)
+	if err != nil {
+		t.Fatalf("ExpandHomePaths() error: %v", err)
+	}
+	if !slices.Equal(got, paths) {
+		t.Errorf("ExpandHomePaths() = %v, want %v", got, paths)
 	}
 }


### PR DESCRIPTION
## Summary
- cover cached wrapper binary detection across cache miss, hit, and target isolation
- cover configured/default log directories and safe section logging without an active log
- cover WSL coordinator path delegation and no-subprocess home expansion

## Validation
- golangci-lint run ./...
- go vet ./...
- go test ./cmd/globals ./internal/wrapper ./internal/wsl
- go test ./...
- go build -v ./...
- .hooks/pre-commit
- git diff --check
- gocyclo -over 8 on changed tests (no output)

Test-only closure mop-up; no production files or issue-fenced packages changed.