### PR TITLE
chore: use only CODACY_REPOSITORY_API_TOKEN for coverage

### DIFF
--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -32,9 +32,7 @@ jobs:
         env:
           CODACY_COMMIT_UUID: ${{ github.event.workflow_run.head_sha }}
         with:
-          # Prefer the standard name; fall back to the legacy CODACY_PROJECT_TOKEN
-          # secret until it is renamed in repo settings.
-          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN || secrets.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN }}
           coverage-reports: coverage/coverage.out
           force-coverage-parser: go
           language: Go


### PR DESCRIPTION
## Summary
Drop the temporary `CODACY_PROJECT_TOKEN` fallback. Coverage upload uses the standard repository secret name only.

## Ops
After merge, ensure `CODACY_REPOSITORY_API_TOKEN` is set, then delete `CODACY_PROJECT_TOKEN`.

## Test plan
- [ ] CI green
- [ ] Codacy Coverage succeeds with the new secret name