### PR TITLE
docs: record Codacy coverage denominator probe and baseline command

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,9 +92,10 @@ jobs:
             go test ./... -v -race -coverprofile=coverage.out -covermode=atomic
           fi
           tr -d '\r' < coverage.out > coverage.tmp && mv coverage.tmp coverage.out
-      # Upload per-OS coverage so Codecov merges all three legs. Much of the
-      # PowerShell/launcher/keychain code is Windows-only, so a Linux-only
-      # report understates true coverage; merging the OS matrix reflects it.
+      # Upload per-OS coverage so Codecov merges all three legs. Prereq checks,
+      # engine builders, and process control have Windows-only implementations,
+      # so a Linux-only report covers a different file set; merging the OS
+      # matrix reflects the true total.
       # use_pypi: true — install CLI from PyPI instead of cli.codecov.io so we
       # skip native-binary GPG verification (fails with "Could not verify
       # signature" when key import is empty; codecov/codecov-action#1876).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -26,6 +26,12 @@ go test -v ./internal/toolchain
 # Test (single test)
 go test -v -run TestParseBuildVersion ./internal/toolchain
 
+# Coverage baseline (use this exact command so numbers are comparable across runs)
+go test -coverprofile=.tmp/cover.out -covermode=atomic ./... && go tool cover -func=.tmp/cover.out | tail -1
+
+# Per-package coverage for a subset
+go tool cover -func=.tmp/cover.out | rg "cmd/pipeline|cmd/engine|cmd/game|cmd/mcp"
+
 # Static analysis
 go vet ./...
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,6 +16,9 @@ go test -v ./internal/toolchain                                      # Single pa
 go test -v -run TestParseBuildVersion ./internal/toolchain           # Single test
 go vet ./...                                                         # Static analysis
 go mod tidy                                                          # Clean up module deps
