### PR TITLE
ci: align coverage pipeline with juggernaut Codacy pattern

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,10 +81,16 @@ jobs:
       # endings, which Codecov's parser rejects (the upload lands in an ERROR
       # state and never merges), so strip CR in the same step. tr is identical
       # on GNU/BSD/Git-bash; the strip is a no-op on Linux/macOS.
+      # -race on Linux/macOS (matching AGENTS.md invariant); Windows has no
+      # race detector support in Go.
       - name: Run tests with coverage
         shell: bash
         run: |
-          go test ./... -v -coverprofile=coverage.out -covermode=atomic
+          if [ "${{ matrix.os }}" = "windows-latest" ]; then
+            go test ./... -v -coverprofile=coverage.out -covermode=atomic
+          else
+            go test ./... -v -race -coverprofile=coverage.out -covermode=atomic
+          fi
           tr -d '\r' < coverage.out > coverage.tmp && mv coverage.tmp coverage.out
       # Upload per-OS coverage so Codecov merges all three legs. Much of the
       # PowerShell/launcher/keychain code is Windows-only, so a Linux-only
@@ -92,6 +98,8 @@ jobs:
       # use_pypi: true — install CLI from PyPI instead of cli.codecov.io so we
       # skip native-binary GPG verification (fails with "Could not verify
       # signature" when key import is empty; codecov/codecov-action#1876).
+      # fail_ci_if_error: false — Codecov is a soft block; infra flakiness
+      # must not fail the required test job and block valid PRs.
       - name: Upload coverage to Codecov
         if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
@@ -99,7 +107,7 @@ jobs:
           use_oidc: true
           use_pypi: true
           files: ./coverage.out
-          fail_ci_if_error: ${{ matrix.os != 'windows-latest' }}
+          fail_ci_if_error: false
       # Codacy coverage is uploaded by the trusted workflow_run workflow.
       # Keeping the report in an artifact lets Dependabot PRs provide coverage
       # without making the repository API token available to PR code.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,3 +173,24 @@ jobs:
           echo "$OUT"
           echo "$OUT" | grep -q " dev$" && { echo "version ldflags did not resolve (still 'dev')"; exit 1; }
           echo "smoke test OK"
+
+  # Codacy Static Analysis — runs on push to main to keep the dashboard in sync.
+  # PR-level checks come from the GitHub integration webhook; main-level
+  # analysis does not fire automatically after squash-merge, so we run the
+  # Codacy Analysis CLI here and upload results. Uses the existing project
+  # token (CODACY_REPOSITORY_API_TOKEN) — no new secrets needed.
+  codacy-analysis:
+    name: Codacy Analysis
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
+      - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
+        with:
+          go-version-file: go.mod
+      - name: Run Codacy Analysis CLI
+        uses: codacy/codacy-analysis-cli-action@562ee3e92b8e92df8b67e0a5ff8aa8e261919c08  # v4.4.7
+        with:
+          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN }}
+          upload: true
+          max-allowed-issues: 2147483647

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,58 +64,50 @@ jobs:
   test:
     name: Test
     strategy:
+      fail-fast: false  # one leg failing must not cancel the others' coverage uploads
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
-      id-token: write   # OIDC: lets the Linux leg mint a short-lived Codecov upload token
+      id-token: write  # OIDC; lets each leg mint the Codecov upload token
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0  # v7.0.0
       - uses: actions/setup-go@b7ad1dad31e06c5925ef5d2fc7ad053ef454303e  # v7.0.0
         with:
           go-version-file: go.mod
-      - name: Install hadolint and trivy (Linux)
-        if: runner.os == 'Linux'
+      # Run in bash on every OS so the working directory and tooling are
+      # consistent. Go on the Windows runner writes coverage.out with CRLF line
+      # endings, which Codecov's parser rejects (the upload lands in an ERROR
+      # state and never merges), so strip CR in the same step. tr is identical
+      # on GNU/BSD/Git-bash; the strip is a no-op on Linux/macOS.
+      - name: Run tests with coverage
+        shell: bash
         run: |
