### PR TITLE
ci: add GoReleaser snapshot build job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,3 +113,30 @@ jobs:
           coverage-reports: coverage.out
           force-coverage-parser: go
           language: Go
+
+  goreleaser:
+    name: Release build (snapshot)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+      # Build-only: verifies .goreleaser.yml compiles all platforms. NEVER
+      # publishes (no `release`, no tag). Catches release-config breakage on PRs.
+      - uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94  # v7
+        with:
+          args: build --snapshot --clean
+      - name: Smoke-test the built linux binary
+        # Exec the freshly built native binary to prove it runs and the version
+        # ldflags resolved (not the "dev" fallback baked into internal/version.Version).
+        # The runner is linux/amd64, so glob that build output. Ludus has no `version`
+        # subcommand; Cobra's built-in --version flag prints the raw Version string.
+        run: |
+          BIN=$(find dist -type f -name ludus -path '*linux_amd64*')
+          test -n "$BIN" || { echo "no linux/amd64 ludus binary in dist/"; exit 1; }
+          chmod +x "$BIN"
+          OUT=$("$BIN" --version)
+          echo "$OUT"
+          echo "$OUT" | grep -q " dev$" && { echo "version ldflags did not resolve (still 'dev')"; exit 1; }
+          echo "smoke test OK"


### PR DESCRIPTION
## Summary
- Adds a build-only `goreleaser build --snapshot --clean` job to `.github/workflows/ci.yml`, matching Fabrica's pattern. Never publishes (no `release`, no tag) — catches `.goreleaser.yml` breakage on every PR instead of only discovering it at actual release time.
- Includes a smoke test that execs the built linux/amd64 binary and confirms the version ldflags actually resolved.

## Notes on adapting Fabrica's pattern (not a blind copy)
- Ludus has no `version` subcommand (unlike Fabrica). Used Cobra's built-in `--version` flag instead, which prints `ludus version <Version>`.
- `internal/version.Version` defaults to the literal string `"dev"`, not a semver placeholder — so the smoke test checks for a trailing ` dev` (Cobra's exact output format, verified locally), not Fabrica's `0.0.0-SNAPSHOT` string, which doesn't apply to this repo's version scheme.

## Testing
- [x] `goreleaser build --snapshot --clean` run locally: builds all 5 platform binaries (linux/darwin amd64+arm64, windows amd64) cleanly
- [x] Verified snapshot version resolves correctly (`0.9.3-SNAPSHOT-<sha>` in `dist/metadata.json`)
- [x] Confirmed Cobra's actual `--version` output format locally (`ludus version dev` when unresolved) before writing the smoke-test's grep pattern