### PR TITLE
ci: add standalone gosec and Trivy jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,31 @@ jobs:
           coverage-reports: coverage.out
           force-coverage-parser: go
           language: Go
+
+  gosec:
+    name: gosec
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Run gosec
+        # Exclusions mirror .golangci.yml's gosec linter settings, so this
+        # standalone job flags the same findings as local/CI lint, not a
+        # different noisier set.
+        run: go run github.com/securego/gosec/v2/cmd/gosec@v2.27.1 -exclude=G104,G115,G204,G301,G304,G702,G703,G306 ./...
+
+  trivy:
+    name: Trivy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Run Trivy filesystem scan
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25  # v0.36.0
+        with:
+          scan-type: fs
+          scan-ref: .
+          severity: CRITICAL,HIGH
+          exit-code: "1"
+          ignore-unfixed: true

--- a/internal/buildlog/buildlog.go
+++ b/internal/buildlog/buildlog.go
@@ -40,7 +40,7 @@ func New(dir, runName string, now time.Time) (*Logger, error) {
 		// O_EXCL fails if the file exists, so we never clobber an earlier log.
 		// 0644: build logs are non-secret and must be readable by the non-root
 		// container user that runs MCP/container builds.
-		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644) //nolint:gosec // G302: 0644 intentional, see comment
+		f, err := os.OpenFile(path, os.O_CREATE|os.O_EXCL|os.O_WRONLY, 0o644) // #nosec G302 -- 0644 intentional, see comment //nolint:gosec
 		if err == nil {
 			return &Logger{path: path, f: f}, nil
 		}

--- a/internal/dockerbuild/game_container.go
+++ b/internal/dockerbuild/game_container.go
@@ -57,7 +57,7 @@ func (b *DockerGameBuilder) runBuildContainer(ctx context.Context, outputDir, sc
 		return fmt.Errorf("writing preamble script: %w", err)
 	}
 	preambleFile.Close()
-	if err := os.Chmod(preambleFile.Name(), 0644); err != nil { //nolint:gosec // 0644 intentional: container non-root user must read this file
+	if err := os.Chmod(preambleFile.Name(), 0644); err != nil { // #nosec G302 -- 0644 intentional: container non-root user must read this file //nolint:gosec
 		return fmt.Errorf("chmod preamble script: %w", err)
 	}
 
@@ -72,7 +72,7 @@ func (b *DockerGameBuilder) runBuildContainer(ctx context.Context, outputDir, sc
 		return fmt.Errorf("writing build script: %w", err)
 	}
 	buildFile.Close()
-	if err := os.Chmod(buildFile.Name(), 0644); err != nil { //nolint:gosec // 0644 intentional: container non-root user must read this file
+	if err := os.Chmod(buildFile.Name(), 0644); err != nil { // #nosec G302 -- 0644 intentional: container non-root user must read this file //nolint:gosec
 		return fmt.Errorf("chmod build script: %w", err)
 	}
 

--- a/internal/dockerbuild/game_container_test.go
+++ b/internal/dockerbuild/game_container_test.go
@@ -1,0 +1,94 @@
+package dockerbuild
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+)
+
+func TestPrepareBuildContext(t *testing.T) {
+	tests := []struct {
+		name          string
+		outputDir     func(tmp string) string
+		defaultSubdir string
+		wantDir       func(tmp string) string
+	}{
+		{
+			name:          "empty outputDir defaults to defaultSubdir under cwd",
+			outputDir:     func(string) string { return "" },
+			defaultSubdir: "PackagedServer",
+			wantDir:       func(tmp string) string { return filepath.Join(tmp, "PackagedServer") },
+		},
+		{
+			name:          "relative outputDir resolved against cwd",
+			outputDir:     func(string) string { return "out" },
+			defaultSubdir: "PackagedServer",
+			wantDir:       func(tmp string) string { return filepath.Join(tmp, "out") },
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := NewDockerGameBuilder(DockerGameOptions{}, runner.NewRunner(false, true))
+			tmp := t.TempDir()
+			t.Chdir(tmp)
+
+			got, err := b.prepareBuildContext(tt.outputDir(tmp), tt.defaultSubdir)
+			assertPreparedBuildContext(t, got, err, tt.wantDir(tmp))
+		})
+	}
+
+	t.Run("absolute outputDir used as-is", func(t *testing.T) {
+		b := NewDockerGameBuilder(DockerGameOptions{}, runner.NewRunner(false, true))
+		abs := filepath.Join(t.TempDir(), "Packaged")
+
+		got, err := b.prepareBuildContext(abs, "PackagedServer")
+		assertPreparedBuildContext(t, got, err, abs)
+	})
+}
+
+func assertPreparedBuildContext(t *testing.T, got string, err error, want string) {
+	t.Helper()
+	if err != nil {
+		t.Fatalf("prepareBuildContext() error: %v", err)
+	}
+	if got != want {
+		t.Errorf("prepareBuildContext() = %q, want %q", got, want)
+	}
+	if info, statErr := os.Stat(got); statErr != nil || !info.IsDir() {
+		t.Errorf("expected %q to be created as a directory", got)
+	}
+}
+
+// TestRunBuildContainer exercises runBuildContainer with a dry-run Runner, so
+// no docker/podman invocation actually happens; this covers the preamble/build
+// script tempfile writes and chmods without needing a container runtime.
+func TestRunBuildContainer(t *testing.T) {
+	r := runner.NewRunner(false, true)
+	b := NewDockerGameBuilder(DockerGameOptions{EngineImage: "ludus-engine:test"}, r)
+
+	if err := b.runBuildContainer(context.Background(), t.TempDir(), "#!/bin/bash\necho hi\n", "docker game build"); err != nil {
+		t.Fatalf("runBuildContainer() error: %v", err)
+	}
+}
+
+func TestRunServerBuildContainer(t *testing.T) {
+	r := runner.NewRunner(false, true)
+	b := NewDockerGameBuilder(DockerGameOptions{EngineImage: "ludus-engine:test"}, r)
+
+	if err := b.runServerBuildContainer(context.Background(), t.TempDir()); err != nil {
+		t.Fatalf("runServerBuildContainer() error: %v", err)
+	}
+}
+
+func TestRunClientBuildContainer(t *testing.T) {
+	r := runner.NewRunner(false, true)
+	b := NewDockerGameBuilder(DockerGameOptions{EngineImage: "ludus-engine:test"}, r)
+
+	if err := b.runClientBuildContainer(context.Background(), t.TempDir()); err != nil {
+		t.Fatalf("runClientBuildContainer() error: %v", err)
+	}
+}

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -86,6 +86,6 @@ func backoffDelay(attempt int, base, max time.Duration) time.Duration {
 	}
 	// Full jitter: uniform random in [delay/2, delay]
 	half := delay / 2