-          # hadolint
-          curl -sL https://github.com/hadolint/hadolint/releases/download/v2.12.0/hadolint-Linux-x86_64 -o /usr/local/bin/hadolint
-          chmod +x /usr/local/bin/hadolint
-          hadolint --version
-          # trivy
-          curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-          trivy --version
-      - name: Run tests with race detection and coverage (Linux)
-        if: runner.os == 'Linux'
-        run: go test -race -coverprofile=coverage.out -covermode=atomic -v ./...
-      - name: Run tests with race detection (macOS)
-        if: runner.os == 'macOS'
-        run: go test -race -v ./...
-      - name: Run tests (Windows)
-        if: runner.os == 'Windows'
-        run: go test -v ./...
-      - name: Display coverage summary
-        if: runner.os == 'Linux'
-        run: go tool cover -func=coverage.out
+          go test ./... -v -coverprofile=coverage.out -covermode=atomic
+          tr -d '\r' < coverage.out > coverage.tmp && mv coverage.tmp coverage.out
+      # Upload per-OS coverage so Codecov merges all three legs. Much of the
+      # PowerShell/launcher/keychain code is Windows-only, so a Linux-only
+      # report understates true coverage; merging the OS matrix reflects it.
+      # use_pypi: true — install CLI from PyPI instead of cli.codecov.io so we
+      # skip native-binary GPG verification (fails with "Could not verify
+      # signature" when key import is empty; codecov/codecov-action#1876).
       - name: Upload coverage to Codecov
-        # Linux leg only (it produces coverage.out); skip forks (OIDC tokens
-        # aren't issued to forked-repo runs).
-        if: runner.os == 'Linux' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v7.0.0
         with:
           use_oidc: true
+          use_pypi: true
           files: ./coverage.out
-          # false: this step runs inside the required Test (ubuntu-latest) check,
-          # so a Codecov/OIDC/network outage must NOT fail the test leg and block
-          # merges. Coverage is informational; infra flakiness shouldn't gate PRs.
-          fail_ci_if_error: false
-      # PR jobs must not receive the Codacy repository token. Save the report;
-      # a trusted workflow_run workflow downloads this artifact and uploads it.
+          fail_ci_if_error: ${{ matrix.os != 'windows-latest' }}
+      # Codacy coverage is uploaded by the trusted workflow_run workflow.
+      # Keeping the report in an artifact lets Dependabot PRs provide coverage
+      # without making the repository API token available to PR code.
       - name: Save coverage for Codacy
-        if: ${{ !cancelled() && runner.os == 'Linux' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
         with:
-          name: codacy-coverage-${{ github.run_id }}
+          name: codacy-coverage-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage.out
           if-no-files-found: error
 

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -22,7 +22,7 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
         continue-on-error: true
         with:
-          name: codacy-coverage-${{ github.event.workflow_run.id }}
+          name: codacy-coverage-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}
           path: coverage
           github-token: ${{ secrets.GITHUB_TOKEN }}
           run-id: ${{ github.event.workflow_run.id }}

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -32,9 +32,7 @@ jobs:
         env:
           CODACY_COMMIT_UUID: ${{ github.event.workflow_run.head_sha }}
         with:
-          # Prefer the standard name; fall back to the legacy CODACY_PROJECT_TOKEN
-          # secret until it is renamed in repo settings.
-          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN || secrets.CODACY_PROJECT_TOKEN }}
+          project-token: ${{ secrets.CODACY_REPOSITORY_API_TOKEN }}
           coverage-reports: coverage/coverage.out
           force-coverage-parser: go
           language: Go


### PR DESCRIPTION
Align the test/coverage pipeline with juggernaut's proven Codacy integration pattern.

**Changes:**
- Run coverage on all 3 OS platforms (was Linux-only) so Codecov merges cross-platform coverage
- Upload per-OS coverage to Codecov with use_pypi: true (avoids GPG verification failures)
- Add fail-fast: false to test matrix so one leg failing doesn't cancel the others' coverage uploads
- Strip CRLF from Windows coverage.out (Codecov parser rejects it)
- Align Codacy artifact naming with run_attempt suffix in both ci.yml and codacy-coverage.yml
- Remove stale hadolint/trivy install from test step (trivy has its own job; ludus has no Dockerfiles)

**Why:** Ludus Codacy coverage was incomplete — only Linux coverage was uploaded, understating true coverage. Juggernaut's pattern of per-OS coverage plus merge gives accurate cross-platform coverage to both Codecov and Codacy.