### PR TITLE
ci: upload coverage to Codacy alongside Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,7 +101,12 @@ jobs:
         # coverage tab (Codacy Coverage Variation / Diff Coverage checks).
         # force-coverage-parser: go is required — the default LCOV parser cannot
         # parse Go's native coverprofile format.
+        # continue-on-error: the action has no fail_ci_if_error input (unlike
+        # Codecov's step above), so a missing/rotated token or network hiccup
+        # must not fail the required Test (ubuntu-latest) check over an
+        # informational upload.
         if: ${{ !cancelled() && runner.os == 'Linux' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        continue-on-error: true
         uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
         with:
           project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,3 +96,15 @@ jobs:
           # so a Codecov/OIDC/network outage must NOT fail the test leg and block
           # merges. Coverage is informational; infra flakiness shouldn't gate PRs.
           fail_ci_if_error: false
+      - name: Upload coverage to Codacy
+        # Codacy coverage complements Codecov — feeds the Codacy dashboard's
+        # coverage tab (Codacy Coverage Variation / Diff Coverage checks).
+        # force-coverage-parser: go is required — the default LCOV parser cannot
+        # parse Go's native coverprofile format.
+        if: ${{ !cancelled() && runner.os == 'Linux' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: coverage.out
+          force-coverage-parser: go
+          language: Go


### PR DESCRIPTION
## Summary
- Adds the `Upload coverage to Codacy` step to the Linux test leg in `.github/workflows/ci.yml`, mirroring Fabrica's live, working step (pinned to the same `codacy-coverage-reporter-action@v1.3.0` SHA).
- Uses the `CODACY_PROJECT_TOKEN` repo secret (already configured).
- `force-coverage-parser: go` is required since the default LCOV parser can't read Go's native coverprofile format.

## Why
Codacy's cloud analysis (`Codacy Static Code Analysis`) already runs on every PR, but coverage was only going to Codecov — the Codacy dashboard's coverage tab was empty. This closes that gap per the internal Fabrica-quality-standard replication guide.

## Testing
- [x] Workflow YAML structure verified against Fabrica's known-working equivalent
- [x] `CODACY_PROJECT_TOKEN` secret confirmed present on the repo
- [x] No production/Go code touched — CI config only
- [ ] Confirm on this PR: `Codacy Coverage Variation` / `Codacy Diff Coverage` status checks post successfully