### PR TITLE
ci: add committed CodeQL workflow

### DIFF
--- a/.github/GITHUB_SETTINGS.md
+++ b/.github/GITHUB_SETTINGS.md
@@ -32,11 +32,17 @@ gh api repos/OWNER/REPO \
 }
 EOF
 
-# CodeQL default setup
+# CodeQL: do NOT enable default setup. This repo scans via a committed
+# workflow (.github/workflows/codeql.yml) instead — GitHub refuses to run
+# default setup and an advanced/committed configuration for the same
+# languages concurrently, so default setup must stay disabled or the
+# committed workflow's SARIF uploads fail with "CodeQL analyses from
+# advanced configurations cannot be processed when the default setup is
+# enabled". If a fork/new instance somehow has default setup on, disable it:
 gh api repos/OWNER/REPO/code-scanning/default-setup \
   --method PATCH \
   --input - <<'EOF'
-{ "state": "configured", "query_suite": "default" }
+{ "state": "not-configured" }
 EOF
 
 # Branch ruleset: Protect main
@@ -139,6 +145,6 @@ EOF
 ### Security & Analysis
 - Secret scanning: enabled
 - Push protection: enabled
-- CodeQL (default setup): enabled — Go, JavaScript/TypeScript, Actions
+- CodeQL: committed workflow (`.github/workflows/codeql.yml` + `.github/codeql/codeql-config.yml`), `security-extended` query suite, matrix over `actions`/`go`/`javascript-typescript`. Default setup is explicitly **disabled** — required, since GitHub rejects committed-workflow SARIF uploads while default setup is on for the same languages.
 - Dependabot alerts: enabled
 - Dependabot security updates: enabled

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,4 @@
+name: "CodeQL Config"
+
+queries:
+  - uses: security-extended

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,37 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "0 0 * * 0"
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: Analyze ${{ matrix.language }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, go, javascript-typescript]
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
+        with:
+          languages: ${{ matrix.language }}
+          config-file: ./.github/codeql/codeql-config.yml
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a  # v4
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/codeql.yml` + `.github/codeql/codeql-config.yml`, replacing GitHub's default-setup CodeQL scanning with a committed, editable workflow — matching Juggernaut/Fabrica's pattern.
- Uses the `security-extended` query suite (deeper than default setup's `default` suite), same language matrix (`actions`, `go`, `javascript-typescript`), weekly schedule.

## Sequencing (per the internal Fabrica quality-standard guide, Phase 1E)
GitHub does not run both default-setup and a committed workflow for the same languages — one takes precedence. To avoid any gap in scanning coverage:
1. This PR merges with default setup still `configured` (as it is today).
2. After merge, I'll verify the committed workflow's `Analyze (actions/go/javascript-typescript)` checks actually run and pass on `main`.
3. Only then will default setup be explicitly disabled (`gh api -X PATCH .../code-scanning/default-setup -f state=not-configured`) so the committed workflow becomes the sole scanner — a deliberate follow-up step, not bundled into this PR.

## Testing
- [x] YAML structure verified against Juggernaut's live, working equivalent (fetched and diffed)
- [x] `codeql-action@v4` SHA pin (`7188fc3...`) verified as a legitimate, recent (2026-07-16) release commit via the GitHub API
- [x] No production/Go code touched — CI config only