### PR TITLE
test(prereq): cover Lyra content fix-hint message branches

### DIFF
--- a/internal/prereq/checker_logic_test.go
+++ b/internal/prereq/checker_logic_test.go
@@ -339,6 +339,62 @@ func TestDetectLyraContentState(t *testing.T) {
 	})
 }
 
+// --- fixMissingTopContent / fixMissingPluginContent -------------------------
+
+func TestFixMissingTopContent(t *testing.T) {
+	s := lyraContentState{lyraDir: "/engine/Samples/Games/Lyra", contentDir: "/engine/Samples/Games/Lyra/Content"}
+
+	t.Run("no content source configured", func(t *testing.T) {
+		c := &Checker{}
+		res := c.fixMissingTopContent(s, "")
+		if res.Passed {
+			t.Errorf("expected failing result, got %+v", res)
+		}
+		if !strings.Contains(res.Message, "Download 'Lyra Starter Game'") {
+			t.Errorf("unexpected message: %q", res.Message)
+		}
+	})
+
+	t.Run("content source configured but --fix not set", func(t *testing.T) {
+		c := &Checker{Fix: false}
+		res := c.fixMissingTopContent(s, "/downloads/Lyra")
+		if res.Passed {
+			t.Errorf("expected failing result, got %+v", res)
+		}
+		if !strings.Contains(res.Message, "run with --fix") || !strings.Contains(res.Message, "/downloads/Lyra") {
+			t.Errorf("unexpected message: %q", res.Message)
+		}
+	})
+}
+
+func TestFixMissingPluginContent(t *testing.T) {
+	s := lyraContentState{lyraDir: "/engine/Samples/Games/Lyra", missingPlugins: []string{"ShooterCore", "TopDownArena"}}
+
+	t.Run("content source configured but --fix not set", func(t *testing.T) {
+		c := &Checker{Fix: false}
+		res := c.fixMissingPluginContent(s, "/downloads/Lyra")
+		if res.Passed {
+			t.Errorf("expected failing result, got %+v", res)
+		}
+		if !strings.Contains(res.Message, "run 'ludus init --fix'") ||
+			!strings.Contains(res.Message, "ShooterCore, TopDownArena") {
+			t.Errorf("unexpected message: %q", res.Message)
+		}
+	})
+
+	t.Run("no content source configured", func(t *testing.T) {
+		c := &Checker{}
+		res := c.fixMissingPluginContent(s, "")
+		if res.Passed {
+			t.Errorf("expected failing result, got %+v", res)
+		}
+		if !strings.Contains(res.Message, "Copy the ENTIRE downloaded Lyra project") ||
+			!strings.Contains(res.Message, s.lyraDir) {
+			t.Errorf("unexpected message: %q", res.Message)
+		}
+	})
+}
+
 // --- goVersionTooOld --------------------------------------------------------
 
 func TestGoVersionTooOld(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds table-driven tests for `fixMissingTopContent` and `fixMissingPluginContent` in `internal/prereq/checker_lyra.go`, previously at 0% coverage.
- Covers the pure, no-disk-I/O branches: no content source configured, and content source configured but `--fix` not passed. Both only assemble a `CheckResult` message — the `--fix`-with-source branch (which calls `overlayLyraContent` → `robocopy`/`cp`) is intentionally out of scope for a unit test.

## Why
Small, low-risk test-only PR to validate the newly-added Codacy coverage-upload step (#473) end-to-end on a real PR — confirming `Codacy Diff Coverage` reflects new test coverage correctly, and that `Codacy Coverage Variation` now appears now that `main` has a baseline report.

## Testing
- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes
- [x] `gofmt -l` clean on changed file
- [x] `gocyclo -over 8` on changed test file — no output