### PR TITLE
test(coverage): cover CI and container option resolvers

### DIFF
--- a/cmd/ci/ci_test.go
+++ b/cmd/ci/ci_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/jpvelasco/ludus/cmd/globals"
 	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/runner"
 )
 
 func TestRunInitDryRunUsesDefaults(t *testing.T) {
@@ -149,4 +150,29 @@ func captureCIStdout(t *testing.T, run func() error) (string, error) {
 		t.Fatal(err)
 	}
 	return string(data), runErr
+}
+
+func TestResolveNameDefault(t *testing.T) {
+	resetCIGlobals(t)
+	if got := resolveName(); !strings.HasPrefix(got, "ludus-") || len(got) <= len("ludus-") {
+		t.Fatalf("resolveName() = %q, want ludus-hostname", got)
+	}
+}
+
+func TestResolveRepoFromGitRemote(t *testing.T) {
+	resetCIGlobals(t)
+	t.Chdir(t.TempDir())
+	if err := (&runner.Runner{}).Run(context.Background(), "git", "init", "--quiet"); err != nil {
+		t.Fatal(err)
+	}
+	if err := (&runner.Runner{}).Run(context.Background(), "git", "remote", "add", "origin", "https://github.com/example/project.git"); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveRepo(context.Background(), runner.NewRunner(false, false))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "example/project" {
+		t.Fatalf("resolveRepo() = %q, want example/project", got)
+	}
 }

--- a/cmd/globals/ddc_test.go
+++ b/cmd/globals/ddc_test.go
@@ -1,10 +1,12 @@
 package globals
 
 import (
+	"reflect"
 	"runtime"
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/dockerbuild"
 )
 
 func TestResolveContainerBackend(t *testing.T) {
@@ -262,17 +264,17 @@ func TestResolveContainerGameOptions(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ResolveContainerGameOptions() error = %v", err)
 	}
-	if got.EngineImage != "custom-engine:5.7.4" {
-		t.Errorf("EngineImage = %q, want custom-engine:5.7.4", got.EngineImage)
+	want := dockerbuild.DockerGameOptions{
+		EngineImage:   "custom-engine:5.7.4",
+		EngineVersion: "5.7",
+		Runtime:       "podman",
+		ProjectPath:   Cfg.Game.ProjectPath,
+		ProjectName:   Cfg.Game.ProjectName,
+		OutputDir:     config.ResolveServerArchiveRoot(Cfg),
+		DDCMode:       "none",
 	}
-	if got.EngineVersion != "5.7" || got.Runtime != "podman" {
-		t.Errorf("resolved engine/runtime = %q/%q, want 5.7/podman", got.EngineVersion, got.Runtime)
-	}
-	if got.ProjectPath != Cfg.Game.ProjectPath || got.ProjectName != Cfg.Game.ProjectName {
-		t.Errorf("project fields = %q/%q, want %q/%q", got.ProjectPath, got.ProjectName, Cfg.Game.ProjectPath, Cfg.Game.ProjectName)
-	}
-	if got.DDCMode != "none" || got.DDCPath != "" || got.DDCZenPath != "" {
-		t.Errorf("DDC fields = %q/%q/%q, want none and empty paths", got.DDCMode, got.DDCPath, got.DDCZenPath)
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("resolved options = %#v, want %#v", got, want)
 	}
 }
 

--- a/cmd/globals/ddc_test.go
+++ b/cmd/globals/ddc_test.go
@@ -246,3 +246,42 @@ func TestResolveDDC(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveContainerGameOptions(t *testing.T) {
+	t.Chdir(t.TempDir())
+	origCfg, origMode := Cfg, DDCMode
+	t.Cleanup(func() { Cfg, DDCMode = origCfg, origMode })
+	DDCMode = "none"
+	Cfg = &config.Config{}
+	Cfg.Engine.Version = "5.7.4"
+	Cfg.Engine.DockerImageName = "custom-engine"
+	Cfg.Game.ProjectPath = `C:\projects\Lyra`
+	Cfg.Game.ProjectName = "Lyra"
+
+	got, err := ResolveContainerGameOptions(Cfg, "podman")
+	if err != nil {
+		t.Fatalf("ResolveContainerGameOptions() error = %v", err)
+	}
+	if got.EngineImage != "custom-engine:5.7.4" {
+		t.Errorf("EngineImage = %q, want custom-engine:5.7.4", got.EngineImage)
+	}
+	if got.EngineVersion != "5.7" || got.Runtime != "podman" {
+		t.Errorf("resolved engine/runtime = %q/%q, want 5.7/podman", got.EngineVersion, got.Runtime)
+	}
+	if got.ProjectPath != Cfg.Game.ProjectPath || got.ProjectName != Cfg.Game.ProjectName {
+		t.Errorf("project fields = %q/%q, want %q/%q", got.ProjectPath, got.ProjectName, Cfg.Game.ProjectPath, Cfg.Game.ProjectName)
+	}
+	if got.DDCMode != "none" || got.DDCPath != "" || got.DDCZenPath != "" {
+		t.Errorf("DDC fields = %q/%q/%q, want none and empty paths", got.DDCMode, got.DDCPath, got.DDCZenPath)
+	}
+}
+
+func TestResolveContainerGameOptionsInvalidDDC(t *testing.T) {
+	origCfg, origMode := Cfg, DDCMode
+	t.Cleanup(func() { Cfg, DDCMode = origCfg, origMode })
+	Cfg = &config.Config{}
+	DDCMode = "invalid"
+	if _, err := ResolveContainerGameOptions(Cfg, "docker"); err == nil {
+		t.Fatal("expected invalid DDC mode error")
+	}
+}


### PR DESCRIPTION
## Summary\n- cover CI runner name and git-remote repository resolution\n- cover container game option assembly and invalid DDC propagation\n- test-only; excludes internal/ec2fleet and internal/gamelift\n\n## Validation\n- golangci-lint run ./...\n- go vet ./...\n- go test ./...\n- go build -v ./...\n- .hooks/pre-commit\n\nLocal Windows coverage: 57.5% (baseline 57.4%).