### PR TITLE
ci: group Dependabot updates by upstream release

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,4 +1,30 @@
 version: 2
+
+# Grouping rationale
+#
+# Ungrouped, a single upstream release fans out into one PR per module. Because
+# `main` requires strict status checks (a PR must be up-to-date with main), each
+# merge invalidates every sibling PR — so N related bumps cost N rebase + full-CI
+# cycles, and the go.sum ones conflict with each other on top of that.
+#
+# Worse, some bumps are only correct *together*. Two such couplings are known:
+#
+#   1. github/codeql-action — init and analyze share a release SHA and must run
+#      the same version. Bumping one alone fails every Analyze job with
+#      "Loaded a configuration file for version X, but running version Y".
+#   2. actions/upload-artifact + actions/download-artifact — codacy-coverage.yml
+#      is a workflow_run workflow, so it runs main's downloader against an
+#      artifact produced by the PR's uploader. A split bump leaves every PR
+#      reading an artifact written by a different major version.
+#
+# Both couplings hold across major versions, so those two groups deliberately
+# include `major` in update-types. Everything else keeps majors ungrouped so an
+# API break stays individually reviewable.
+#
+# Groups apply to version updates only (`applies-to` defaults to
+# version-updates), so security updates still arrive as individual PRs and can
+# be fast-tracked.
+
 updates:
   - package-ecosystem: gomod
     directory: /
@@ -6,9 +32,49 @@ updates:
       interval: weekly
     commit-message:
       prefix: "deps"
+    groups:
+      # One aws-sdk-go-v2 release touches the shared core (aws-sdk-go-v2 +
+      # smithy-go) plus every service and internal module pinned here — 23
+      # modules today. They must resolve to one consistent set.
+      aws-sdk:
+        patterns:
+          - "github.com/aws/*"
+        update-types:
+          - minor
+          - patch
+
   - package-ecosystem: github-actions
     directory: /
     schedule:
       interval: weekly
     commit-message:
       prefix: "ci"
+    groups:
+      # Coupling 1: must move in lockstep, including across majors.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
+        update-types:
+          - major
+          - minor
+          - patch
+      # Coupling 2: must move in lockstep, including across majors.
+      artifact-actions:
+        patterns:
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
+        update-types:
+          - major
+          - minor
+          - patch
+      # Everything else: bundle routine minor/patch noise, leave majors alone.
+      actions:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "github/codeql-action*"
+          - "actions/upload-artifact"
+          - "actions/download-artifact"
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
Follow-up to the 2026-07 Dependabot batch, which arrived as **10 PRs for 4 logical upgrades**. `.github/dependabot.yml` had no `groups:` config, so one upstream release fanned out into one PR per module.

## Why this is more than churn

With `strict_required_status_checks_policy` on `main`, each merge invalidates every sibling PR — so N related bumps cost N rebase + full-CI cycles, and the `go.mod` ones conflict with each other on top of that.

Two of the couplings were **correctness** issues, both found by CI during that batch:

1. **`github/codeql-action`** — `init` and `analyze` share a release SHA and must run the same version. #488 bumped `init` alone and every Analyze job failed:
   ```
   Loaded a configuration file for version '4.37.3', but running version '4.37.1'
   ```
   Either half merged alone breaks CodeQL on main.

2. **`actions/upload-artifact` + `actions/download-artifact`** — `codacy-coverage.yml` is a `workflow_run` workflow, so it runs **main's** downloader against an artifact produced by the **PR's** uploader. A split bump leaves every PR reading an artifact written by a different major version.

Those two groups include `major` in `update-types`, because the coupling holds across majors. Every other group is `minor`/`patch` only, so an API-breaking major still arrives as its own reviewable PR.

Groups apply to version updates only (`applies-to` defaults to `version-updates`), so **security updates keep arriving as individual PRs** and can still be fast-tracked.

## Resulting groups

| Ecosystem | Group | Matches | Majors grouped |
| --- | --- | --- | --- |
| gomod | `aws-sdk` | all 23 `github.com/aws/*` (core + smithy-go + services + internals) | no |
| github-actions | `codeql-action` | `init`, `analyze` | **yes** (coupled) |
| github-actions | `artifact-actions` | `upload-artifact`, `download-artifact` | **yes** (coupled) |
| github-actions | `actions` | the other 11 actions | no |

## Test plan

Dependabot config changes can't be exercised by CI, so I verified the patterns against Dependabot's **actual** matcher rather than assuming glob semantics:

- [x] YAML parses; group keys resolve as intended
- [x] Confirmed `WildcardMatcher` ([`common/lib/wildcard_matcher.rb`](https://github.com/dependabot/dependabot-core/blob/main/common/lib/wildcard_matcher.rb)) compiles `*` to `.*` — **not** `fnmatch`, so it crosses `/` in nested module paths. This is what makes `github.com/aws/*` match `.../service/s3`; had it been slash-aware, the group would have silently matched nothing.
- [x] Replayed that matcher against the real dependency names: **23/23** AWS modules matched; both couplings route to their own groups; remaining 11 actions fall through to the catch-all with no overlap and no orphans
- [x] Confirmed `applies-to` defaults to `version-updates`, so security updates stay individual
- [ ] Next weekly Dependabot run opens grouped PRs (observable only after merge)

## Note

No CI check exercises this file, so the last item can only be confirmed on the next weekly run. If a pattern is wrong, the failure mode is benign — ungrouped PRs, i.e. today's behavior — not a broken pipeline.