### PR TITLE
ci: bump upload-artifact to v7.0.1 and download-artifact to v8.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -113,7 +113,7 @@ jobs:
       # without making the repository API token available to PR code.
       - name: Save coverage for Codacy
         if: ${{ !cancelled() && matrix.os == 'ubuntu-latest' }}
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4.6.2
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7.0.1
         with:
           name: codacy-coverage-${{ github.run_id }}-${{ github.run_attempt }}
           path: coverage.out

--- a/.github/workflows/codacy-coverage.yml
+++ b/.github/workflows/codacy-coverage.yml
@@ -19,7 +19,7 @@ jobs:
       # This workflow intentionally does not check out or execute the PR
       # revision. The only input from it is the coverage report artifact.
       - name: Download coverage report
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093  # v4.3.0
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         continue-on-error: true
         with:
           name: codacy-coverage-${{ github.event.workflow_run.id }}-${{ github.event.workflow_run.run_attempt }}


### PR DESCRIPTION
Combines #490 (`upload-artifact` 4.6.2 → 7.0.1) and #489 (`download-artifact` 4.3.0 → 8.0.1).

## Why combined

These two are a **coupled pair**. `codacy-coverage.yml` is a `workflow_run` workflow, so it always executes **main's** downloader against an artifact produced by the **PR's** uploader. Merging them separately opens a window where a v4 downloader reads a v7 upload (or vice versa) on every PR until the second one lands. One commit closes that window.

## Compatibility review

Both are cross-major, so I checked each breaking change against how we actually use them:

| Change | Impact here |
| --- | --- |
| v6: Node 24, requires runner ≥ 2.327.1 | Safe — all jobs are GitHub-hosted; repo has no self-hosted runners |
| v7 upload: opt-in direct/unzipped upload (`archive: false`) | Safe — we don't set it, so the artifact stays zipped and `name` is still honored |
| v8 download: skips unzip based on `Content-Type` | Safe — matches the zipped upload above; `skip-decompress` left at default |
| v8 download: `digest-mismatch` now defaults to `error` (was warn) | **Desirable** — this artifact crosses a trust boundary into a token-bearing workflow. The step is already `continue-on-error: true` and the Codacy upload is `hashFiles`-gated, so a mismatch degrades coverage reporting without failing CI |

Only `actions/upload-artifact` and `actions/download-artifact` are affected; `grep` confirms no other workflow, and no generated workflow template in `internal/ci`, references either action.

## Test plan

- [ ] 6 required checks pass (Build/Lint/Test × ubuntu+windows)
- [ ] `Save coverage for Codacy` step uploads successfully under v7
- [ ] After merge: confirm the `Codacy Coverage` `workflow_run` on main downloads the artifact under v8 and uploads coverage without a digest mismatch

Supersedes #489 and #490.