### PR TITLE
ci: harden CI (lint bump + socket workflow)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9
         with:
-          version: v2.10.1
+          version: v2.12.2
 
   lint-windows:
     name: Lint (Windows)
@@ -32,7 +32,7 @@ jobs:
           go-version-file: go.mod
       - uses: golangci/golangci-lint-action@ba0d7d2ec06a0ea1cb5fa41b2e4a3ab91d21278a  # v9
         with:
-          version: v2.10.1
+          version: v2.12.2
 
   vuln:
     name: Vulnerability scan

--- a/.github/workflows/socket.yml
+++ b/.github/workflows/socket.yml
@@ -1,0 +1,20 @@
+name: Socket
+
+on:
+  pull_request:
+    branches: ["main"]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  security:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - name: Socket Security
+        uses: SocketDev/action@ba6de6cc0565af1f42295590380973573297e31f  # v1.3.2
+        with:
+          mode: firewall-free
+          github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
golangci-lint v2.10.1 to v2.12.2 in lint and lint-windows jobs. Add Socket workflow for supply-chain security scanning in firewall-free mode.