### PR TITLE
docs: reconcile and expand agent-facing guidance in CLAUDE.md and AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This guide provides essential context for AI agents working with Ludus, a CLI tool that automates the end-to-end pipeline for building Unreal Engine 5 dedicated servers and deploying them to AWS GameLift, GameLift Anywhere, managed EC2 fleets, CloudFormation stacks, or binary output.
 
+See also [CLAUDE.md](CLAUDE.md) for the detailed architecture, CI, coverage, and release reference, and [ARCHITECTURE.md](ARCHITECTURE.md) for the module map. This file is the compact agent-facing guide; keep it short and reconcile it with CLAUDE.md when the two drift.
+
 ## Build, Test & Lint
 
 ```bash
@@ -42,14 +44,17 @@ go mod tidy
 .hooks/pre-commit
 ```
 
+Git hooks live in `.hooks/` — activate with `git config core.hooksPath .hooks`. `pre-commit` runs build + lint + tests (falls back to `go vet` when golangci-lint is blocked), `commit-msg` enforces Conventional Commits, and `pre-push` fails if a changed Go function has 0% coverage (early warning only — CI's Codecov patch gate is the real authority).
+
 ## Key Project Structure
 
 - `main.go` → `cmd/root/root.go` → subcommand packages in `cmd/`
+- `cmd/root/init.go` — the `init` command lives here, not in a separate `cmd/init/` package
 - `cmd/globals/globals.go` — shared mutable state (`Cfg`, `Verbose`, `DryRun`, `JSONOutput`, `Profile`)
 - `cmd/mcp/` — MCP server with 26 tools for AI orchestration
 - `internal/` — all business logic (unexported); most files stay close to one primary type, but some packages are deliberately split across sibling files by concern when complexity gets too high
 - Platform-specific files: `_windows.go` / `_unix.go` with `//go:build` tags
-- Current top-level command areas include `buildgraph`, `ci`, `config`, `connect`, `container`, `ddc`, `deploy`, `doctor`, `engine`, `game`, `logs`, `mcp`, `resources`, `setup`, and `status`
+- Top-level commands (registered in `cmd/root/root.go`): `buildgraph`, `ci`, `config` (`cmd/configcmd/`, `get`/`set` only via dot-notation keys — no `view`), `connect`, `container`, `ddc`, `deploy`, `doctor`, `engine`, `game`, `logs`, `mcp`, `pipeline` (`run`), `resources`, `setup`, `status`
 
 ## Critical Features to Understand
 
@@ -71,6 +76,10 @@ go mod tidy
 - `--ddc local` (legacy FileSystem cache, deprecated — recommend `zen`)
 - `--ddc none` (disabled)
 
+### Deploy Targets
+- Five targets implement `deploy.Target` (`internal/deploy/target.go`): `gamelift` (default/empty), `stack`, `ec2`, `anywhere`, `binary`. Factory switch in `cmd/globals/resolve.go`; `ResolveSessionTarget` falls back to the target recorded in state.
+- The pipeline checks `target.Capabilities()` (`NeedsContainerBuild`, `SupportsSession`, etc.) to skip irrelevant stages — e.g. `anywhere` and `ec2` skip container build.
+
 ### Observability & Privacy
 - Build logs are written to `.ludus/logs/` by default with retention configured under `observability.logs`
 - Optional OpenTelemetry export is configured under `observability.otlp` and honors standard `OTEL_*` environment variables
@@ -78,17 +87,20 @@ go mod tidy
 
 ### Coverage
 
-- Coverage is uploaded to Codecov from the ubuntu test leg via OIDC.
+- Coverage is uploaded to Codecov from **all three test legs** (ubuntu/macos/windows) via OIDC (`use_oidc: true`, `fail_ci_if_error: false`); ubuntu/macos add `-race`. Windows coverage profiles are CRLF-stripped before upload — Codecov's parser rejects CRLF and the upload silently lands in ERROR state. `fail-fast: false` so one failing leg can't cancel the others' uploads.
+- Codacy gets its own coverage upload from the ubuntu leg only, via a `workflow_run` (`codacy-coverage.yml`) that never checks out the PR revision, so PR code never sees `CODACY_REPOSITORY_API_TOKEN`. This is deliberate: Codacy scores only files in the uploaded profile, so Windows/darwin-only files get empty (excluded) rather than 0% coverage.
+- `internal/wrapper/**` is ignored in Codecov but scored in Codacy (~28%) — a separate PID-1 binary that is E2E-covered; accepted, not papered over.
 - Patch coverage is enforced at 80% in `codecov.yml`; new or changed lines under that threshold post a failing `codecov/patch` status.
 - It is a soft block, not a required check, so genuinely E2E-only code can still merge with judgment.
 
 ## Development Environment
 
-- Go 1.25.12 required (see `go.mod`; CI follows it)
+- Go 1.25.12 required (see `go.mod`; CI follows it via `go-version-file`)
+- Supported engine versions: UE 5.4–5.8 (`toolchainMap` in `internal/toolchain/toolchain.go`; 5.7 and 5.8 share the v26 toolchain)
 - Linux or Windows with Docker/Podman for container builds
 - macOS with Docker/Podman for container builds only
 - AWS CLI v2 configured with credentials
-- UE5 source with Lyra game assets (must be downloaded manually); README currently documents UE 5.8 support
+- UE5 source with Lyra game assets (must be downloaded manually)
 - 16+ GB RAM recommended (UE5 compilation is memory-hungry)
 - 300+ GB disk space for native engine builds; container engine builds can need roughly 2 TB because UE images are very large
 
@@ -127,6 +139,7 @@ The MCP server is started with `ludus mcp` and exposes 26 tools for AI orchestra
 - All tests use Go standard library only.
 - Prefer table-driven tests with `tt` as the loop variable, and keep tests in the same package when they need unexported symbols.
 - Use `t.TempDir()` for temporary directories, `t.Setenv()` for environment variable overrides, and `t.Chdir()` for working directory changes.
+- Shared test infra — use it instead of rebuilding fixtures: `internal/testsupport/` (`FakeEngineTree`, `FakeProject`, `FakeTool`/`FakeTools` PATH-injected stubs, `RecordingRunner`) and `cmd/globals/testing.go` (`SetGlobals`, `SwapResolveTarget`). Dry-run works as a test seam; AWS HTTP stubbing does not — inject a narrow API interface instead.
 - AWS/Docker/`wsl.exe`/subprocess-bound code (`gamelift`, `ec2fleet`, `stack`, `wrapper`, `wsl`, and most deploy logic) is E2E-covered; unit tests there should cover only the pure surface such as adapter `Name`/`Capabilities`, argument assembly, and parameter parsing.
 - Keep each test function under cyclomatic complexity 8. Codacy's Lizard check counts test files and fails PRs otherwise; convert flat assertion chains to map/table loops and extract `t.Run` bodies into named helpers. Verify with `go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 <file>` printing nothing.
 - Codacy also tracks NLOC and parameter-count patterns; keep helpers small, avoid broad fixture builders, and do not hide test files from analysis.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,7 @@ go build -o ludus.exe -v .                                          # Build (Win
 go build -o ludus -v .                                               # Build (Linux/macOS)
 golangci-lint run ./...                                              # Lint (v2 required; CI uses golangci-lint-action v9)
 go test ./...                                                        # All tests
-go test -race ./...                                                  # All tests with race detector (Linux only)
+go test -race ./...                                                  # All tests with race detector (Linux/macOS only)
 go test -v ./internal/toolchain                                      # Single package
 go test -v -run TestParseBuildVersion ./internal/toolchain           # Single test
 go vet ./...                                                         # Static analysis
@@ -23,28 +23,49 @@ go test -coverprofile=.tmp/cover.out -covermode=atomic ./... && go tool cover -f
 
 Git hooks live in `.hooks/`. Activate: `git config core.hooksPath .hooks`. `pre-commit` runs build + lint + tests; `commit-msg` enforces Conventional Commits; `pre-push` fails if a changed Go function has 0% test coverage (early warning only — CI's Codecov patch gate is the real authority, and `--no-verify` bypasses it locally).
 
-CI runs 6 required checks on PRs: Build (ubuntu/windows), Lint (ubuntu/windows), Test (ubuntu/windows). Ubuntu and macOS tests run with `-race`; ubuntu also runs `-coverprofile` and uploads to Codecov. Windows tests skip race detection (needs CGO).
+### CI
 
-`main` is protected by a repo **ruleset** (not classic branch protection — `gh api repos/.../branches/main/protection` 404s; use `gh api repos/.../rules/branches/main`). It requires the 6 checks above to pass, all review threads resolved (incl. bot reviewers — Codacy, Octopus, Codex/chatgpt-codex-connector), and `strict_required_status_checks_policy: true` (a PR must be up-to-date with `main` — `gh pr update-branch` when `mergeStateStatus` is `BEHIND`). A required check occasionally re-enters `pending` after first going green, briefly showing `BLOCKED`; re-watch and retry rather than assuming failure.
+`.github/workflows/ci.yml` runs: Lint (ubuntu + windows), Build (ubuntu/windows/macos, each also `go vet`), Test (ubuntu/windows/macos), plus `govulncheck`, gosec, Trivy filesystem scan, a GoReleaser snapshot with a linux-binary smoke test, and Codacy Analysis CLI. Separate workflows: `codeql.yml`, `octopus.yml` (automated PR review), `socket.yml`, `codacy-coverage.yml`, `release.yml`.
+
+All three test legs run `-coverprofile -covermode=atomic` and upload to Codecov; ubuntu/macos add `-race` (Windows has no race detector without CGO). `fail-fast: false` on the test matrix so one failing leg can't cancel the others' coverage uploads. Windows coverage profiles are CRLF-stripped in the same step — Codecov's parser rejects CRLF and the upload silently lands in ERROR state.
+
+**Dependabot is grouped** (`.github/dependabot.yml`) so coupled upgrades land as one PR: `aws-sdk` (all `github.com/aws/*`, minor+patch — one SDK release touches the shared core plus ~23 pinned service modules that must resolve to one consistent set), `codeql-action` and `artifact-actions` (upload+download, both including majors — must move in lockstep), and a catch-all `actions` group for remaining minor/patch noise with majors left alone. Grouping applies to version updates only, so security advisories still arrive as individual fast-trackable PRs. When a grouped Dependabot PR conflicts after another merges, comment `@dependabot rebase` rather than resolving by hand.
+
+Only **6 of those checks are required** by the ruleset: Build (ubuntu/windows), Lint (ubuntu/windows), Test (ubuntu/windows). macOS legs, security scanners, and Codacy/Codecov are soft — they inform, they don't gate.
+
+`main` is protected by the `protect-main` repo **ruleset** (not classic branch protection — `gh api repos/.../branches/main/protection` 404s; use `gh api repos/.../rules/branches/main`, or `gh api repos/.../rulesets` to list both rulesets). It requires the 6 checks above, all review threads resolved (`required_review_thread_resolution: true` — incl. bot reviewers: Codacy, Octopus, Codex/chatgpt-codex-connector), and `strict_required_status_checks_policy: true` (a PR must be up-to-date with `main` — `gh pr update-branch` when `mergeStateStatus` is `BEHIND`). Deletion and non-fast-forward are blocked; `required_approving_review_count: 0`, so review resolution rather than approval count is the human gate. A required check occasionally re-enters `pending` after first going green, briefly showing `BLOCKED`; re-watch and retry rather than assuming failure.
 
 ### Coverage (Codecov + Codacy)
 
-Coverage is uploaded to **Codecov from all three test legs** (ubuntu/macos/windows) via **OIDC** (`use_oidc: true`, `fail_ci_if_error: false` — a Codecov/network outage must never fail the test leg), and to **Codacy from the ubuntu leg only** (artifact → `codacy-coverage.yml` `workflow_run`). Config in `codecov.yml`: **patch coverage is enforced** (`informational: false`, target 80%) — new/changed lines under 80% post a failing `codecov/patch` status (visible red). It is intentionally a *soft* block (not in the required-checks ruleset) so a skipped upload can't deadlock a PR; self-police on the red, merge past it with judgment when new code is genuinely E2E-territory. Project/component coverage stays informational.
+Coverage is uploaded to **Codecov from all three test legs** (ubuntu/macos/windows) via **OIDC** (`use_oidc: true`, `use_pypi: true` to skip broken native-binary GPG verification, `fail_ci_if_error: false` — a Codecov/network outage must never fail the test leg), and to **Codacy from the ubuntu leg only** (artifact → `codacy-coverage.yml` `workflow_run`, which deliberately never checks out or executes the PR revision, so PR code never sees `CODACY_REPOSITORY_API_TOKEN`).
 
-**Why ubuntu-only Codacy upload is fine (probed 2026-07-30, commit `31ee609`):** Codacy scores only the files present in the uploaded profile. Windows/darwin-only files (`checker_windows.go`, `builder_windows.go`, `jobs_darwin.go`, …) appear in Codacy's file tree with an **empty** coverage object — not 0% — so they are excluded from the coverage denominator rather than dragging it down. Codacy reported **60.01%** against a local Windows-host profile of 58.5% and Codecov's 3-OS merged 60.2%; the three agree within ~1.7pt. A multi-OS Codacy upload would therefore buy honest multi-OS totals, not free percentage points — it is deliberately **not** implemented.
+`codecov.yml`: **patch coverage is enforced** (`informational: false`, target 80%) — new/changed lines under 80% post a failing `codecov/patch` status (visible red). It is intentionally a *soft* block (not in the required-checks ruleset) so a skipped upload can't deadlock a PR; self-police on the red, merge past it with judgment when new code is genuinely E2E-territory. Project status is informational with a 1% drift threshold. Two virtual components split the dashboard by layer: `cmd (CLI layer)` and `internal (core)`, both informational.
 
-**Wrapper policy: ignored in Codecov, scored in Codacy.** `codecov.yml` ignores `internal/wrapper/**` (separate PID-1 binary, E2E-covered); Codacy has no repo-side coverage-exclusion mechanism (`.codacy.yml` `exclude_paths` governs *analysis*, not coverage math), so `internal/wrapper/wrapper.go` shows at 28.47% there. The delta is ~0.4pt (58.5% → 58.9% locally when wrapper lines are filtered out) and is accepted rather than papered over by mislabeling `.codacy.yml`.
+**Current baseline (probed 2026-08-02, commit `d18680f`):**
+
+| Source | Coverage | Scope |
+|---|---|---|
+| Local `go test` (Windows host) | 67.0% | single-OS, includes wrapper |
+| Local, wrapper lines filtered out | 67.5% | approximates Codecov's `ignore` |
+| Codecov | 67.28% | 3-OS merged, `internal/wrapper/**` ignored |
+| Codacy | 67.85% | ubuntu-only profile, wrapper scored |
+
+All four agree within ~0.9pt. Coverage jumped from the 58–60% band after #506/#507 added shared test infrastructure and MCP handler tests.
+
+**Why ubuntu-only Codacy upload is fine:** Codacy scores only the files present in the uploaded profile. Windows/darwin-only files (`checker_windows.go`, `builder_windows.go`, `jobs_darwin.go`, …) appear in Codacy's file tree with an **empty** coverage object — not 0% — so they are excluded from the coverage denominator rather than dragging it down. A multi-OS Codacy upload would therefore buy honest multi-OS totals, not free percentage points — it is deliberately **not** implemented.
+
+**Wrapper policy: ignored in Codecov, scored in Codacy.** `codecov.yml` ignores `internal/wrapper/**` (separate PID-1 binary, E2E-covered); Codacy has no repo-side coverage-exclusion mechanism (`.codacy.yml` `exclude_paths` governs *analysis*, not coverage math), so `internal/wrapper` shows at ~28% there. That is accepted rather than papered over by mislabeling `.codacy.yml`. Note the sign of the Codacy/Codecov gap is **not stable** and shouldn't be relied on: at 58–60% Codacy read ~1.5pt *below* Codecov, and it now reads ~0.6pt *above*. Treat the two as agreeing within ~2pt, and re-probe rather than assuming a fixed offset.
 
 ## Architecture
 
-Go CLI (Cobra + Viper) that orchestrates UE5 dedicated server deployment to AWS GameLift, GameLift Anywhere, managed EC2 fleets, CloudFormation stacks, or binary output. Module: `github.com/jpvelasco/ludus`, Go 1.25.12 (see `go.mod`; CI follows it).
+Go CLI (Cobra + Viper) that orchestrates UE5 dedicated server deployment to AWS GameLift, GameLift Anywhere, managed EC2 fleets, CloudFormation stacks, or binary output. Module: `github.com/jpvelasco/ludus`, Go 1.25.12 (see `go.mod`; CI follows it via `go-version-file`). Supported engine versions: **UE 5.4–5.8** (`toolchainMap` in `internal/toolchain/toolchain.go`; 5.7 and 5.8 share the v26 toolchain).
 
 ### Pipeline
 
-Six stages, independently runnable or chained via `ludus run`:
+Six conceptual stages, independently runnable or chained via `ludus run`:
 init → engine build → game build → container build → deploy → connect
 
-Not all stages run for every target — the pipeline checks `target.Capabilities()` and skips irrelevant stages (e.g. `anywhere` and `ec2` skip container build).
+`cmd/pipeline/pipeline.go` expands these into eight `pipelineStage` entries (validate, engine, server, optional client, container build, ECR push, deploy, optional session), each with a `skip` predicate. Not all stages run for every target — the pipeline checks `target.Capabilities()` (`NeedsContainerBuild`, `NeedsContainerPush`, `SupportsSession`, `SupportsDeploy`, `SupportsDestroy`) and skips irrelevant stages (e.g. `anywhere` and `ec2` skip container build).
 
 ### Code Organization
 
@@ -53,16 +74,18 @@ Not all stages run for every target — the pipeline checks `target.Capabilities
 - `cmd/root/init.go` — the `init` command lives here, not in a separate `cmd/init/` package
 - `internal/` — all business logic, one primary type per file, unexported packages
 
-Beyond the six pipeline stages, these top-level commands exist:
+Beyond the six pipeline stages, these top-level commands exist (all registered in `cmd/root/root.go`):
 - `ludus setup` (`cmd/setup/`) — interactive first-time wizard: scans system, auto-detects UE source/version, picks deploy target, writes `ludus.yaml` (`--profile` writes `ludus-<name>.yaml`).
-- `ludus config` (`cmd/configcmd/`) — `get`/`set`/`view` for `ludus.yaml` via dot-notation keys (e.g. `ludus config set engine.version 5.7.3`).
+- `ludus config` (`cmd/configcmd/`) — `get` / `set` only, via dot-notation keys (e.g. `ludus config set engine.version 5.7.3`). There is no `view` subcommand.
 - `ludus doctor` (`cmd/doctor/`) — deeper diagnostics than `init` (stale DLLs, toolchain mismatch, disk, partial build state, AWS credential expiry, cache integrity). Use when `init` passes but something is broken.
-- `ludus ci` (`cmd/ci/`, `internal/ci/`) — `ci init` generates a GitHub Actions workflow; `ci runner` manages a self-hosted runner agent.
-- `ludus logs` (`cmd/logs/`), `ludus resources` (`cmd/resources/`), `ludus ddc` (`cmd/ddc/`), `ludus buildgraph` (`cmd/buildgraph/`) — see their respective sections below.
+- `ludus ci` (`cmd/ci/`, `internal/ci/`) — `ci init` generates a GitHub Actions workflow; `ci runner install|status|uninstall` manages a self-hosted runner agent.
+- `ludus logs` (`cmd/logs/`) — `list`, `path`, `tail`.
+- `ludus ddc` (`cmd/ddc/`) — `status`, `clean`, `prune`, `warmup`.
+- `ludus resources` (`cmd/resources/`), `ludus buildgraph` (`cmd/buildgraph/`), `ludus status`, `ludus connect`, `ludus mcp`.
 
 ### Deploy Target System
 
-All backends implement `deploy.Target` interface (`internal/deploy/target.go`). Five targets: `gamelift`, `stack`, `ec2`, `anywhere`, `binary`. Factory in `cmd/globals/resolve.go` instantiates the correct target from config.
+All backends implement `deploy.Target` (`internal/deploy/target.go`). Five targets: `gamelift` (also the empty-string default), `stack`, `ec2`, `anywhere`, `binary`. Factory in `cmd/globals/resolve.go` instantiates the correct target from config; `ResolveSessionTarget` falls back to the target recorded in state when config doesn't name a session-capable one.
 
 To add a new deploy target:
 1. `internal/<pkg>/deployer.go` — implement the deployer
@@ -72,27 +95,29 @@ To add a new deploy target:
 5. `cmd/mcp/tools_deploy.go` — expose via MCP
 6. `internal/status/status.go` — add status check
 
-`cmd/resources/` lists all ludus-managed AWS resources, discovered by `ManagedBy=ludus` tag and known naming patterns (ECR repos, S3 build buckets) via `internal/inventory/`.
+`cmd/resources/` lists all ludus-managed AWS resources, discovered by `ManagedBy=ludus` tag (`internal/tags/`) and known naming patterns (ECR repos, S3 build buckets) via `internal/inventory/`. `internal/cleanup/` handles ECR image and S3 object teardown.
 
 ### Runner Abstraction
 
-All shell execution goes through `runner.Runner` (`internal/runner/runner.go`), never raw `exec.Command`. Handles `--verbose` output (`+ cmd args`), `--dry-run` (print without executing), and consistent error wrapping.
+All shell execution goes through `runner.Runner` (`internal/runner/runner.go`), never raw `exec.Command`. Handles `--verbose` output (`+ cmd args`), `--dry-run` (print without executing), and consistent error wrapping. Construct CLI runners via `globals.NewRunner()` so build-log teeing is wired in.
 
 Network-facing operations (Docker, AWS) wrap calls with `internal/retry/`: exponential backoff with jitter, configurable via a `Config` struct. Use `retry.Default()` for standard CLI retry behavior; pass a custom `Config` when you need different attempt counts or delays.
 
+`internal/progress/` prints a periodic elapsed-time ticker during long silent operations (used by engine and game builders — UE linking can go quiet for many minutes).
+
 ### DDC (Derived Data Cache)
 
-`internal/ddc/` manages UE5's Derived Data Cache — persistent shader/asset cache that survives Docker container lifecycles. Three modes: `zen` (default since v0.7.0 — the Unreal Zen Store, UE's default local backend since 5.4, applies to UE 5.4+), `local` (legacy FileSystem cache, **deprecated** — delete-only in UE since 5.4; `doctor`/`ddc status`/config load warn and recommend `zen`), and `none` (disabled). The package is split by concern: `ddc.go` (mode constants, `ValidateDDCMode` which maps `""` → `zen`, env/Zen-path constants), `paths.go` (path resolution), `size.go` (dir sizing), `ops.go` (clean/prune).
+`internal/ddc/` manages UE5's Derived Data Cache — persistent shader/asset cache that survives Docker container lifecycles. Three modes: `zen` (default since v0.7.0 — the Unreal Zen Store, UE's default local backend since 5.4, applies to all supported versions 5.4–5.8), `local` (legacy FileSystem cache, **deprecated** — delete-only in UE since 5.4; `doctor`/`ddc status`/config load surface `ddc.LocalModeDeprecationWarning` and recommend `zen`), and `none` (disabled). The package is split by concern: `ddc.go` (mode constants, `ValidateDDCMode` which maps `""` → `zen`, env/Zen-path constants), `paths.go` (path resolution), `size.go` (dir sizing), `ops.go` (clean/prune).
 
 Integration points live in `internal/dockerbuild/game_ddc.go` (mount-arg assembly) and `game_script.go` (build-script preamble): for `zen`, the host Zen directory (`ddc.zenPath`, default `~/.ludus/zen`) is bind-mounted to the container's fixed ZenStore data path (`ddc.ZenContainerPath` = `/home/ue/.config/Epic/UnrealEngine/Common/Zen/Data`); the preamble recursively chowns `/home/ue/.config` so `zenserver` (running as `ue`) can write it. For legacy `local`, the host DDC dir is mounted at `/ddc` and passed via `UE-LocalDataCachePath`.
 
-`ludus ddc` subcommands: `status`, `clean`, `prune`, `warmup`. Config in `ludus.yaml` under `ddc.mode` / `ddc.zenPath` / `ddc.localPath`, overridable via `--ddc` flag.
+Config in `ludus.yaml` under `ddc.mode` / `ddc.zenPath` / `ddc.localPath`, overridable via `--ddc` flag. `cmd/globals/ddc.go` resolves all three (`ResolveDDC`) — don't re-derive them at call sites.
 
 ### Build Observability
 
-`internal/buildlog/` tees build output to per-run log files under `.ludus/logs/` (project-local). All CLI runners are constructed via `globals.NewRunner()`, which lazily opens the run log on first use and tees stdout/stderr to it; MCP async builds get a per-build-id log via `syncBuffer.sink`. `ludus logs` subcommands: `list`, `path`, `tail`. Config under `observability.logs` (`enabled`/`dir`/`retainRuns`); `--no-logs` disables. Dry-run is never logged.
+`internal/buildlog/` tees build output to per-run log files under `.ludus/logs/` (project-local; `retention.go` prunes old runs). All CLI runners are constructed via `globals.NewRunner()`, which lazily opens the run log on first use and tees stdout/stderr to it; MCP async builds get a per-build-id log via `syncBuffer.sink`. Config under `observability.logs` (`enabled`/`dir`/`retainRuns`); `--no-logs` disables. Dry-run is never logged.
 
-`internal/tracing/` adds optional OpenTelemetry (OTLP) trace export — one span per pipeline stage under a `ludus.run` root span, wired in `cmd/pipeline/executeStages`. No-op with zero overhead unless `observability.otlp.enabled` (or standard `OTEL_*` env vars) is set. Initialized in root `PersistentPreRunE`, flushed in `Execute()`.
+`internal/tracing/` adds optional OpenTelemetry (OTLP) trace export — one span per pipeline stage under a `ludus.run` root span, wired in `cmd/pipeline/executeStages`. No-op with zero overhead unless `observability.otlp.enabled` (or standard `OTEL_*` env vars) is set. Initialized in root `PersistentPreRunE` via `globals.InitTracing`, flushed in `Execute()`.
 
 `internal/dflint/` lints Dockerfiles (hadolint) and scans the built image for vulnerabilities (trivy), surfaced via `ludus status`. Both tools degrade gracefully when not installed. Built-in rules live in `checks.go`; `lint.go` holds the result types and orchestration; `hadolint.go` / `trivy.go` wrap the external tools.
 
@@ -104,7 +129,7 @@ Several packages keep one concern per file rather than one giant file (Codacy's 
 
 ### MCP Server
 
-`cmd/mcp/` exposes 26 tools via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout). Long-running native/WSL2 engine and game builds have async `_start` variants returning build IDs, polled via `ludus_build_status`; container builds have no async variant yet.
+`cmd/mcp/` exposes **26 tools** via JSON-RPC over stdio. Registration in `cmd/mcp/register.go` delegates to eleven domain-specific `register*Tools()` functions. Stdout redirected to stderr (MCP protocol uses stdout), and root `PersistentPreRunE` skips both output masking and the DDC deprecation warning for `cmd.Name() == "mcp"`. Long-running native/WSL2 engine and game builds have async `_start` variants returning build IDs, polled via `ludus_build_status` (`tools_async.go` + `buildmgr.go`); container builds have no async variant yet. Full tool table in [README.md](README.md#available-tools).
 
 ### GameLift Wrapper
 
@@ -113,6 +138,8 @@ Several packages keep one concern per file rather than one giant file (Codacy's 
 ### Configuration Flow
 
 `ludus.yaml` → Viper → `config.Config` struct (loaded in `PersistentPreRunE`, stored in `globals.Cfg`) → CLI flags override → MCP params override → `internal/` logic consumes.
+
+Top-level config keys (`internal/config/config_types.go`): `engine`, `game`, `container`, `deploy`, `gamelift`, `ec2fleet`, `anywhere`, `aws`, `ci`, `ddc`, `observability`, `privacy`. `ludus.example.yaml` documents only the common subset — read `config_types.go` for the full surface. Engine version auto-detects from `Build.version` via `toolchain.ParseBuildVersion` when `engine.version` is unset.
 
 ### WSL2 Build Backend
 
@@ -124,25 +151,29 @@ Several packages keep one concern per file rather than one giant file (Codacy's 
 
 ### AWS Environment Resolution
 
-`internal/awsenv` centralizes AWS account-ID and region resolution and ECR URI construction. Use `awsenv.NewResolver(DryRun).Resolve(ctx, cfg, awsenv.Requirements{...})` to resolve account/region (auto-detects via STS/IMDS when not configured, respects dry-run). Use `awsenv.ImageURI(env, repo, tag)`, `awsenv.RepositoryURI(env, repo)`, or `awsenv.RegistryURI(env)` for ECR URIs — these validate that account ID and region are present. Never construct `dkr.ecr` strings directly in command code.
+`internal/awsenv` centralizes AWS account-ID and region resolution and ECR URI construction. Use `awsenv.NewResolver(DryRun).Resolve(ctx, cfg, awsenv.Requirements{...})` (`resolve.go`) to resolve account/region (auto-detects via STS/IMDS when not configured, respects dry-run). Use `awsenv.ImageURI(env, repo, tag)`, `awsenv.RepositoryURI(env, repo)`, or `awsenv.RegistryURI(env)` (`uri.go`) for ECR URIs — these validate that account ID and region are present. Never construct `dkr.ecr` strings directly in command code.
 
 Thin wrappers in `cmd/globals/aws.go` (`ResolveAWSAccountID`, `ResolveAWSRegion`) delegate to `awsenv` for backward compatibility; prefer calling `awsenv` directly for new code.
 
-### AWS Polling
+### AWS Polling and Error Classification
 
-`internal/awsutil/poll.go` provides a generic `Poll()` helper used across deployers for waiting on fleet activation, stack events, etc. Prefer it over hand-rolled polling loops when adding new AWS wait conditions.
+`internal/awsutil/poller.go` provides generic `Poll()` / `PollWithOptions()` helpers used across deployers for waiting on fleet activation, stack events, etc. Prefer them over hand-rolled polling loops when adding new AWS wait conditions.
 
-`awsutil.IsNotFound()` and `awsutil.IsConflict()` classify common AWS error patterns — use these in cleanup and idempotent create paths instead of inspecting error strings directly.
+`awsutil.IsNotFound()` and `awsutil.IsConflict()` (`errors.go`) classify common AWS error patterns — use these in cleanup and idempotent create paths instead of inspecting error strings directly.
+
+`internal/glsession/` holds GameLift game-session operations shared by the `gamelift`, `ec2fleet`, `stack`, and `anywhere` targets. It accepts a narrow `API` interface rather than `*gamelift.Client` specifically so tests can inject a fake — follow that pattern for new AWS-touching code.
+
+`internal/pricing/` carries an EC2 instance-type table (vCPU/memory/on-demand price/arch) used to format cost estimates and to `AutoSwitch` an instance type when it mismatches the target architecture.
 
 ### State and Caching
 
 `.ludus/state.json` — fleet IDs, session IPs, ECR URIs, build paths. Typed update helpers in `internal/state/state.go`.
-`.ludus/cache.json` — input hashes per stage. Unchanged stages auto-skip. `--no-cache` forces rebuild.
+`.ludus/cache.json` — input hashes per stage (`internal/cache/`: `cache.go` store, `cache_keys.go` hashing, `cache_helpers.go` git/file metadata). Unchanged stages auto-skip. `--no-cache` forces rebuild.
 Profiles (`--profile <name>`) isolate both: config from `ludus-<name>.yaml`, state in `.ludus/profiles/<name>.json`.
 
 ### Cross-Architecture Support
 
-The `--arch` flag threads through the entire pipeline: game build → container build → deploy. Architecture mismatches are caught automatically (e.g. arm64 build with x86 instance type auto-switches to Graviton). See `internal/config/` for `NormalizeArch`, `ServerPlatformDir`, `BinariesPlatformDir`. Arch aliases (`amd64`/`x86_64`, `arm64`/`aarch64`) normalize through these helpers — don't hand-roll the string comparison.
+The `--arch` flag threads through the entire pipeline: game build → container build → deploy. Architecture mismatches are caught automatically (e.g. arm64 build with x86 instance type auto-switches to Graviton via `pricing.AutoSwitch`). See `internal/config/config_arch.go` for `NormalizeArch`, `ServerPlatformDir`, `BinariesPlatformDir`, `UEPlatformName`. Arch aliases (`amd64`/`x86_64`, `arm64`/`aarch64`) normalize through these helpers — don't hand-roll the string comparison.
 
 macOS is supported only through container backends (`docker`/`podman`); there is no native engine build path on macOS. Engine container images are forced to `linux/amd64` under QEMU (Epic ships only an x86_64 Linux toolchain), even when the host is Apple Silicon. `--arch arm64` game builds still cross-compile Graviton server binaries inside that emulated amd64 environment — the engine image itself stays amd64.
 
@@ -153,24 +184,39 @@ Full style guide in [AGENTS.md](AGENTS.md). Key points for quick reference:
 - **Errors**: `fmt.Errorf("context: %w", err)`. No sentinel errors, no custom types. AWS errors via `smithy.APIError` + `errors.As()`. `internal/diagnose/` matches error patterns to user-facing hints — add new patterns there rather than embedding hint strings in command code.
 - **Output**: `fmt.Println`/`fmt.Printf` for status. No logging library. JSON conditional on `globals.JSONOutput`. Human-readable stdout is filtered through `internal/output` (account-ID masking) when `privacy.maskAccountId` is on and `--show-account-id` is not set — installed once in root `PersistentPreRunE`, skipped for `--json` and `mcp`. Mask new sensitive identifiers by adding a pattern to `internal/output/sanitize.go`, not at call sites.
 - **Shell execution**: Always through `runner.Runner`, never raw `exec.Command`.
-- **Tests**: stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests. AWS/Docker/`wsl.exe`/subprocess-bound code (gamelift, ec2fleet, stack, wrapper, wsl, most deploy logic) relies on E2E coverage — unit tests there cover only the pure surface (adapters' `Name`/`Capabilities`, arg assembly, param parsing). Two hard constraints: (1) keep each test function under **cyclomatic complexity 8** or Codacy's Lizard check fails the PR — convert flat assertion chains to map/table loops and extract `t.Run` bodies into named helpers (`go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 <file>` must print nothing); Lizard also tracks NLOC and parameter count, so keep helpers small and avoid broad fixture builders rather than hiding test files from analysis; (2) read mutex-guarded struct fields **under the same lock** in tests — CI runs `-race` on ubuntu/macos (not Windows, which lacks CGO), and a channel signal alone is not a happens-before edge with a lock-protected write.
-- **Platform code**: `_windows.go` / `_unix.go` suffixes with `//go:build` tags.
-- **Imports**: Two groups separated by a blank line — stdlib first, then third-party and project imports together (alphabetically sorted). Aliases only to resolve conflicts (e.g. `gltypes`, `cftypes`).
+- **Platform code**: `_windows.go` / `_unix.go` / `_darwin.go` / `_linux.go` suffixes with `//go:build` tags. `internal/prereq/` is the densest example (per-OS checkers for disk, memory, MSVC, WSL2, Docker).
+- **Imports**: Two groups separated by a blank line — stdlib first, then third-party and project imports together (alphabetically sorted). Aliases only to resolve conflicts (e.g. `gltypes`, `cftypes`, `mcpsdk`).
 - **Naming**: Acronyms fully uppercase (`ID`, `URI`, `ARN`, `ECR`). Constructors `New*` returning a pointer. Single-letter pointer receivers matching type initial (`b *Builder`, `d *Deployer`). `context.Context` is the first parameter for all I/O or long-running methods.
+
+### Tests
+
+Stdlib only, table-driven with `tt` loop var, same-package (access unexported), `t.TempDir()` for temp dirs, `t.Setenv()` for env overrides, `t.Chdir()` for cwd-dependent tests.
+
+Shared test infrastructure — use it instead of rebuilding fixtures:
+- `internal/testsupport/` — `FakeEngineTree(t, opts...)` and `FakeProject(t, name)` build on-disk UE trees/projects (`WithVersion`, `WithoutSetup`, `WithLinuxToolchain`); `FakeTool(t, name, ToolBehavior{...})` / `FakeTools` create PATH-injected stub executables (`.bat` on Windows, shell script on Unix); `RecordingRunner()` returns a dry-run `*runner.Runner` plus a reader for the command lines it echoed.
+- `cmd/globals/testing.go` — `SetGlobals(t, cfg, WithVerbose(…), WithDryRun(…), …)` sets and auto-restores global state; `SwapResolveTarget(t, fn)` injects a fake deploy target.
+
+AWS/Docker/`wsl.exe`/subprocess-bound code (gamelift, ec2fleet, stack, wrapper, wsl, most deploy logic) relies on E2E coverage — unit tests there cover only the pure surface (adapters' `Name`/`Capabilities`, arg assembly, param parsing). Dry-run works as a test seam; AWS HTTP stubbing does not — inject a narrow API interface instead (see `internal/glsession`, `internal/cleanup`).
+
+Two hard constraints:
+1. Keep each test function under **cyclomatic complexity 8** or Codacy's Lizard check fails the PR — convert flat assertion chains to map/table loops and extract `t.Run` bodies into named helpers (`go run github.com/fzipp/gocyclo/cmd/gocyclo@latest -over 8 <file>` must print nothing). Lizard also enforces NLOC 50 per function, 500 per file, and 8 parameters (thresholds live in Codacy Code Patterns, documented in `.codacy.yml`), so keep helpers small and avoid broad fixture builders rather than hiding test files from analysis.
+2. Read mutex-guarded struct fields **under the same lock** in tests — CI runs `-race` on ubuntu/macos (not Windows, which lacks CGO), and a channel signal alone is not a happens-before edge with a lock-protected write.
 
 ## Lint Configuration
 
-`.golangci.yml` v2 format. Enabled: errcheck, govet, ineffassign, staticcheck, unused, gocritic, misspell, unconvert, gosec, dupl.
+`.golangci.yml` v2 format. Enabled: errcheck, govet, ineffassign, staticcheck, unused, gocritic, misspell, unconvert, gosec, dupl. `gofmt` as formatter. Exclusion presets: `std-error-handling`, `common-false-positives`.
 
-gosec exclusions: G104 (cleanup), G115 (bounded int math), G204/G702 (intentional subprocess), G301/G306 (dir/file perms), G304/G703 (config file reads). ST1005 suppressed for proper nouns in error strings (e.g. `Setup.sh`).
+gosec exclusions: G104 (cleanup), G115 (bounded int math), G204/G702 (intentional subprocess), G301/G306 (dir/file perms), G304/G703 (config file reads). The CI `gosec` job mirrors these. ST1005 suppressed for proper nouns in error strings (e.g. `Setup.sh`).
 
 ## UE Source Patches
 
-Ludus patches UE source files at init/build time. See [UE_SOURCE_PATCHES.md](UE_SOURCE_PATCHES.md) for details and testing procedures.
+Ludus patches UE source files at init/build time. See [UE_SOURCE_PATCHES.md](UE_SOURCE_PATCHES.md) for details and testing procedures. Related build-time fixups live in `internal/game/workarounds.go`.
 
 ## Codacy Integration
 
-When the Codacy MCP server is configured: after any successful file edit, run `codacy_cli_analyze` with `rootPath` = workspace path and `file` = edited file (tool unset). After dependency changes (`go.mod`, `npm/package.json`), run it with `tool: "trivy"`. Use `provider: gh`, `organization: jpvelasco`, `repository: ludus` for Codacy tool calls. If Codacy MCP is not available, skip silently. Codacy config: `.codacy/codacy.yaml`.
+When the Codacy MCP server is configured: after any successful file edit, run `codacy_cli_analyze` with `rootPath` = workspace path and `file` = edited file (tool unset). After dependency changes (`go.mod`, `npm/package.json`), run it with `tool: "trivy"`. Use `provider: gh`, `organization: jpvelasco`, `repository: ludus` for Codacy tool calls. If Codacy MCP is not available, skip silently.
+
+Two config files, different jobs: `.codacy/codacy.yaml` pins CLI runtimes and tool versions (lizard, opengrep, revive, trivy, pmd, …); `.codacy.yml` versions `exclude_paths` for analysis scope (`.codacy/`, `dist/`, `npm/`, `scripts/`, scratch JSON). Neither controls coverage math, and neither enables/disables tools or sets Lizard thresholds — those are Codacy Code Patterns settings. Tests are deliberately **not** excluded so complexity warnings surface locally.
 
 ## Feature Design Specs
 
@@ -178,14 +224,13 @@ Approved feature designs are kept locally (not in the public repo). Check local 
 
 ## Release Process
 
-Releases are **tag-triggered**: pushing a `vX.Y.Z` tag to main runs `.github/workflows/release.yml` → GoReleaser builds 5 binaries → `scripts/embed-checksums.js` writes SHA-256 into `npm/package.json` → `npm publish` from `npm/`. npm auth is **OIDC trusted publishing** (`id-token: write`), so there is no npm token to manage. `scripts/validate_ue_versions.sh` validates UE version consistency at init/CI time.
+Releases are **tag-triggered**: pushing a `vX.Y.Z` tag to main runs `.github/workflows/release.yml` → GoReleaser builds 5 binaries (linux/darwin/windows × amd64/arm64, minus windows/arm64) → `scripts/embed-checksums.js` writes SHA-256 into `npm/package.json` → `npm publish` from `npm/`. npm auth is **OIDC trusted publishing** (`id-token: write`), so there is no npm token to manage. `scripts/validate_ue_versions.sh` validates UE version consistency at init/CI time. The CLI's `--version` comes from `internal/version.Version`, set via ldflags.
 
 Releasing is a gated, ordered process — do not improvise it:
 - **CHANGELOG before tag.** Land the `vX.Y.Z` CHANGELOG entry (and any version-source bumps) on main via a normal PR with green CI *before* tagging. The tag is the last step, never the first.
 - **Leave `npm/package.json` `version` at its `0.0.0` placeholder.** The workflow stamps the real version at publish time; committing a version causes a "Version not changed" failure.
-- **`v*` tags are immutable** (protected against deletion/force-update by a repo ruleset). Re-tagging after a failed release is a deliberate recovery — temporarily relax the tag protection, fix on main via PR, re-tag, then restore protection — not a force-push. Never reuse a version that may already have published to npm; cut the next patch instead.
+- **`v*` tags are immutable.** The `protect-version-tags` ruleset covers `refs/tags/v*` with `deletion`, `non_fast_forward`, and `update` rules — so a tag can't be moved, rewritten, or deleted. Re-tagging after a failed release is a deliberate recovery — temporarily relax the tag protection, fix on main via PR, re-tag, then restore protection — not a force-push. Never reuse a version that may already have published to npm; cut the next patch instead.
 
 npm package: `ludus-cli`. README in `npm/README.md`, keywords in `npm/package.json`.
 
-The published tarball is a thin shim and ships **no binary** (`bin/` is git/npm-ignored). `npm/install.js` exports `ensureBinary()`, which downloads the platform archive from the GitHub release, SHA-256-verifies it against `package.json`'s `binaryChecksums`, extracts atomically (unique temp dir + rename), and writes a `bin/.installed-version` marker. `postinstall` runs it once; `npm/run.js` (the `bin` entry) also calls it before every spawn, so a skipped postinstall (`ignore-scripts`/pnpm), a failed download, or a version-skewed binary self-heals on first run. The marker comparison short-circuits the common path (cheap file reads, no network). **All `ensureBinary` progress must go to stderr** — `ludus mcp` (JSON-RPC) and `--json` write to stdout. `LUDUS_SKIP_AUTO_DOWNLOAD=1` bypasses the self-heal for air-gapped/self-managed binaries. Tests: `cd npm && npm test` (`node --test`, network-free).
-
+The published tarball is a thin shim and ships **no binary** (`npm/bin/` is git/npm-ignored). `npm/install.js` exports `ensureBinary()`, which downloads the platform archive from the GitHub release, SHA-256-verifies it against `package.json`'s `binaryChecksums`, extracts atomically (unique temp dir + rename), and writes a `bin/.installed-version` marker. `postinstall` runs it once; `npm/run.js` (the `bin` entry) also calls it before every spawn, so a skipped postinstall (`ignore-scripts`/pnpm), a failed download, or a version-skewed binary self-heals on first run. The marker comparison short-circuits the common path (cheap file reads, no network). **All `ensureBinary` progress must go to stderr** — `ludus mcp` (JSON-RPC) and `--json` write to stdout. `LUDUS_SKIP_AUTO_DOWNLOAD=1` bypasses the self-heal for air-gapped/self-managed binaries. Tests: `cd npm && npm test` (`node --test`, network-free).


### PR DESCRIPTION
Reconciles and expands the two agent-facing guides so AGENTS.md stays the compact operational reference while CLAUDE.md carries the detailed architecture/CI/coverage detail.

Highlights:
- AGENTS.md: cross-links CLAUDE.md/ARCHITECTURE.md, documents git hooks activation and behavior, notes the init command location, adds a Deploy Targets section (Capabilities-based stage skipping), expands coverage details (3-leg upload, Codacy workflow_run, wrapper policy), UE 5.4-5.8 toolchain map, shared test infra.
- CLAUDE.md: detailed CI matrix (required vs soft checks), ruleset details (protect-main + protect-version-tags), Dependabot grouping strategy, refreshed coverage baseline table (2026-08-02), pipeline stage expansion detail, per-command subcommands, config surface, AWS polling/error classification, shared test infrastructure, Lizard thresholds, release-process specifics.

Docs-only change; no code touched.