### PR TITLE
ci: add govulncheck job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,19 @@ jobs:
         with:
           version: v2.10.1
 
+  vuln:
+    name: Vulnerability scan
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Run govulncheck
+        run: |
+          go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
+          govulncheck ./...
+
   build:
     name: Build
     strategy:


### PR DESCRIPTION
## Summary
- Adds a standalone `govulncheck` job (v1.1.4) to `.github/workflows/ci.yml`, matching the Fabrica quality-standard guide's gap list for Ludus.

## Why
Ludus was the only one of the three sibling repos (ludus/juggernaut/fabrica) missing a dependency-vulnerability scan step. This closes that gap without touching branch protection — the job is not added to required checks in this PR, so it's purely additive/informational until we decide to promote it.

## Testing
- [x] Ran `govulncheck ./...` locally: 0 vulnerabilities reachable by our code (2 exist in dependency code paths our code doesn't call — informational only, won't fail the job)
- [x] No production code touched — CI config only