### PR TITLE
test(state,cache): cover Load-error branches in state/cache mutators

### DIFF
--- a/internal/cache/cache_errors_test.go
+++ b/internal/cache/cache_errors_test.go
@@ -1,0 +1,61 @@
+package cache
+
+import (
+	"os"
+	"testing"
+)
+
+// TestSave_MkdirAllFails covers the error branch when .ludus cannot be created
+// because a file already occupies that path.
+func TestSave_MkdirAllFails(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.WriteFile(cacheDir, []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Cache{Entries: make(map[StageKey]*Entry)}
+	if err := Save(c); err == nil {
+		t.Fatal("expected error when cacheDir path is occupied by a file")
+	}
+}
+
+// TestRecordBuild_LoadFailsIsNoop verifies that RecordBuild silently no-ops
+// (does not panic, does not write) when the existing cache.json is corrupted.
+func TestRecordBuild_LoadFailsIsNoop(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachePath(), []byte("{not valid json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	RecordBuild(StageEngine, "hash-1", false)
+
+	data, err := os.ReadFile(cachePath())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(data) != "{not valid json" {
+		t.Errorf("RecordBuild should not have modified the corrupted cache file, got: %s", data)
+	}
+}
+
+// TestCheckSkip_LoadFailsReturnsFalse verifies CheckSkip returns false
+// (proceed with build) rather than erroring when cache.json is corrupted.
+func TestCheckSkip_LoadFailsReturnsFalse(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cachePath(), []byte("{not valid json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := CheckSkip(StageEngine, "any-hash", "TestProject", false); got {
+		t.Error("expected CheckSkip to return false when cache load fails")
+	}
+}

--- a/internal/state/state_update_error_test.go
+++ b/internal/state/state_update_error_test.go
@@ -1,0 +1,52 @@
+package state
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestUpdateAndClearErrorOnCorruptedState verifies that every Update*/Clear*
+// helper propagates the Load() error instead of silently overwriting a state
+// file it could not parse.
+func TestUpdateAndClearErrorOnCorruptedState(t *testing.T) {
+	tests := []struct {
+		name string
+		fn   func() error
+	}{
+		{"UpdateFleet", func() error { return UpdateFleet(&FleetState{FleetID: "f-1"}) }},
+		{"UpdateSession", func() error { return UpdateSession(&SessionState{SessionID: "s-1"}) }},
+		{"UpdateClient", func() error { return UpdateClient(&ClientState{Platform: "Linux"}) }},
+		{"ClearSession", ClearSession},
+		{"ClearFleet", ClearFleet},
+		{"UpdateEngineImage", func() error { return UpdateEngineImage(&EngineImageState{ImageTag: "t"}) }},
+		{"UpdateDeploy", func() error { return UpdateDeploy(&DeployState{TargetName: "gamelift"}) }},
+		{"UpdateAnywhere", func() error { return UpdateAnywhere(&AnywhereState{FleetID: "a-1"}) }},
+		{"ClearAnywhere", ClearAnywhere},
+		{"UpdateEC2Fleet", func() error { return UpdateEC2Fleet(&EC2FleetState{FleetID: "ec2-1"}) }},
+		{"ClearEC2Fleet", ClearEC2Fleet},
+		{"UpdateWSL2Engine", func() error { return UpdateWSL2Engine(&WSL2EngineState{EnginePath: "/e"}) }},
+		{"ClearWSL2Engine", ClearWSL2Engine},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			setupTest(t)
+			writeCorruptedState(t)
+
+			if err := tt.fn(); err == nil {
+				t.Fatalf("%s: expected error when state file is corrupted", tt.name)
+			}
+		})
+	}
+}
+
+func writeCorruptedState(t *testing.T) {
+	t.Helper()
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, stateFile), []byte("{not valid json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
- Continues the coverage campaign from `main`, fenced away from `internal/ec2fleet` / `internal/gamelift` (issues #444/#446, PR #462).
- Adds table-driven tests covering the untested `Load()`-error branch in every `Update*`/`Clear*` helper in `internal/state/state.go` (13 functions) — a corrupted `state.json` previously silently fell through to happy-path assertions only.
- Adds tests for the equivalent uncovered error branches in `internal/cache/cache.go`: `Save` when `.ludus` cannot be created (path occupied by a file), `RecordBuild` no-op on a corrupted `cache.json`, and `CheckSkip` returning `false` (proceed with build) on load failure.
- Test-only change: no production code touched.

## Test plan
- [x] `golangci-lint run ./...` — clean (fixed 5 `gocritic unlambda` findings on first pass)
- [x] `go vet ./...` — clean
- [x] Focused: `go test ./internal/state/... ./internal/cache/... -v` — all pass
- [x] `go test ./...` — all pass
- [x] `go build -v ./...` — succeeds
- [x] `.hooks/pre-commit` — succeeds
- [x] `git diff --check` — clean
- [x] `gocyclo -over 8` on changed test files — no findings