-	jitter := time.Duration(rand.Int64N(int64(half) + 1)) //nolint:gosec // jitter for backoff timing, not security
+	jitter := time.Duration(rand.Int64N(int64(half) + 1)) // #nosec G404 -- jitter for backoff timing, not security //nolint:gosec
 	return half + jitter
 }


### PR DESCRIPTION
## Summary
- Adds dedicated `gosec` (v2.27.1) and `Trivy` filesystem-scan jobs to `.github/workflows/ci.yml`, giving each its own PR status check. Previously gosec only ran as a golangci-lint sub-linter with no dedicated check, and the Trivy binary was only installed for `internal/dflint`'s runtime use, never run as its own CI scan.
- `gosec` exclusions (`G104,G115,G204,G301,G304,G702,G703,G306`) mirror `.golangci.yml`'s existing gosec linter settings, so this job flags the same findings as local/CI lint rather than a different, noisier set.

## A real gap this surfaced
Running gosec as a standalone binary (rather than through golangci-lint) revealed that **3 already-reviewed and justified findings were invisible to it**: the codebase suppresses gosec findings with `//nolint:gosec` comments, which golangci-lint understands, but the standalone `gosec` binary only recognizes `#nosec` comments — and its regex requires that directive to appear *first* in the comment (golangci-lint's `nolint` tolerates trailing text). Fixed by reordering the 3 affected comments so both tools recognize the same suppression:
- `internal/retry/retry.go:89` (G404, jitter RNG)
- `internal/buildlog/buildlog.go:43` (G302, 0644 log file perms)
- `internal/dockerbuild/game_container.go:60,75` (G302, 0644 container script perms)

The remaining ~11 gosec findings only appear when gosec runs natively on Windows — they're all in `_windows.go` build-tagged files. Verified with `GOOS=linux` (matching the `ubuntu-latest` runner this job actually uses) that gosec's own build-constraint resolution excludes them cleanly, same as `go build`/`go vet` already do.

## Testing
- [x] `go build ./...` and `GOOS=linux go build ./...` both pass
- [x] `go vet ./...` passes
- [x] `golangci-lint run ./...` — 0 issues (comment reordering doesn't break its nolint recognition)
- [x] `go test ./...` passes
- [x] Standalone gosec, run with `GOOS=linux` to match the CI runner: 0 issues
- [x] Trivy filesystem scan: not run against a live registry in this session, but config mirrors Fabrica's working job exactly (same action pin, same severity/exit-code settings)