### PR TITLE
fix: add run_attempt to Codacy coverage artifact download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         if: ${{ !cancelled() && runner.os == 'Linux' }}
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
         with:
-          name: codacy-coverage-${{ github.run_id }}
+          name: codacy-coverage-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage.out
           if-no-files-found: error
 

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         continue-on-error: true
         with:
-          name: codacy-coverage-${{ github.event.workflow_run.id }}
+          name: codacy-coverage-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
           path: coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}


### PR DESCRIPTION
codacy-coverage.yml downloads the artifact without run_attempt suffix but ci.yml uploads with it. Add matching suffix to the download so they align.