### PR TITLE
fix: accept legacy CODACY_PROJECT_TOKEN for coverage

### DIFF
--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -32,7 +32,9 @@ jobs:
         env:
           CODACY_COMMIT_UUID: ${{ github.event.workflow_run.head_sha }}
         with:
-          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN }}
+          # Prefer the standard name; fall back to the legacy CODACY_PROJECT_TOKEN
+          # secret until it is renamed in repo settings.
+          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN || secrets.CODACY_PROJECT_TOKEN }}
           coverage-reports: coverage/coverage.out
           force-coverage-parser: go
           language: Go


### PR DESCRIPTION
## Summary
Post-merge Codacy Coverage failed because the handoff reads `CODACY_REPOSITORY_API_TOKEN` while the repo still has `CODACY_PROJECT_TOKEN` (same credential type). Fall back so coverage works without a secret rename tonight.

## Test plan
- [x] CI green
- [x] Codacy Coverage workflow succeeds on main after merge