+
+# Coverage baseline — use this exact command so numbers stay comparable run to run
+go test -coverprofile=.tmp/cover.out -covermode=atomic ./... && go tool cover -func=.tmp/cover.out | tail -1
 ```
 
 Git hooks live in `.hooks/`. Activate: `git config core.hooksPath .hooks`. `pre-commit` runs build + lint + tests; `commit-msg` enforces Conventional Commits; `pre-push` fails if a changed Go function has 0% test coverage (early warning only — CI's Codecov patch gate is the real authority, and `--no-verify` bypasses it locally).
@@ -24,9 +27,13 @@ CI runs 6 required checks on PRs: Build (ubuntu/windows), Lint (ubuntu/windows),
 
 `main` is protected by a repo **ruleset** (not classic branch protection — `gh api repos/.../branches/main/protection` 404s; use `gh api repos/.../rules/branches/main`). It requires the 6 checks above to pass, all review threads resolved (incl. bot reviewers — Codacy, Octopus, Codex/chatgpt-codex-connector), and `strict_required_status_checks_policy: true` (a PR must be up-to-date with `main` — `gh pr update-branch` when `mergeStateStatus` is `BEHIND`). A required check occasionally re-enters `pending` after first going green, briefly showing `BLOCKED`; re-watch and retry rather than assuming failure.
 
-### Coverage (Codecov)
+### Coverage (Codecov + Codacy)
 
-Coverage is uploaded from the ubuntu test leg via **OIDC** (`use_oidc: true`, `fail_ci_if_error: false` — a Codecov/network outage must never fail the test leg). Config in `codecov.yml`: **patch coverage is enforced** (`informational: false`, target 80%) — new/changed lines under 80% post a failing `codecov/patch` status (visible red). It is intentionally a *soft* block (not in the required-checks ruleset) so a skipped upload can't deadlock a PR; self-police on the red, merge past it with judgment when new code is genuinely E2E-territory. Project/component coverage stays informational (whole-repo ~41%, much of it I/O-bound).
+Coverage is uploaded to **Codecov from all three test legs** (ubuntu/macos/windows) via **OIDC** (`use_oidc: true`, `fail_ci_if_error: false` — a Codecov/network outage must never fail the test leg), and to **Codacy from the ubuntu leg only** (artifact → `codacy-coverage.yml` `workflow_run`). Config in `codecov.yml`: **patch coverage is enforced** (`informational: false`, target 80%) — new/changed lines under 80% post a failing `codecov/patch` status (visible red). It is intentionally a *soft* block (not in the required-checks ruleset) so a skipped upload can't deadlock a PR; self-police on the red, merge past it with judgment when new code is genuinely E2E-territory. Project/component coverage stays informational.
+
+**Why ubuntu-only Codacy upload is fine (probed 2026-07-30, commit `31ee609`):** Codacy scores only the files present in the uploaded profile. Windows/darwin-only files (`checker_windows.go`, `builder_windows.go`, `jobs_darwin.go`, …) appear in Codacy's file tree with an **empty** coverage object — not 0% — so they are excluded from the coverage denominator rather than dragging it down. Codacy reported **60.01%** against a local Windows-host profile of 58.5% and Codecov's 3-OS merged 60.2%; the three agree within ~1.7pt. A multi-OS Codacy upload would therefore buy honest multi-OS totals, not free percentage points — it is deliberately **not** implemented.
+
+**Wrapper policy: ignored in Codecov, scored in Codacy.** `codecov.yml` ignores `internal/wrapper/**` (separate PID-1 binary, E2E-covered); Codacy has no repo-side coverage-exclusion mechanism (`.codacy.yml` `exclude_paths` governs *analysis*, not coverage math), so `internal/wrapper/wrapper.go` shows at 28.47% there. The delta is ~0.4pt (58.5% → 58.9% locally when wrapper lines are filtered out) and is accepted rather than papered over by mislabeling `.codacy.yml`.
 
 ## Architecture
 


### PR DESCRIPTION
Phase 0 of the test-coverage plan (`docs/superpowers/plans/2026-07-29-test-coverage-to-100.md`). Measurement and documentation only — no test code, no production code.

## Task 0.0 — Codacy denominator probe (the point of this phase)

The plan hypothesized that the ubuntu-only Codacy coverage upload understates coverage by ~3–4 points, because Go's coverprofile only lists files compiled on that OS. **The probe falsifies that.**

Probed `jpvelasco/ludus` @ `31ee609` (main) via the Codacy v3 API, enumerating all 394 analyzed files:

| Probe | Result |
|---|---|
| `internal/prereq/checker_windows.go` | **Listed**, `coverage: {}` (empty — not 0%) |
| `internal/engine/builder_windows.go` | **Listed**, `coverage: {}` |
| `internal/anywhere/process_windows.go` | **Listed**, `coverage: {}` |
| `internal/game/sysenv_windows.go` | **Listed**, `coverage: {}` |
| `internal/game/jobs_darwin.go`, `internal/prereq/checker_darwin.go` | **Listed**, `coverage: {}` |
| `internal/anywhere/process_unix.go` (compiled on Linux) | Listed, `totalCoverage: 75.9` |
| `internal/wrapper/wrapper.go` | **Listed**, `totalCoverage: 28.47` |

Of 181 non-test `.go` files in Codacy's tree, 164 carry coverage data and 17 have an empty coverage object — 11 of those 17 are platform-suffixed (`_windows`/`_darwin`/`_unix`).

**Conclusion:** Codacy scores only files present in the uploaded profile. Files not compiled on Linux are *excluded from the denominator*, not counted as 0%. The three numbers agree within ~1.7pt:

| Source | Coverage |
|---|---|
| Codacy (ubuntu-only upload), main | **60.01%** |
| Codecov (3-OS merged), same commit | **60.2%** |
| Local `go test` (Windows host) | **58.5%** |

## Task 0.1 — multi-OS Codacy upload: NOT implemented

The probe shows no denominator inflation, so a multi-OS upload would buy honest multi-OS totals, not free percentage points. Per the plan's own instruction ("do not sell it as pure measurement win", "do not block Phase 1"), this is deliberately skipped and the reasoning recorded in CLAUDE.md. Also per the plan's fallback: Windows-only paths were **not** stuffed into `.codacy.yml` `exclude_paths` — that file governs analysis (Lizard etc.), not coverage math.

## Task 0.2 — wrapper policy: A, with the residual documented

Policy A (keep wrapper out of unit-coverage expectations; it is E2E territory). Codecov ignores `internal/wrapper/**`. Codacy has **no repo-side coverage-exclusion mechanism** — `.codacy.yml` `exclude_paths` does not affect coverage math — so `wrapper.go` shows at 28.47% there. Measured residual: filtering wrapper lines out of the local profile moves 58.5% → 58.9%, i.e. **~0.4pt**. Accepted and documented rather than papered over by mislabeling `.codacy.yml`.

## Task 0.3 — baseline command documented

Added to both CLAUDE.md and AGENTS.md:

\`\`\`bash
go test -coverprofile=.tmp/cover.out -covermode=atomic ./... && go tool cover -func=.tmp/cover.out | tail -1
\`\`\`

## Drive-by fix

The `ci.yml` comment justifying the 3-OS Codecov upload described "PowerShell/launcher/keychain code" — code from a different project. Replaced with an accurate description (prereq checks, engine builders, process control).

## Verification

| Gate | Result |
|---|---|
| \`go build -o ludus.exe -v .\` | pass |
| \`go test ./...\` | pass |
| \`golangci-lint run ./...\` | **0 issues** |
| Coverage total (Windows host) | **58.5%** — unchanged, no test code in this PR |
| gocyclo -over 8 | n/a (no test files touched) |
| Network/daemon-free | yes (probe was a read-only API query, not a test) |

## Phase 0 exit checklist

- [x] Task 0.0 probe result recorded in PR body (Windows files **listed but empty**, wrapper **listed at 28.47%**)
- [x] Multi-OS Codacy upload not shipped; residual delta explained instead
- [x] Wrapper policy A chosen; applied on Codecov, residual documented for Codacy
- [x] Baseline cover command documented in CLAUDE.md **and** AGENTS.md
- [x] Universal PR gate green
- [x] No new test code required for this phase (measurement/config only)