### PR TITLE
chore: trusted Codacy coverage handoff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,23 +109,15 @@ jobs:
           # so a Codecov/OIDC/network outage must NOT fail the test leg and block
           # merges. Coverage is informational; infra flakiness shouldn't gate PRs.
           fail_ci_if_error: false
-      - name: Upload coverage to Codacy
-        # Codacy coverage complements Codecov — feeds the Codacy dashboard's
-        # coverage tab (Codacy Coverage Variation / Diff Coverage checks).
-        # force-coverage-parser: go is required — the default LCOV parser cannot
-        # parse Go's native coverprofile format.
-        # continue-on-error: the action has no fail_ci_if_error input (unlike
-        # Codecov's step above), so a missing/rotated token or network hiccup
-        # must not fail the required Test (ubuntu-latest) check over an
-        # informational upload.
-        if: ${{ !cancelled() && runner.os == 'Linux' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
-        continue-on-error: true
-        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
+      # PR jobs must not receive the Codacy repository token. Save the report;
+      # a trusted workflow_run workflow downloads this artifact and uploads it.
+      - name: Save coverage for Codacy
+        if: ${{ !cancelled() && runner.os == 'Linux' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: coverage.out
-          force-coverage-parser: go
-          language: Go
+          name: codacy-coverage-${{ github.run_id }}
+          path: coverage.out
+          if-no-files-found: error
 
   gosec:
     name: gosec

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -1,0 +1,38 @@
+name: Codacy Coverage
+
+on:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
+
+permissions:
+  actions: read
+  contents: read
+
+jobs:
+  upload:
+    # A successful Ubuntu test job can produce coverage even when another
+    # independent CI leg fails. Let the artifact determine whether to upload.
+    if: ${{ always() }}
+    runs-on: ubuntu-latest
+    steps:
+      # This workflow intentionally does not check out or execute the PR
+      # revision. The only input from it is the coverage report artifact.
+      - name: Download coverage report
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        continue-on-error: true
+        with:
+          name: codacy-coverage-${{ github.event.workflow_run.id }}
+          path: coverage
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          run-id: ${{ github.event.workflow_run.id }}
+      - name: Upload coverage to Codacy
+        if: ${{ always() && hashFiles('coverage/coverage.out') != '' }}
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699  # v1.3.0
+        env:
+          CODACY_COMMIT_UUID: ${{ github.event.workflow_run.head_sha }}
+        with:
+          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN }}
+          coverage-reports: coverage/coverage.out
+          force-coverage-parser: go
+          language: Go


### PR DESCRIPTION
## Summary
- Stop uploading Codacy coverage from PR CI (which exposed the token path to untrusted PR contexts and used the legacy `CODACY_PROJECT_TOKEN` name).
- Save `coverage.out` as an artifact; trusted `codacy-coverage.yml` uploads via `CODACY_REPOSITORY_API_TOKEN`.
- Codacy is informational — not a required status check (already true on ludus rulesets).

## Secret rename required
Rename/set the repo secret:
```
gh secret set CODACY_REPOSITORY_API_TOKEN --repo jpvelasco/ludus
# then remove CODACY_PROJECT_TOKEN if still present
gh secret delete CODACY_PROJECT_TOKEN --repo jpvelasco/ludus
```

## Test plan
- [ ] CI green
- [ ] After merge + secret rename, Codacy Coverage workflow uploads on next push