### PR TITLE
test: close coverage gap in deploy, globals, setup, mcp, prereq

### DIFF
--- a/cmd/deploy/deploy_core_test.go
+++ b/cmd/deploy/deploy_core_test.go
@@ -1,0 +1,263 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/deploy"
+	"github.com/jpvelasco/ludus/internal/state"
+)
+
+func TestDryRun(t *testing.T) {
+	tests := []struct {
+		name string
+		dry  bool
+		want bool
+	}{
+		{"enabled short-circuits", true, true},
+		{"disabled proceeds", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			globals.SetGlobals(t, &config.Config{}, globals.WithDryRun(tt.dry))
+			if got := dryRun("dry-run message"); got != tt.want {
+				t.Errorf("dryRun() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPrintPricingHints(t *testing.T) {
+	tests := []struct {
+		name    string
+		it      string
+		arch    string
+		wantEst bool
+		wantTip bool
+	}{
+		{"known x86 instance prints estimate and tip", "c6i.large", "amd64", true, true},
+		{"unknown instance prints nothing", "bogus-type", "arm64", false, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			out := captureStdout(func() { printPricingHints(tt.it, tt.arch) })
+			if got := strings.Contains(out, "Estimated cost"); got != tt.wantEst {
+				t.Errorf("estimate printed = %v, want %v (output: %q)", got, tt.wantEst, out)
+			}
+			if got := strings.Contains(out, "Tip:"); got != tt.wantTip {
+				t.Errorf("tip printed = %v, want %v (output: %q)", got, tt.wantTip, out)
+			}
+		})
+	}
+}
+
+func TestPrintNextStep(t *testing.T) {
+	tests := []struct {
+		name        string
+		withSession bool
+		want        string
+	}{
+		{"session created points to connect", true, "ludus connect"},
+		{"no session points to deploy session", false, "ludus deploy session"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saveDeployFlags(t)
+			withSession = tt.withSession
+			out := captureStdout(printNextStep)
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("printNextStep() output %q missing %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestResolveTargetFlagOverrides(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{
+		AWS:      config.AWSConfig{Region: "us-east-1"},
+		GameLift: config.GameLiftConfig{InstanceType: "c6i.large", FleetName: "ludus-fleet"},
+	})
+
+	tests := []struct {
+		name                                        string
+		region, instanceType, fleetName, targetFlag string
+		wantRegion, wantIT, wantFleet, wantOverride string
+	}{
+		{"no flags fall back to config defaults", "", "", "", "", "us-east-1", "c6i.large", "ludus-fleet", ""},
+		{"flags override config and target", "eu-west-1", "c7g.large", "override-fleet", "stack", "eu-west-1", "c7g.large", "override-fleet", "stack"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			saveDeployFlags(t)
+			region, instanceType, fleetName, targetFlag = tt.region, tt.instanceType, tt.fleetName, tt.targetFlag
+
+			var gotCfg *config.Config
+			var gotOverride string
+			swapTargetFactory(t, func(_ context.Context, cfg *config.Config, override string) (deploy.Target, error) {
+				gotCfg = cfg
+				gotOverride = override
+				return &fakeTarget{name: "gamelift"}, nil
+			})
+
+			target, err := resolveTarget(newCommand())
+			if err != nil {
+				t.Fatalf("resolveTarget() error = %v", err)
+			}
+			if target == nil {
+				t.Fatal("resolveTarget() returned nil target")
+			}
+			checkResolvedOverrides(t, gotCfg, gotOverride, tt.wantRegion, tt.wantIT, tt.wantFleet, tt.wantOverride)
+		})
+	}
+}
+
+func checkResolvedOverrides(t *testing.T, cfg *config.Config, gotOverride, wantRegion, wantIT, wantFleet, wantOverride string) {
+	t.Helper()
+	if cfg.AWS.Region != wantRegion {
+		t.Errorf("resolved Region = %q, want %q", cfg.AWS.Region, wantRegion)
+	}
+	if cfg.GameLift.InstanceType != wantIT {
+		t.Errorf("resolved InstanceType = %q, want %q", cfg.GameLift.InstanceType, wantIT)
+	}
+	if cfg.GameLift.FleetName != wantFleet {
+		t.Errorf("resolved FleetName = %q, want %q", cfg.GameLift.FleetName, wantFleet)
+	}
+	if gotOverride != wantOverride {
+		t.Errorf("resolved target override = %q, want %q", gotOverride, wantOverride)
+	}
+}
+
+func TestMaybeCreateSession(t *testing.T) {
+	t.Run("skipped when with-session is false", maybeCreateSessionSkipped)
+	t.Run("session creation error propagates", maybeCreateSessionError)
+	t.Run("success persists session state", maybeCreateSessionSuccess)
+	t.Run("state write failure warns but returns nil", maybeCreateSessionWriteFailure)
+}
+
+func maybeCreateSessionSkipped(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{})
+	saveDeployFlags(t)
+	withSession = false
+	fake := &fakeTarget{name: "gamelift"}
+	if err := maybeCreateSession(context.Background(), fake); err != nil {
+		t.Fatalf("maybeCreateSession() error = %v", err)
+	}
+	if fake.sessionCalls != 0 {
+		t.Errorf("CreateSession called %d times, want 0", fake.sessionCalls)
+	}
+}
+
+func maybeCreateSessionError(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{})
+	saveDeployFlags(t)
+	withSession = true
+	err := maybeCreateSession(context.Background(), &fakeTarget{sessionErr: fmt.Errorf("create failed")})
+	if err == nil {
+		t.Fatal("maybeCreateSession() expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "session creation failed") {
+		t.Errorf("error = %v, want session creation failed", err)
+	}
+}
+
+func maybeCreateSessionSuccess(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{})
+	saveDeployFlags(t)
+	withSession = true
+	fake := &fakeTarget{sessionInfo: &deploy.SessionInfo{SessionID: "sess-9", IPAddress: "10.1.2.3", Port: 7777}}
+	if err := maybeCreateSession(context.Background(), fake); err != nil {
+		t.Fatalf("maybeCreateSession() error = %v", err)
+	}
+	s, err := state.Load()
+	if err != nil {
+		t.Fatalf("state.Load() error = %v", err)
+	}
+	if s.Session == nil || s.Session.SessionID != "sess-9" || s.Session.IPAddress != "10.1.2.3" {
+		t.Errorf("state session = %+v, want sess-9 / 10.1.2.3", s.Session)
+	}
+}
+
+func maybeCreateSessionWriteFailure(t *testing.T) {
+	blockStateWrites(t)
+	globals.SetGlobals(t, &config.Config{})
+	saveDeployFlags(t)
+	withSession = true
+	if err := maybeCreateSession(context.Background(), &fakeTarget{}); err != nil {
+		t.Fatalf("maybeCreateSession() error = %v", err)
+	}
+}
+
+func TestMakeDeployer(t *testing.T) {
+	t.Run("defaults from config", func(t *testing.T) {
+		globals.SetGlobals(t, testGameliftCfg(), globals.WithDryRun(true))
+		saveDeployFlags(t)
+		d, err := makeDeployer(newCommand())
+		if err != nil {
+			t.Fatalf("makeDeployer() error = %v", err)
+		}
+		if d == nil {
+			t.Fatal("makeDeployer() returned nil deployer")
+		}
+	})
+
+	t.Run("flag overrides applied", func(t *testing.T) {
+		globals.SetGlobals(t, testGameliftCfg(), globals.WithDryRun(true))
+		saveDeployFlags(t)
+		region = "eu-west-1"
+		instanceType = "c6i.xlarge"
+		fleetName = "override-fleet"
+		if _, err := makeDeployer(newCommand()); err != nil {
+			t.Fatalf("makeDeployer() error = %v", err)
+		}
+	})
+
+	t.Run("auto-switches instance type for arm64", func(t *testing.T) {
+		cfg := testGameliftCfg()
+		cfg.Game.Arch = "arm64"
+		globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+		saveDeployFlags(t)
+		instanceType = "c6i.large"
+		var runErr error
+		out := captureStdout(func() { _, runErr = makeDeployer(newCommand()) })
+		if runErr != nil {
+			t.Fatalf("makeDeployer() error = %v", runErr)
+		}
+		if !strings.Contains(out, "Switching instance type") {
+			t.Errorf("expected switch note in output, got %q", out)
+		}
+	})
+
+	t.Run("empty ECR repository errors", func(t *testing.T) {
+		cfg := testGameliftCfg()
+		cfg.AWS.ECRRepository = ""
+		globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+		saveDeployFlags(t)
+		if _, err := makeDeployer(newCommand()); err == nil {
+			t.Fatal("makeDeployer() expected error for empty ECR repository")
+		}
+	})
+
+	t.Run("aws config resolution error propagates", func(t *testing.T) {
+		globals.SetGlobals(t, testGameliftCfg(), globals.WithDryRun(true))
+		t.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+		t.Setenv("AWS_CONFIG_FILE", t.TempDir())
+		saveDeployFlags(t)
+		if _, err := makeDeployer(newCommand()); err == nil {
+			t.Fatal("makeDeployer() expected aws resolution error")
+		}
+	})
+}
+
+func testGameliftCfg() *config.Config {
+	return &config.Config{
+		AWS:       config.AWSConfig{Region: "us-east-1", AccountID: "123456789012", ECRRepository: "ludus-server"},
+		Container: config.ContainerConfig{Tag: "latest", ServerPort: 7777},
+		GameLift:  config.GameLiftConfig{InstanceType: "c6i.large", FleetName: "ludus-fleet", ContainerGroupName: "grp"},
+		Game:      config.GameConfig{Arch: "amd64"},
+	}
+}

--- a/cmd/deploy/deploy_destroy_run_test.go
+++ b/cmd/deploy/deploy_destroy_run_test.go
@@ -1,0 +1,204 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/spf13/cobra"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/deploy"
+)
+
+func TestRunDestroyDeclinesPurge(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg())
+	saveDeployFlags(t)
+	destroyPurge = true
+
+	cmd := &cobra.Command{}
+	cmd.SetIn(strings.NewReader("n\n"))
+	var out bytes.Buffer
+	cmd.SetOut(&out)
+
+	if err := runDestroy(cmd, nil); err != nil {
+		t.Fatalf("runDestroy() error = %v", err)
+	}
+	if !strings.Contains(out.String(), "Aborted") {
+		t.Errorf("runDestroy() output missing Aborted message: %q", out.String())
+	}
+}
+
+func TestRunDestroyPurgeAcceptedThenActiveTargetError(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg())
+	saveDeployFlags(t)
+	destroyPurge = true
+	destroyYes = true
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return nil, fmt.Errorf("resolve boom")
+	})
+	if err := runDestroy(newCommand(), nil); err == nil {
+		t.Fatal("runDestroy() expected destroyActiveTarget error")
+	}
+}
+
+func TestRunDestroyActiveTargetSuccess(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg())
+	saveDeployFlags(t)
+	region = "eu-west-1"
+	destroyPurge = false
+	destroyAllTgts = false
+
+	var target *fakeTarget
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		target = &fakeTarget{name: "gamelift"}
+		return target, nil
+	})
+	if err := runDestroy(newCommand(), nil); err != nil {
+		t.Fatalf("runDestroy() error = %v", err)
+	}
+	if target.destroyCalls != 1 {
+		t.Errorf("destroyActiveTarget called Destroy %d times, want 1", target.destroyCalls)
+	}
+}
+
+func TestRunDestroyDurableSuccessWithCleanupLoadFailure(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg())
+	t.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir())
+	saveDeployFlags(t)
+	destroyPurge = true
+	destroyYes = true
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "gamelift"}, nil
+	})
+	if err := runDestroy(newCommand(), nil); err != nil {
+		t.Fatalf("runDestroy() error = %v", err)
+	}
+}
+
+func TestRunDestroySweep(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg())
+	saveDeployFlags(t)
+	destroyPurge = false
+	destroyAllTgts = true
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "ok"}, nil
+	})
+	if err := runDestroy(newCommand(), nil); err != nil {
+		t.Fatalf("runDestroy() sweep error = %v", err)
+	}
+}
+
+func TestRunDestroySweepResolveFailure(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg())
+	saveDeployFlags(t)
+	destroyPurge = false
+	destroyAllTgts = true
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return nil, fmt.Errorf("resolve boom")
+	})
+	if err := runDestroy(newCommand(), nil); err != nil {
+		t.Fatalf("runDestroy() sweep error = %v", err)
+	}
+}
+
+func TestDestroyAllTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		verbose bool
+		factory func(context.Context, *config.Config, string) (deploy.Target, error)
+		want    string
+	}{
+		{
+			name:    "resolve failures skipped silently",
+			verbose: false,
+			factory: func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+				return nil, fmt.Errorf("boom")
+			},
+			want: "No resources found to destroy.",
+		},
+		{
+			name:    "resolve failures reported when verbose",
+			verbose: true,
+			factory: func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+				return nil, fmt.Errorf("boom")
+			},
+			want: "No resources found to destroy.",
+		},
+		{
+			name:    "destroy failures continue and count none",
+			verbose: false,
+			factory: func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+				return &fakeTarget{name: "x", destroyErr: fmt.Errorf("boom")}, nil
+			},
+			want: "No resources found to destroy.",
+		},
+		{
+			name:    "all targets destroyed",
+			verbose: false,
+			factory: func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+				return &fakeTarget{name: "x"}, nil
+			},
+			want: "Destroyed resources across 5 target(s).",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			globals.SetGlobals(t, &config.Config{}, globals.WithVerbose(tt.verbose))
+			swapTargetFactory(t, tt.factory)
+			out := captureStdout(func() {
+				destroyAllTargets(context.Background(), &config.Config{})
+			})
+			if !strings.Contains(out, tt.want) {
+				t.Errorf("destroyAllTargets() output %q missing %q", out, tt.want)
+			}
+		})
+	}
+}
+
+func TestDestroyActiveTarget(t *testing.T) {
+	t.Run("destroy error propagates", func(t *testing.T) {
+		globals.SetGlobals(t, testGameliftCfg())
+		saveDeployFlags(t)
+		swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+			return &fakeTarget{name: "gamelift", destroyErr: fmt.Errorf("destroy boom")}, nil
+		})
+
+		err := destroyActiveTarget(newCommand())
+		if err == nil {
+			t.Fatal("destroyActiveTarget() expected error")
+		}
+		if !strings.Contains(err.Error(), "destroy boom") {
+			t.Errorf("destroyActiveTarget() error = %v, want destroy boom", err)
+		}
+	})
+
+	t.Run("success prints confirmation", func(t *testing.T) {
+		globals.SetGlobals(t, testGameliftCfg())
+		saveDeployFlags(t)
+		swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+			return &fakeTarget{name: "gamelift"}, nil
+		})
+
+		var runErr error
+		out := captureStdout(func() { runErr = destroyActiveTarget(newCommand()) })
+		if runErr != nil {
+			t.Fatalf("destroyActiveTarget() error = %v", runErr)
+		}
+		if !strings.Contains(out, "resources destroyed") {
+			t.Errorf("destroyActiveTarget() output missing confirmation: %q", out)
+		}
+	})
+}
+
+func TestResolveAccountIDConfigured(t *testing.T) {
+	got := resolveAccountID(context.Background(), aws.Config{}, "123456789012")
+	if got != "123456789012" {
+		t.Errorf("resolveAccountID() = %q, want configured value", got)
+	}
+}

--- a/cmd/deploy/deploy_ec2_anywhere_test.go
+++ b/cmd/deploy/deploy_ec2_anywhere_test.go
@@ -1,0 +1,223 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/deploy"
+)
+
+func testEC2Cfg() *config.Config {
+	return &config.Config{
+		AWS:       config.AWSConfig{Region: "us-west-2"},
+		Game:      config.GameConfig{Arch: "amd64", ProjectName: "Lyra", ProjectPath: `C:\proj\Lyra.uproject`},
+		GameLift:  config.GameLiftConfig{InstanceType: "c6i.large"},
+		Container: config.ContainerConfig{ServerPort: 7777},
+	}
+}
+
+func testAnywhereCfg() *config.Config {
+	return &config.Config{
+		AWS:       config.AWSConfig{Region: "us-east-1"},
+		Game:      config.GameConfig{Arch: "amd64", ProjectName: "Lyra", ProjectPath: `C:\proj\Lyra.uproject`},
+		GameLift:  config.GameLiftConfig{FleetName: "anywhere-fleet"},
+		Anywhere:  config.AnywhereConfig{LocationName: "custom-test"},
+		Container: config.ContainerConfig{ServerPort: 7777},
+	}
+}
+
+func TestRunEC2MissingServerBuildDir(t *testing.T) {
+	cfg := testEC2Cfg()
+	cfg.Game.ProjectPath = ""
+	globals.SetGlobals(t, cfg, globals.WithDryRun(false))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "ec2"}, nil
+	})
+
+	err := runEC2(newCommand(), nil)
+	if err == nil {
+		t.Fatal("runEC2() expected error for missing server build dir")
+	}
+	if !strings.Contains(err.Error(), "server build directory") {
+		t.Errorf("runEC2() error = %v, want server build directory hint", err)
+	}
+}
+
+func TestRunEC2ResolveError(t *testing.T) {
+	globals.SetGlobals(t, testEC2Cfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return nil, fmt.Errorf("resolve boom")
+	})
+	if err := runEC2(newCommand(), nil); err == nil {
+		t.Fatal("runEC2() expected resolve error")
+	}
+}
+
+func TestRunEC2DeployError(t *testing.T) {
+	globals.SetGlobals(t, testEC2Cfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "ec2", deployErr: fmt.Errorf("deploy boom")}, nil
+	})
+
+	err := runEC2(newCommand(), nil)
+	if err == nil {
+		t.Fatal("runEC2() expected deploy error")
+	}
+	if !strings.Contains(err.Error(), "deploy boom") {
+		t.Errorf("runEC2() error = %v, want deploy boom", err)
+	}
+}
+
+func TestRunEC2DeploySuccess(t *testing.T) {
+	globals.SetGlobals(t, testEC2Cfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "ec2", deployResult: &deploy.DeployResult{TargetName: "ec2", Status: "ACTIVE", Detail: "fleet-ec2"}}, nil
+	})
+	if err := runEC2(newCommand(), nil); err != nil {
+		t.Fatalf("runEC2() error = %v", err)
+	}
+}
+
+func TestRunEC2DeploySuccessNonSession(t *testing.T) {
+	globals.SetGlobals(t, testEC2Cfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &nonSessionTarget{name: "ec2"}, nil
+	})
+	if err := runEC2(newCommand(), nil); err != nil {
+		t.Fatalf("runEC2() error = %v", err)
+	}
+}
+
+func TestRunEC2DeploySuccessWithSession(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, testEC2Cfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	withSession = true
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "ec2", sessionInfo: &deploy.SessionInfo{SessionID: "sess-ec2", IPAddress: "9.9.9.9", Port: 7777}}, nil
+	})
+	if err := runEC2(newCommand(), nil); err != nil {
+		t.Fatalf("runEC2() error = %v", err)
+	}
+}
+
+func TestRunEC2DeploySuccessSessionError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, testEC2Cfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	withSession = true
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "ec2", sessionErr: fmt.Errorf("session boom")}, nil
+	})
+
+	err := runEC2(newCommand(), nil)
+	if err == nil {
+		t.Fatal("runEC2() expected session error")
+	}
+	if !strings.Contains(err.Error(), "session boom") {
+		t.Errorf("runEC2() error = %v, want session boom", err)
+	}
+}
+
+func TestRunAnywhereDryRun(t *testing.T) {
+	globals.SetGlobals(t, testAnywhereCfg(), globals.WithDryRun(true))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, override string) (deploy.Target, error) {
+		if override != "anywhere" {
+			t.Errorf("runAnywhere() resolved target override %q, want anywhere", override)
+		}
+		return &fakeTarget{name: "anywhere"}, nil
+	})
+	if err := runAnywhere(newCommand(), nil); err != nil {
+		t.Fatalf("runAnywhere() dry-run error = %v", err)
+	}
+}
+
+func TestRunAnywhereResolveError(t *testing.T) {
+	globals.SetGlobals(t, testAnywhereCfg(), globals.WithDryRun(true))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return nil, fmt.Errorf("resolve boom")
+	})
+	if err := runAnywhere(newCommand(), nil); err == nil {
+		t.Fatal("runAnywhere() expected resolve error")
+	}
+}
+
+func TestRunAnywhereDeployError(t *testing.T) {
+	globals.SetGlobals(t, testAnywhereCfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "anywhere", deployErr: fmt.Errorf("deploy boom")}, nil
+	})
+
+	err := runAnywhere(newCommand(), nil)
+	if err == nil {
+		t.Fatal("runAnywhere() expected deploy error")
+	}
+	if !strings.Contains(err.Error(), "deploy boom") {
+		t.Errorf("runAnywhere() error = %v, want deploy boom", err)
+	}
+}
+
+func TestRunAnywhereDeploySuccess(t *testing.T) {
+	globals.SetGlobals(t, testAnywhereCfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "anywhere"}, nil
+	})
+	if err := runAnywhere(newCommand(), nil); err != nil {
+		t.Fatalf("runAnywhere() error = %v", err)
+	}
+}
+
+func TestRunAnywhereDeploySuccessNonSession(t *testing.T) {
+	globals.SetGlobals(t, testAnywhereCfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &nonSessionTarget{name: "anywhere"}, nil
+	})
+	if err := runAnywhere(newCommand(), nil); err != nil {
+		t.Fatalf("runAnywhere() error = %v", err)
+	}
+}
+
+func TestRunAnywhereDeploySuccessWithSession(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, testAnywhereCfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	withSession = true
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "anywhere", sessionInfo: &deploy.SessionInfo{SessionID: "sess-any", IPAddress: "10.0.0.9", Port: 7777}}, nil
+	})
+	if err := runAnywhere(newCommand(), nil); err != nil {
+		t.Fatalf("runAnywhere() error = %v", err)
+	}
+}
+
+func TestRunAnywhereDeploySuccessSessionError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, testAnywhereCfg(), globals.WithDryRun(false))
+	saveDeployFlags(t)
+	withSession = true
+	swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+		return &fakeTarget{name: "anywhere", sessionErr: fmt.Errorf("session boom")}, nil
+	})
+
+	err := runAnywhere(newCommand(), nil)
+	if err == nil {
+		t.Fatal("runAnywhere() expected session error")
+	}
+	if !strings.Contains(err.Error(), "session boom") {
+		t.Errorf("runAnywhere() error = %v, want session boom", err)
+	}
+}

--- a/cmd/deploy/deploy_ec2_test.go
+++ b/cmd/deploy/deploy_ec2_test.go
@@ -19,6 +19,7 @@ func TestValidateEC2Prereqs(t *testing.T) {
 	// does not panic.
 	cfg := &config.Config{}
 	cfg.Game.Arch = "amd64"
+	stubAWSCLI(t)
 
 	err := validateEC2Prereqs(cfg)
 	if runtime.GOOS == "linux" && err != nil {

--- a/cmd/deploy/deploy_fleet_stack_test.go
+++ b/cmd/deploy/deploy_fleet_stack_test.go
@@ -1,0 +1,114 @@
+package deploy
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/gamelift"
+	"github.com/jpvelasco/ludus/internal/stack"
+	"github.com/jpvelasco/ludus/internal/state"
+)
+
+func TestRunFleetDryRun(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg(), globals.WithDryRun(true))
+	saveDeployFlags(t)
+	if err := runFleet(newCommand(), nil); err != nil {
+		t.Fatalf("runFleet() dry-run error = %v", err)
+	}
+}
+
+func TestRunFleetDryRunWithInstanceTypeFlag(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg(), globals.WithDryRun(true))
+	saveDeployFlags(t)
+	instanceType = "c6i.xlarge"
+	if err := runFleet(newCommand(), nil); err != nil {
+		t.Fatalf("runFleet() dry-run error = %v", err)
+	}
+}
+
+func TestRunFleetMakeDeployerError(t *testing.T) {
+	cfg := testGameliftCfg()
+	cfg.AWS.ECRRepository = ""
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	saveDeployFlags(t)
+	if err := runFleet(newCommand(), nil); err == nil {
+		t.Fatal("runFleet() expected makeDeployer error")
+	}
+}
+
+func TestRunStackDryRun(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg(), globals.WithDryRun(true))
+	saveDeployFlags(t)
+	if err := runStack(newCommand(), nil); err != nil {
+		t.Fatalf("runStack() dry-run error = %v", err)
+	}
+}
+
+func TestRunStackFlagOverrides(t *testing.T) {
+	cfg := testGameliftCfg()
+	cfg.Game.Arch = "arm64"
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	saveDeployFlags(t)
+	region = "eu-west-1"
+	instanceType = "c6i.large"
+	stackName = "custom-stack"
+
+	var runErr error
+	out := captureStdout(func() { runErr = runStack(newCommand(), nil) })
+	if runErr != nil {
+		t.Fatalf("runStack() error = %v", runErr)
+	}
+	if !strings.Contains(out, "Switching instance type") {
+		t.Errorf("runStack() output missing switch note: %q", out)
+	}
+}
+
+func TestRunStackApplyFlagsError(t *testing.T) {
+	cfg := testGameliftCfg()
+	cfg.AWS.ECRRepository = ""
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	saveDeployFlags(t)
+	if err := runStack(newCommand(), nil); err == nil {
+		t.Fatal("runStack() expected applyStackFlags error")
+	}
+}
+
+func TestApplyStackFlagsResolveError(t *testing.T) {
+	globals.SetGlobals(t, testGameliftCfg(), globals.WithDryRun(true))
+	t.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+	t.Setenv("AWS_CONFIG_FILE", t.TempDir())
+	saveDeployFlags(t)
+
+	cfg := globals.Cfg.Clone()
+	if _, _, _, _, err := applyStackFlags(context.Background(), &cfg); err == nil {
+		t.Fatal("applyStackFlags() expected aws resolution error")
+	}
+}
+
+func TestSaveStackState(t *testing.T) {
+	t.Chdir(t.TempDir())
+	saveStackState(&stack.StackResult{StackName: "ludus-fleet", StackID: "arn:stack", Status: "CREATE_COMPLETE", FleetID: "fleet-42"})
+
+	s, err := state.Load()
+	if err != nil {
+		t.Fatalf("state.Load() error = %v", err)
+	}
+	if s.Fleet == nil || s.Fleet.StackName != "ludus-fleet" || s.Fleet.FleetID != "fleet-42" {
+		t.Errorf("fleet state = %+v, want stack ludus-fleet / fleet-42", s.Fleet)
+	}
+	if s.Deploy == nil || s.Deploy.TargetName != "stack" {
+		t.Errorf("deploy state = %+v, want target stack", s.Deploy)
+	}
+}
+
+func TestSaveStackStateWriteWarning(t *testing.T) {
+	blockStateWrites(t)
+	saveStackState(&stack.StackResult{StackName: "st", StackID: "si", Status: "ACTIVE", FleetID: "f1"})
+}
+
+func TestRecordFleetDeployStateWriteWarning(t *testing.T) {
+	blockStateWrites(t)
+	recordFleetDeployState(&gamelift.FleetStatus{FleetID: "fleet-x", Status: "ACTIVE"})
+}

--- a/cmd/deploy/deploy_helpers_test.go
+++ b/cmd/deploy/deploy_helpers_test.go
@@ -1,0 +1,167 @@
+package deploy
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/deploy"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+// fakeTarget is a configurable deploy.Target that also implements
+// deploy.SessionManager, so deploy commands can be exercised without AWS.
+type fakeTarget struct {
+	name         string
+	deployErr    error
+	destroyErr   error
+	sessionErr   error
+	deployResult *deploy.DeployResult
+	sessionInfo  *deploy.SessionInfo
+	sessionCalls int
+	destroyCalls int
+}
+
+func (f *fakeTarget) Name() string                      { return f.name }
+func (f *fakeTarget) Capabilities() deploy.Capabilities { return deploy.Capabilities{} }
+
+func (f *fakeTarget) Deploy(_ context.Context, _ deploy.DeployInput) (*deploy.DeployResult, error) {
+	if f.deployErr != nil {
+		return nil, f.deployErr
+	}
+	if f.deployResult != nil {
+		return f.deployResult, nil
+	}
+	return &deploy.DeployResult{TargetName: f.name, Status: "active", Detail: f.name + "-detail"}, nil
+}
+
+func (f *fakeTarget) Status(_ context.Context) (*deploy.DeployStatus, error) {
+	return &deploy.DeployStatus{TargetName: f.name, Status: "active"}, nil
+}
+
+func (f *fakeTarget) Destroy(_ context.Context) error {
+	f.destroyCalls++
+	return f.destroyErr
+}
+
+func (f *fakeTarget) CreateSession(_ context.Context, _ int) (*deploy.SessionInfo, error) {
+	f.sessionCalls++
+	if f.sessionErr != nil {
+		return nil, f.sessionErr
+	}
+	if f.sessionInfo != nil {
+		return f.sessionInfo, nil
+	}
+	return &deploy.SessionInfo{SessionID: "sess-1", IPAddress: "10.0.0.1", Port: 7777}, nil
+}
+
+func (f *fakeTarget) DescribeSession(_ context.Context, _ string) (string, error) {
+	return "active", nil
+}
+
+// nonSessionTarget implements deploy.Target but not deploy.SessionManager.
+type nonSessionTarget struct {
+	name string
+}
+
+func (n *nonSessionTarget) Name() string                      { return n.name }
+func (n *nonSessionTarget) Capabilities() deploy.Capabilities { return deploy.Capabilities{} }
+
+func (n *nonSessionTarget) Deploy(_ context.Context, _ deploy.DeployInput) (*deploy.DeployResult, error) {
+	return &deploy.DeployResult{TargetName: n.name, Status: "active", Detail: n.name + "-detail"}, nil
+}
+
+func (n *nonSessionTarget) Status(_ context.Context) (*deploy.DeployStatus, error) {
+	return &deploy.DeployStatus{TargetName: n.name, Status: "active"}, nil
+}
+
+func (n *nonSessionTarget) Destroy(_ context.Context) error { return nil }
+
+// swapTargetFactory installs a fake deploy.Target factory and restores the
+// original on test cleanup.
+func swapTargetFactory(t *testing.T, fn func(context.Context, *config.Config, string) (deploy.Target, error)) {
+	t.Helper()
+	globals.SwapResolveTarget(t, fn)
+}
+
+// newCommand returns a cobra command with a background context.
+func newCommand() *cobra.Command {
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+// captureStdout captures os.Stdout while fn runs and returns what was written.
+func captureStdout(fn func()) string {
+	origStdout := os.Stdout
+	defer func() { os.Stdout = origStdout }()
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		return ""
+	}
+	defer func() { _ = r.Close() }()
+
+	os.Stdout = w
+	var buf bytes.Buffer
+	done := make(chan bool, 1)
+	go func() {
+		_, _ = io.Copy(&buf, r)
+		done <- true
+	}()
+
+	fn()
+
+	_ = w.Close()
+	<-done
+	return buf.String()
+}
+
+// deployFlags mirrors the package flag vars so tests can restore them.
+type deployFlags struct {
+	region, instanceType, fleetName, targetFlag           string
+	stackName, anywhereIP, ec2Arch                        string
+	withSession, destroyAllTgts, destroyPurge, destroyYes bool
+}
+
+// stubAWSCLI puts a fake `aws` executable on PATH so the prereq AWS-readiness
+// check (checkAWSCredentials shells out to `aws sts get-caller-identity`)
+// resolves to the stub instead of the real CLI, keeping deploy tests hermetic.
+func stubAWSCLI(t *testing.T) {
+	t.Helper()
+	testsupport.FakeTool(t, "aws", testsupport.ToolBehavior{ExitCode: 1})
+}
+
+// saveDeployFlags snapshots the package flag vars and restores them on cleanup.
+func saveDeployFlags(t *testing.T) {
+	t.Helper()
+	stubAWSCLI(t)
+	orig := deployFlags{
+		region, instanceType, fleetName, targetFlag,
+		stackName, anywhereIP, ec2Arch,
+		withSession, destroyAllTgts, destroyPurge, destroyYes,
+	}
+	t.Cleanup(func() {
+		region, instanceType, fleetName, targetFlag = orig.region, orig.instanceType, orig.fleetName, orig.targetFlag
+		stackName, anywhereIP, ec2Arch = orig.stackName, orig.anywhereIP, orig.ec2Arch
+		withSession, destroyAllTgts, destroyPurge, destroyYes = orig.withSession, orig.destroyAllTgts, orig.destroyPurge, orig.destroyYes
+	})
+}
+
+// blockStateWrites makes state.Load/Save fail by placing a file where the
+// .ludus state directory should be.
+func blockStateWrites(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".ludus"), []byte("not a dir"), 0o644); err != nil {
+		t.Fatalf("create .ludus blocker: %v", err)
+	}
+}

--- a/cmd/deploy/deploy_session_test.go
+++ b/cmd/deploy/deploy_session_test.go
@@ -1,0 +1,83 @@
+package deploy
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/deploy"
+)
+
+func TestRunSession(t *testing.T) {
+	t.Run("success with explicit target", func(t *testing.T) {
+		globals.SetGlobals(t, sessionCfg())
+		saveDeployFlags(t)
+		targetFlag = "gamelift"
+		swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+			return &fakeTarget{name: "gamelift"}, nil
+		})
+		if err := runSession(newCommand(), nil); err != nil {
+			t.Fatalf("runSession() error = %v", err)
+		}
+	})
+
+	t.Run("success via session target fallback", func(t *testing.T) {
+		globals.SetGlobals(t, sessionCfg())
+		saveDeployFlags(t)
+		targetFlag = ""
+		swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+			return &fakeTarget{name: "gamelift"}, nil
+		})
+		if err := runSession(newCommand(), nil); err != nil {
+			t.Fatalf("runSession() error = %v", err)
+		}
+	})
+
+	t.Run("target without session support errors", func(t *testing.T) {
+		globals.SetGlobals(t, sessionCfg())
+		saveDeployFlags(t)
+		targetFlag = "binary"
+		swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+			return &nonSessionTarget{name: "binary"}, nil
+		})
+
+		err := runSession(newCommand(), nil)
+		if err == nil {
+			t.Fatal("runSession() expected error for non-session target")
+		}
+		if !strings.Contains(err.Error(), "does not support game sessions") {
+			t.Errorf("error = %v, want does not support game sessions", err)
+		}
+	})
+
+	t.Run("resolve failure propagates", func(t *testing.T) {
+		globals.SetGlobals(t, sessionCfg())
+		saveDeployFlags(t)
+		targetFlag = "gamelift"
+		swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+			return nil, fmt.Errorf("resolve boom")
+		})
+		if err := runSession(newCommand(), nil); err == nil {
+			t.Fatal("runSession() expected resolve error")
+		}
+	})
+
+	t.Run("session creation error propagates", func(t *testing.T) {
+		globals.SetGlobals(t, sessionCfg())
+		saveDeployFlags(t)
+		targetFlag = "gamelift"
+		swapTargetFactory(t, func(_ context.Context, _ *config.Config, _ string) (deploy.Target, error) {
+			return &fakeTarget{sessionErr: fmt.Errorf("create boom")}, nil
+		})
+		if err := runSession(newCommand(), nil); err == nil {
+			t.Fatal("runSession() expected session creation error")
+		}
+	})
+}
+
+func sessionCfg() *config.Config {
+	return &config.Config{Game: config.GameConfig{Arch: "amd64"}}
+}

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -61,78 +61,78 @@ func TestApplyFlagsDoNotMutateGlobal(t *testing.T) {
 		Anywhere:  config.AnywhereConfig{IPAddress: "10.0.0.1"},
 	}
 
-	t.Run("applyEC2Flags isolates mutations", func(t *testing.T) {
-		origRegion, origInstance, origFleet, origArch := region, instanceType, fleetName, ec2Arch
-		t.Cleanup(func() { region, instanceType, fleetName, ec2Arch = origRegion, origInstance, origFleet, origArch })
+	t.Run("applyEC2Flags isolates mutations", applyEC2IsolationCase)
+	t.Run("applyAnywhereFlags isolates mutations", applyAnywhereIsolationCase)
+	t.Run("applyStackFlags isolates mutations", applyStackIsolationCase)
+}
 
-		region = "eu-west-1"
-		instanceType = "c7g.large"
-		fleetName = "new-fleet"
-		ec2Arch = "arm64"
+func applyEC2IsolationCase(t *testing.T) {
+	saveDeployFlags(t)
 
-		cfg := globals.Cfg.Clone()
-		applyEC2Flags(&cfg)
+	region = "eu-west-1"
+	instanceType = "c7g.large"
+	fleetName = "new-fleet"
+	ec2Arch = "arm64"
 
-		if cfg.AWS.Region != "eu-west-1" {
-			t.Errorf("local Region = %q, want %q", cfg.AWS.Region, "eu-west-1")
-		}
-		if cfg.Game.Arch != "arm64" {
-			t.Errorf("local Arch = %q, want %q", cfg.Game.Arch, "arm64")
-		}
-		if globals.Cfg.AWS.Region != "us-east-1" {
-			t.Errorf("global Region mutated: got %q, want %q", globals.Cfg.AWS.Region, "us-east-1")
-		}
-		if globals.Cfg.Game.Arch != "amd64" {
-			t.Errorf("global Arch mutated: got %q, want %q", globals.Cfg.Game.Arch, "amd64")
-		}
-	})
+	cfg := globals.Cfg.Clone()
+	applyEC2Flags(&cfg)
 
-	t.Run("applyAnywhereFlags isolates mutations", func(t *testing.T) {
-		origRegion, origFleet, origIP := region, fleetName, anywhereIP
-		t.Cleanup(func() { region, fleetName, anywhereIP = origRegion, origFleet, origIP })
+	if cfg.AWS.Region != "eu-west-1" {
+		t.Errorf("local Region = %q, want %q", cfg.AWS.Region, "eu-west-1")
+	}
+	if cfg.Game.Arch != "arm64" {
+		t.Errorf("local Arch = %q, want %q", cfg.Game.Arch, "arm64")
+	}
+	if globals.Cfg.AWS.Region != "us-east-1" {
+		t.Errorf("global Region mutated: got %q, want %q", globals.Cfg.AWS.Region, "us-east-1")
+	}
+	if globals.Cfg.Game.Arch != "amd64" {
+		t.Errorf("global Arch mutated: got %q, want %q", globals.Cfg.Game.Arch, "amd64")
+	}
+}
 
-		region = "ap-southeast-1"
-		fleetName = "anywhere-fleet"
-		anywhereIP = "192.168.1.1"
+func applyAnywhereIsolationCase(t *testing.T) {
+	saveDeployFlags(t)
 
-		cfg := globals.Cfg.Clone()
-		applyAnywhereFlags(&cfg)
+	region = "ap-southeast-1"
+	fleetName = "anywhere-fleet"
+	anywhereIP = "192.168.1.1"
 
-		if cfg.Anywhere.IPAddress != "192.168.1.1" {
-			t.Errorf("local IPAddress = %q, want %q", cfg.Anywhere.IPAddress, "192.168.1.1")
-		}
-		if globals.Cfg.Anywhere.IPAddress != "10.0.0.1" {
-			t.Errorf("global IPAddress mutated: got %q, want %q", globals.Cfg.Anywhere.IPAddress, "10.0.0.1")
-		}
-	})
+	cfg := globals.Cfg.Clone()
+	applyAnywhereFlags(&cfg)
 
-	t.Run("applyStackFlags isolates mutations", func(t *testing.T) {
-		origRegion, origInstance := region, instanceType
-		t.Cleanup(func() { region, instanceType = origRegion, origInstance })
+	if cfg.Anywhere.IPAddress != "192.168.1.1" {
+		t.Errorf("local IPAddress = %q, want %q", cfg.Anywhere.IPAddress, "192.168.1.1")
+	}
+	if globals.Cfg.Anywhere.IPAddress != "10.0.0.1" {
+		t.Errorf("global IPAddress mutated: got %q, want %q", globals.Cfg.Anywhere.IPAddress, "10.0.0.1")
+	}
+}
 
-		prev := globals.DryRun
-		globals.DryRun = true
-		defer func() { globals.DryRun = prev }()
+func applyStackIsolationCase(t *testing.T) {
+	saveDeployFlags(t)
 
-		region = "us-west-2"
-		instanceType = "m5.xlarge"
+	prev := globals.DryRun
+	globals.DryRun = true
+	defer func() { globals.DryRun = prev }()
 
-		cfg := globals.Cfg.Clone()
-		_, _, _, _, err := applyStackFlags(context.Background(), &cfg)
-		if err != nil {
-			t.Fatalf("applyStackFlags failed: %v", err)
-		}
+	region = "us-west-2"
+	instanceType = "m5.xlarge"
 
-		if cfg.AWS.Region != "us-west-2" {
-			t.Errorf("local Region = %q, want %q", cfg.AWS.Region, "us-west-2")
-		}
-		if globals.Cfg.AWS.Region != "us-east-1" {
-			t.Errorf("global Region mutated: got %q, want %q", globals.Cfg.AWS.Region, "us-east-1")
-		}
-		if globals.Cfg.GameLift.InstanceType != "c6i.large" {
-			t.Errorf("global InstanceType mutated: got %q, want %q", globals.Cfg.GameLift.InstanceType, "c6i.large")
-		}
-	})
+	cfg := globals.Cfg.Clone()
+	if _, _, _, _, err := applyStackFlags(context.Background(), &cfg); err != nil {
+		t.Fatalf("applyStackFlags failed: %v", err)
+	}
+
+	if cfg.AWS.Region != "us-west-2" {
+		t.Errorf("local Region = %q, want %q", cfg.AWS.Region, "us-west-2")
+	}
+	if globals.Cfg.AWS.Region != "us-east-1" {
+		t.Errorf("global Region mutated: got %q, want %q", globals.Cfg.AWS.Region, "us-east-1")
+	}
+	if globals.Cfg.GameLift.InstanceType != "c6i.large" {
+		t.Errorf("global InstanceType mutated: got %q, want %q", globals.Cfg.GameLift.InstanceType, "c6i.large")
+	}
 }
 
 func TestPrereqCheckerUsesOverriddenConfig(t *testing.T) {

--- a/cmd/globals/ddc_test.go
+++ b/cmd/globals/ddc_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/dockerbuild"
+	"github.com/jpvelasco/ludus/internal/state"
 )
 
 func TestResolveContainerBackend(t *testing.T) {
@@ -92,50 +93,59 @@ func TestResolveDDCMode(t *testing.T) {
 	}
 }
 
+// ddcPathCase is a single ResolveDDCPath table row. wantPath of "" means
+// "any non-empty value" (the resolver fills defaults the table doesn't pin).
+type ddcPathCase struct {
+	name      string
+	localPath string
+	nilCfg    bool
+	wantPath  string
+	wantErr   bool
+}
+
 func TestResolveDDCPath(t *testing.T) {
 	absPath := "/custom/ddc"
 	if runtime.GOOS == "windows" {
 		absPath = `C:\custom\ddc`
 	}
 
-	tests := []struct {
-		name      string
-		localPath string
-		nilCfg    bool
-		wantPath  string // exact match; empty means "any non-empty"
-		wantErr   bool
-	}{
-		{"config path", absPath, false, absPath, false},
-		{"relative path errors", "relative/ddc", false, "", true},
-		{"default path", "", false, "", false},
-		{"nil config uses default", "", true, "", false},
+	tests := []ddcPathCase{
+		{name: "config path", localPath: absPath, wantPath: absPath},
+		{name: "relative path errors", localPath: "relative/ddc", wantErr: true},
+		{name: "default path"},
+		{name: "nil config uses default", nilCfg: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			origCfg := Cfg
-			t.Cleanup(func() { Cfg = origCfg })
-
-			if tt.nilCfg {
-				Cfg = nil
-			} else {
-				Cfg = &config.Config{}
-				Cfg.DDC.LocalPath = tt.localPath
-			}
-
-			got, err := ResolveDDCPath()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ResolveDDCPath() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.wantErr {
-				return
-			}
-			if tt.wantPath != "" && got != tt.wantPath {
-				t.Errorf("ResolveDDCPath() = %q, want %q", got, tt.wantPath)
-			}
-			if tt.wantPath == "" && got == "" {
-				t.Error("ResolveDDCPath() returned empty string")
-			}
+			assertResolveDDCPath(t, tt)
 		})
+	}
+}
+
+func assertResolveDDCPath(t *testing.T, tt ddcPathCase) {
+	t.Helper()
+	origCfg := Cfg
+	t.Cleanup(func() { Cfg = origCfg })
+
+	if tt.nilCfg {
+		Cfg = nil
+	} else {
+		Cfg = &config.Config{}
+		Cfg.DDC.LocalPath = tt.localPath
+	}
+
+	got, err := ResolveDDCPath()
+	if (err != nil) != tt.wantErr {
+		t.Fatalf("ResolveDDCPath() error = %v, wantErr %v", err, tt.wantErr)
+	}
+	if tt.wantErr {
+		return
+	}
+	if tt.wantPath != "" && got != tt.wantPath {
+		t.Errorf("ResolveDDCPath() = %q, want %q", got, tt.wantPath)
+	}
+	if tt.wantPath == "" && got == "" {
+		t.Error("ResolveDDCPath() returned empty string")
 	}
 }
 
@@ -187,6 +197,19 @@ func assertOptionalEqual(t *testing.T, label, got, want string) {
 	}
 }
 
+// ddcCase is a single ResolveDDC table row. wantPath/wantZenPath of "" means
+// "don't assert exact value" (the resolver fills defaults the table doesn't pin).
+type ddcCase struct {
+	name        string
+	mode        string
+	ddcPath     string
+	zenPath     string
+	wantMode    string
+	wantPath    string
+	wantZenPath string
+	wantErr     bool
+}
+
 func TestResolveDDC(t *testing.T) {
 	absPath := "/test/ddc"
 	if runtime.GOOS == "windows" {
@@ -198,54 +221,48 @@ func TestResolveDDC(t *testing.T) {
 		absZen = `C:\test\zen`
 	}
 
-	tests := []struct {
-		name        string
-		mode        string
-		ddcPath     string
-		zenPath     string
-		wantMode    string
-		wantPath    string
-		wantZenPath string
-		wantErr     bool
-	}{
-		{"default (empty) resolves to zen", "", "", absZen, "zen", "", absZen, false},
-		{"zen mode returns zen path", "zen", "", absZen, "zen", "", absZen, false},
-		{"local mode returns local path", "local", absPath, "", "local", absPath, "", false},
-		{"none mode returns empty paths", "none", "", "", "none", "", "", false},
-		{"invalid mode errors", "garbage", "", "", "", "", "", true},
+	tests := []ddcCase{
+		{name: "default (empty) resolves to zen", zenPath: absZen, wantMode: "zen", wantZenPath: absZen},
+		{name: "zen mode returns zen path", mode: "zen", zenPath: absZen, wantMode: "zen", wantZenPath: absZen},
+		{name: "local mode returns local path", mode: "local", ddcPath: absPath, wantMode: "local", wantPath: absPath},
+		{name: "none mode returns empty paths", mode: "none", wantMode: "none"},
+		{name: "invalid mode errors", mode: "garbage", wantErr: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			origMode := DDCMode
-			origCfg := Cfg
-			t.Cleanup(func() {
-				DDCMode = origMode
-				Cfg = origCfg
-			})
-
-			DDCMode = tt.mode
-			Cfg = &config.Config{}
-			Cfg.DDC.LocalPath = tt.ddcPath
-			Cfg.DDC.ZenPath = tt.zenPath
-
-			mode, path, zenPath, err := ResolveDDC()
-			if (err != nil) != tt.wantErr {
-				t.Fatalf("ResolveDDC() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if tt.wantErr {
-				return
-			}
-			if mode != tt.wantMode {
-				t.Errorf("mode = %q, want %q", mode, tt.wantMode)
-			}
-			// wantPath/wantZenPath of "" means "don't assert exact value"
-			// (the resolver fills defaults we don't pin here).
-			assertOptionalEqual(t, "path", path, tt.wantPath)
-			assertOptionalEqual(t, "zenPath", zenPath, tt.wantZenPath)
-			if tt.wantMode == "none" && (path != "" || zenPath != "") {
-				t.Errorf("none mode should return empty paths, got path=%q zenPath=%q", path, zenPath)
-			}
+			assertResolveDDC(t, tt)
 		})
+	}
+}
+
+func assertResolveDDC(t *testing.T, tt ddcCase) {
+	t.Helper()
+	origMode := DDCMode
+	origCfg := Cfg
+	t.Cleanup(func() {
+		DDCMode = origMode
+		Cfg = origCfg
+	})
+
+	DDCMode = tt.mode
+	Cfg = &config.Config{}
+	Cfg.DDC.LocalPath = tt.ddcPath
+	Cfg.DDC.ZenPath = tt.zenPath
+
+	mode, path, zenPath, err := ResolveDDC()
+	if (err != nil) != tt.wantErr {
+		t.Fatalf("ResolveDDC() error = %v, wantErr %v", err, tt.wantErr)
+	}
+	if tt.wantErr {
+		return
+	}
+	if mode != tt.wantMode {
+		t.Errorf("mode = %q, want %q", mode, tt.wantMode)
+	}
+	assertOptionalEqual(t, "path", path, tt.wantPath)
+	assertOptionalEqual(t, "zenPath", zenPath, tt.wantZenPath)
+	if tt.wantMode == "none" && (path != "" || zenPath != "") {
+		t.Errorf("none mode should return empty paths, got path=%q zenPath=%q", path, zenPath)
 	}
 }
 
@@ -285,5 +302,48 @@ func TestResolveContainerGameOptionsInvalidDDC(t *testing.T) {
 	DDCMode = "invalid"
 	if _, err := ResolveContainerGameOptions(Cfg, "docker"); err == nil {
 		t.Fatal("expected invalid DDC mode error")
+	}
+}
+
+func TestResolveEngineImage_StateImageTag(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cfg := &config.Config{}
+	cfg.Engine.DockerImageName = "configured-name"
+	cfg.Engine.Version = "9.9.9"
+	if err := state.UpdateEngineImage(&state.EngineImageState{ImageTag: "state-engine:5.7"}); err != nil {
+		t.Fatalf("UpdateEngineImage: %v", err)
+	}
+
+	got, err := ResolveEngineImage(cfg, true)
+	if err != nil {
+		t.Fatalf("ResolveEngineImage() error = %v, want nil", err)
+	}
+	if got != "state-engine:5.7" {
+		t.Errorf("ResolveEngineImage() = %q, want %q", got, "state-engine:5.7")
+	}
+}
+
+func TestResolveDDC_PathErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		mode      string
+		localPath string
+		zenPath   string
+	}{
+		{name: "relative local path errors", mode: "local", localPath: "relative/ddc"},
+		{name: "relative zen path errors", mode: "zen", zenPath: "relative/zen"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origMode, origCfg := DDCMode, Cfg
+			t.Cleanup(func() { DDCMode, Cfg = origMode, origCfg })
+			DDCMode = tt.mode
+			Cfg = &config.Config{}
+			Cfg.DDC.LocalPath = tt.localPath
+			Cfg.DDC.ZenPath = tt.zenPath
+			if _, _, _, err := ResolveDDC(); err == nil {
+				t.Fatal("expected DDC path resolution error")
+			}
+		})
 	}
 }

--- a/cmd/globals/resolve_targets_test.go
+++ b/cmd/globals/resolve_targets_test.go
@@ -1,0 +1,60 @@
+package globals
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+// TestResolveTarget_AWSTargets exercises the target factory switch for every
+// target that resolves AWS state. Dry-run keeps the awsenv resolver offline:
+// the region comes from config, the account from the placeholder, and the
+// deployer constructors are pure, so no network or credentials are touched.
+func TestResolveTarget_AWSTargets(t *testing.T) {
+	tests := []struct {
+		name         string
+		target       string
+		instanceType string
+		arch         string
+		projectPath  string
+		wantName     string
+		wantErr      bool
+	}{
+		{name: "empty defaults to gamelift", wantName: "gamelift"},
+		{name: "gamelift", target: "gamelift", wantName: "gamelift"},
+		{name: "gamelift arch mismatch", target: "gamelift", instanceType: "c7g.large", arch: "amd64", wantName: "gamelift"},
+		{name: "stack", target: "stack", wantName: "stack"},
+		{name: "stack arch mismatch", target: "stack", instanceType: "c7g.large", arch: "amd64", wantName: "stack"},
+		{name: "anywhere", target: "anywhere", projectPath: "C:\\projects\\MyGame\\MyGame.uproject", wantName: "anywhere"},
+		{name: "anywhere missing project path", target: "anywhere", wantErr: true},
+		{name: "ec2", target: "ec2", wantName: "ec2"},
+		{name: "ec2 arch mismatch", target: "ec2", instanceType: "c7g.large", arch: "amd64", wantName: "ec2"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cfg := &config.Config{
+				Deploy:    config.DeployConfig{Target: tt.target},
+				Game:      config.GameConfig{Arch: tt.arch, ProjectPath: tt.projectPath},
+				GameLift:  config.GameLiftConfig{InstanceType: tt.instanceType},
+				AWS:       config.AWSConfig{Region: "us-west-2", AccountID: "123456789012", ECRRepository: "ludus-server"},
+				Container: config.ContainerConfig{Tag: "latest"},
+			}
+			SetGlobals(t, cfg, WithDryRun(true))
+
+			target, err := ResolveTarget(context.Background(), cfg, "")
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("ResolveTarget() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if target == nil {
+				t.Fatal("ResolveTarget() returned nil target")
+			}
+			if got := target.Name(); got != tt.wantName {
+				t.Errorf("target.Name() = %q, want %q", got, tt.wantName)
+			}
+		})
+	}
+}

--- a/cmd/globals/resolve_test.go
+++ b/cmd/globals/resolve_test.go
@@ -2,6 +2,7 @@ package globals
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
@@ -191,5 +192,51 @@ func TestResolveSessionTarget_UnknownStateFallbackErrors(t *testing.T) {
 	_, err := ResolveSessionTarget(ctx, Cfg)
 	if err == nil {
 		t.Fatal("expected error for unknown fallback target, got nil")
+	}
+}
+
+// sessionStubTarget embeds swapStubTarget (deploy.Target) and adds the
+// deploy.SessionManager methods so ResolveSessionTarget takes the direct
+// return path instead of falling through to state.
+type sessionStubTarget struct {
+	swapStubTarget
+}
+
+func (s *sessionStubTarget) CreateSession(context.Context, int) (*deploy.SessionInfo, error) {
+	return nil, nil
+}
+
+func (s *sessionStubTarget) DescribeSession(context.Context, string) (string, error) {
+	return "", nil
+}
+
+// TestResolveSessionTarget_DirectSessionManagerTarget verifies that a config
+// target implementing SessionManager is returned without consulting state.
+func TestResolveSessionTarget_DirectSessionManagerTarget(t *testing.T) {
+	stub := &sessionStubTarget{swapStubTarget{name: "session"}}
+	SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return stub, nil
+	})
+
+	target, err := ResolveSessionTarget(context.Background(), &config.Config{})
+	if err != nil {
+		t.Fatalf("ResolveSessionTarget() error = %v, want nil", err)
+	}
+	if target != stub {
+		t.Errorf("ResolveSessionTarget() = %v, want the session stub", target)
+	}
+}
+
+// TestResolveSessionTarget_ConfigError verifies an error from ResolveTarget is
+// returned unchanged.
+func TestResolveSessionTarget_ConfigError(t *testing.T) {
+	wantErr := errors.New("resolve exploded")
+	SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return nil, wantErr
+	})
+
+	_, err := ResolveSessionTarget(context.Background(), &config.Config{})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("ResolveSessionTarget() error = %v, want %v", err, wantErr)
 	}
 }

--- a/cmd/globals/runner_test.go
+++ b/cmd/globals/runner_test.go
@@ -3,6 +3,7 @@ package globals
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/config"
@@ -138,4 +139,61 @@ func TestSectionLogWithoutActiveLog(t *testing.T) {
 	defer resetRunnerState(t)
 
 	SectionLog("build")
+}
+
+func TestNewRunner_UsesDefaultLogDirAndName(t *testing.T) {
+	resetRunnerState(t)
+	defer resetRunnerState(t)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	Cfg = &config.Config{} // logs enabled by default; Dir and CommandName empty
+
+	_ = NewRunner()
+	CloseBuildLog()
+
+	entries, err := os.ReadDir(filepath.Join(dir, ".ludus", "logs"))
+	if err != nil {
+		t.Fatalf("expected default logs dir created: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("expected 1 log file, got %d", len(entries))
+	}
+	if !strings.HasPrefix(entries[0].Name(), "ludus-") {
+		t.Errorf("log file name = %q, want ludus- prefix", entries[0].Name())
+	}
+}
+
+func TestNewRunner_LogOpenFailureIsNonFatal(t *testing.T) {
+	resetRunnerState(t)
+	defer resetRunnerState(t)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	blocker := filepath.Join(dir, "blocked")
+	if err := os.WriteFile(blocker, []byte("x"), 0o644); err != nil {
+		t.Fatalf("creating blocker file: %v", err)
+	}
+	Cfg = &config.Config{}
+	Cfg.Observability.Logs.Dir = filepath.Join(blocker, "logs")
+
+	r := NewRunner()
+	if r == nil {
+		t.Fatal("NewRunner() = nil, want a runner even when the log cannot open")
+	}
+	CloseBuildLog()
+}
+
+func TestSectionLogWithActiveLog(t *testing.T) {
+	resetRunnerState(t)
+	defer resetRunnerState(t)
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	Cfg = config.Defaults()
+	CommandName = "engine"
+
+	_ = NewRunner()
+	SectionLog("stage")
+	CloseBuildLog()
 }

--- a/cmd/globals/tracing_test.go
+++ b/cmd/globals/tracing_test.go
@@ -1,0 +1,74 @@
+package globals
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+// clearOTELEnv blanks the standard OpenTelemetry env vars so a disabled config
+// stays disabled regardless of the host environment.
+func clearOTELEnv(t *testing.T) {
+	t.Helper()
+	for _, k := range []string{"OTEL_TRACES_EXPORTER", "OTEL_EXPORTER_OTLP_ENDPOINT", "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT"} {
+		t.Setenv(k, "")
+	}
+}
+
+func TestInitTracingDisabled(t *testing.T) {
+	clearOTELEnv(t)
+	origCfg := Cfg
+	t.Cleanup(func() { Cfg = origCfg })
+
+	tests := []struct {
+		name string
+		cfg  *config.Config
+	}{
+		{name: "nil config", cfg: nil},
+		{name: "otlp disabled in config", cfg: &config.Config{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			tracerShutdown = nil
+			Cfg = tt.cfg
+			if err := InitTracing(context.Background()); err != nil {
+				t.Fatalf("InitTracing() error = %v, want nil", err)
+			}
+			if tracerShutdown == nil {
+				t.Fatal("tracerShutdown must be set even when tracing is disabled")
+			}
+		})
+	}
+}
+
+func TestInitTracingEnabledAndShutdown(t *testing.T) {
+	clearOTELEnv(t)
+	origCfg := Cfg
+	t.Cleanup(func() { Cfg = origCfg })
+
+	Cfg = &config.Config{}
+	Cfg.Observability.OTLP = config.OTLPConfig{
+		Enabled:  true,
+		Endpoint: "127.0.0.1:4318",
+		Insecure: true,
+		Headers:  map[string]string{"test": "1"},
+	}
+	tracerShutdown = nil
+
+	if err := InitTracing(context.Background()); err != nil {
+		t.Fatalf("InitTracing(enabled) error = %v, want nil", err)
+	}
+	if tracerShutdown == nil {
+		t.Fatal("tracerShutdown must be set after enabled InitTracing")
+	}
+	ShutdownTracing(context.Background())
+	if tracerShutdown != nil {
+		t.Error("tracerShutdown must be cleared by ShutdownTracing")
+	}
+}
+
+func TestShutdownTracingNoopWhenUnset(t *testing.T) {
+	tracerShutdown = nil
+	ShutdownTracing(context.Background())
+}

--- a/cmd/mcp/tools_deploy_extra_test.go
+++ b/cmd/mcp/tools_deploy_extra_test.go
@@ -1,0 +1,230 @@
+package mcp
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/deploy"
+	"github.com/jpvelasco/ludus/internal/state"
+)
+
+// TestHandleDeployFleetResolveError covers the ResolveTarget failure branch
+// (tools_deploy.go:176-179).
+func TestHandleDeployFleetResolveError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{})
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return nil, errors.New("resolve exploded")
+	})
+
+	result, _, err := handleDeployFleet(context.Background(), nil, deployFleetInput{})
+	if err != nil {
+		t.Fatalf("handleDeployFleet() error = %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "could not resolve deploy target") {
+		t.Errorf("result = %q, want resolution failure", text)
+	}
+}
+
+// TestHandleDeployFleetDeployError covers the target.Deploy failure branch
+// (tools_deploy.go:208-211).
+func TestHandleDeployFleetDeployError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{
+		AWS:       config.AWSConfig{ECRRepository: "ludus-server"},
+		Container: config.ContainerConfig{Tag: "5.7.3"},
+	}, globals.WithDryRun(true))
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return &testDeployTarget{name: "gamelift", err: errors.New("fleet deploy failed")}, nil
+	})
+
+	result, _, err := handleDeployFleet(context.Background(), nil, deployFleetInput{DryRun: true})
+	if err != nil {
+		t.Fatalf("handleDeployFleet() error = %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "fleet deployment failed") {
+		t.Errorf("result = %q, want fleet deployment failure", text)
+	}
+}
+
+// TestHandleDeployStackAutoSwitchAndEnvError covers the pricing.AutoSwitch branch
+// (tools_deploy.go:234-236) and the AWS env resolution failure (244-246). The
+// mismatched arch/instance type triggers the switch before the env resolve fails.
+func TestHandleDeployStackAutoSwitchAndEnvError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	t.Setenv("AWS_PROFILE", "ludus-does-not-exist-anywhere")
+	t.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+
+	cfg := &config.Config{
+		Game:     config.GameConfig{ProjectName: "Lyra", ProjectPath: "Lyra.uproject", Arch: "arm64"},
+		GameLift: config.GameLiftConfig{FleetName: "testfleet", InstanceType: "c5.large"},
+	}
+	globals.SetGlobals(t, cfg)
+
+	result, _, err := handleDeployStack(context.Background(), nil, deployStackInput{})
+	if err != nil {
+		t.Fatalf("handleDeployStack() error = %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "could not resolve AWS environment") {
+		t.Errorf("result = %q, want AWS environment failure", text)
+	}
+}
+
+// TestHandleDeployAnywhereResolveError covers the anywhere ResolveTarget branch
+// (tools_deploy.go:297-299).
+func TestHandleDeployAnywhereResolveError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{})
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return nil, errors.New("resolve exploded")
+	})
+
+	result, _, err := handleDeployAnywhere(context.Background(), nil, deployAnywhereInput{})
+	if err != nil {
+		t.Fatalf("handleDeployAnywhere() error = %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "could not resolve anywhere target") {
+		t.Errorf("result = %q, want anywhere resolution failure", text)
+	}
+}
+
+// TestHandleDeployAnywhereDeployError covers the anywhere Deploy failure branch
+// (tools_deploy.go:317-320).
+func TestHandleDeployAnywhereDeployError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{}, globals.WithDryRun(true))
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return &testDeployTarget{name: "anywhere", err: errors.New("anywhere deploy failed")}, nil
+	})
+
+	result, _, err := handleDeployAnywhere(context.Background(), nil, deployAnywhereInput{DryRun: true})
+	if err != nil {
+		t.Fatalf("handleDeployAnywhere() error = %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "anywhere deployment failed") {
+		t.Errorf("result = %q, want anywhere deployment failure", text)
+	}
+}
+
+// TestHandleDeployEC2ResolveError covers the ec2 ResolveTarget branch
+// (tools_deploy.go:343-345).
+func TestHandleDeployEC2ResolveError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{})
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return nil, errors.New("resolve exploded")
+	})
+
+	result, _, err := handleDeployEC2(context.Background(), nil, deployEC2Input{})
+	if err != nil {
+		t.Fatalf("handleDeployEC2() error = %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "could not resolve ec2 target") {
+		t.Errorf("result = %q, want ec2 resolution failure", text)
+	}
+}
+
+// TestHandleDeployEC2DeployError covers the ec2 Deploy failure branch
+// (tools_deploy.go:363-366).
+func TestHandleDeployEC2DeployError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{}, globals.WithDryRun(true))
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return &testDeployTarget{name: "ec2", err: errors.New("ec2 deploy failed")}, nil
+	})
+
+	result, _, err := handleDeployEC2(context.Background(), nil, deployEC2Input{DryRun: true})
+	if err != nil {
+		t.Fatalf("handleDeployEC2() error = %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "EC2 fleet deployment failed") {
+		t.Errorf("result = %q, want ec2 deployment failure", text)
+	}
+}
+
+// TestHandleDeployEC2ReadsStateFleet covers the state EC2Fleet read after a
+// successful deploy (tools_deploy.go:374-378).
+func TestHandleDeployEC2ReadsStateFleet(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{
+		Game: config.GameConfig{ProjectName: "Lyra", ProjectPath: "Lyra.uproject", Arch: "amd64"},
+	}, globals.WithDryRun(true))
+
+	if err := state.UpdateEC2Fleet(&state.EC2FleetState{FleetID: "fleet-ec2-123", BuildID: "build-ec2-456"}); err != nil {
+		t.Fatalf("state.UpdateEC2Fleet: %v", err)
+	}
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return &testDeployTarget{name: "ec2", result: &deploy.DeployResult{TargetName: "ec2", Status: "CREATED"}}, nil
+	})
+
+	result, _, err := handleDeployEC2(context.Background(), nil, deployEC2Input{DryRun: true})
+	if err != nil {
+		t.Fatalf("handleDeployEC2() error = %v", err)
+	}
+	text := toolResultText(t, result)
+	if !strings.Contains(text, "fleet-ec2-123") || !strings.Contains(text, "build-ec2-456") {
+		t.Errorf("result = %q, want fleet and build IDs from state", text)
+	}
+}
+
+// TestHandleDeploySessionResolveError covers the ResolveSessionTarget failure
+// branch (tools_deploy.go:389-391).
+func TestHandleDeploySessionResolveError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	globals.SetGlobals(t, &config.Config{Deploy: config.DeployConfig{Target: "gamelift"}})
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return nil, errors.New("resolve exploded")
+	})
+
+	result, _, err := handleDeploySession(context.Background(), nil, deploySessionInput{})
+	if err != nil {
+		t.Fatalf("handleDeploySession() error = %v", err)
+	}
+	if text := toolResultText(t, result); !strings.Contains(text, "could not resolve deploy target") {
+		t.Errorf("result = %q, want session resolution failure", text)
+	}
+}
+
+// TestRunDestroyForMCPDestroyError covers the single-target Destroy failure
+// branch (tools_deploy.go:456-458).
+func TestRunDestroyForMCPDestroyError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cfg := &config.Config{}
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return &testDeployTarget{name: "gamelift", err: errors.New("destroy exploded")}, nil
+	})
+
+	err := runDestroyForMCP(context.Background(), cfg, deployDestroyInput{Target: "gamelift"})
+	if err == nil || !strings.Contains(err.Error(), "destroy exploded") {
+		t.Fatalf("runDestroyForMCP() error = %v, want destroy failure", err)
+	}
+}
+
+// TestDestroyAllTargetsContinuesOnDestroyError covers destroyAllTargets
+// continuing past a Destroy error (tools_deploy.go:475-477).
+func TestDestroyAllTargetsContinuesOnDestroyError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cfg := &config.Config{}
+
+	globals.SwapResolveTarget(t, func(context.Context, *config.Config, string) (deploy.Target, error) {
+		return &testDeployTarget{name: "target", err: errors.New("destroy exploded")}, nil
+	})
+
+	err := runDestroyForMCP(context.Background(), cfg, deployDestroyInput{AllTargets: true})
+	if err != nil {
+		t.Fatalf("runDestroyForMCP(all) error = %v, want nil", err)
+	}
+}

--- a/cmd/mcp/tools_resources_test.go
+++ b/cmd/mcp/tools_resources_test.go
@@ -1,0 +1,46 @@
+package mcp
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+// TestHandleResourcesLoadAWSConfigFailure drives handleResources through its
+// LoadAWSConfig error branch (tools_resources.go:32-35). A bogus AWS profile
+// makes awsconfig.LoadDefaultConfig fail deterministically and without network,
+// covering region defaulting (input empty -> config region) and the explicit
+// region override path (input set -> used verbatim).
+func TestHandleResourcesLoadAWSConfigFailure(t *testing.T) {
+	t.Setenv("AWS_PROFILE", "ludus-does-not-exist-anywhere")
+	t.Setenv("AWS_SDK_LOAD_CONFIG", "1")
+
+	tests := []struct {
+		name  string
+		input resourcesInput
+	}{
+		{name: "region defaults from config", input: resourcesInput{}},
+		{name: "explicit region override", input: resourcesInput{Region: "eu-central-1"}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			origCfg := globals.Cfg
+			t.Cleanup(func() { globals.Cfg = origCfg })
+			globals.Cfg = &config.Config{AWS: config.AWSConfig{Region: "us-west-2"}}
+
+			result, _, err := handleResources(context.Background(), nil, tt.input)
+			if err != nil {
+				t.Fatalf("handleResources() error = %v", err)
+			}
+			if !result.IsError {
+				t.Fatal("handleResources() should return an error result")
+			}
+			if text := toolResultText(t, result); !strings.Contains(text, "could not load AWS config") {
+				t.Errorf("result = %q, want AWS config load failure", text)
+			}
+		})
+	}
+}

--- a/cmd/setup/aws_test.go
+++ b/cmd/setup/aws_test.go
@@ -1,0 +1,74 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+// forceNoAWS blanks every AWS configuration source (env vars and config files)
+// so the SDK credential/region chain resolves nothing, making detectAWSAccountID
+// deterministic and network-free.
+func forceNoAWS(t *testing.T) {
+	t.Helper()
+	empty := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(empty, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, key := range []string{
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_PROFILE",
+		"AWS_REGION",
+		"AWS_DEFAULT_REGION",
+		"AWS_WEB_IDENTITY_TOKEN_FILE",
+	} {
+		t.Setenv(key, "")
+	}
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	t.Setenv("AWS_CONFIG_FILE", empty)
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", empty)
+}
+
+func TestDetectAWSAccountIDNoCredentials(t *testing.T) {
+	forceNoAWS(t)
+	if got := detectAWSAccountID(); got != "" {
+		t.Errorf("detectAWSAccountID() = %q, want empty", got)
+	}
+}
+
+func TestPromptAWSDefaultNoDetection(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		wantR string
+		wantA string
+	}{
+		{name: "typed values", input: "eu-west-1\n123456789012\n", wantR: "eu-west-1", wantA: "123456789012"},
+		{name: "defaults", input: "\n\n", wantR: "us-east-1", wantA: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			forceNoAWS(t)
+			withScannerInput(t, tt.input)
+			region, account := promptAWSDefault("us-east-1", nil)
+			if region != tt.wantR || account != tt.wantA {
+				t.Errorf("promptAWSDefault() = %q, %q; want %q, %q", region, account, tt.wantR, tt.wantA)
+			}
+		})
+	}
+}
+
+func TestPromptAWSDefaultExistingAccount(t *testing.T) {
+	forceNoAWS(t)
+	existing := &config.Config{}
+	existing.AWS.AccountID = "111122223333"
+	withScannerInput(t, "\n\n")
+	region, account := promptAWSDefault("us-east-1", existing)
+	if region != "us-east-1" || account != "111122223333" {
+		t.Errorf("promptAWSDefault() = %q, %q; want us-east-1, 111122223333", region, account)
+	}
+}

--- a/cmd/setup/config_writer_test.go
+++ b/cmd/setup/config_writer_test.go
@@ -1,0 +1,85 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestWriteConfigError(t *testing.T) {
+	answers := setupAnswers{
+		cfgFile:      filepath.Join(t.TempDir(), "missing", "ludus.yaml"),
+		projectName:  "Game",
+		deployTarget: "gamelift",
+	}
+	if err := writeConfig(answers, nil); err == nil {
+		t.Error("writeConfig() expected error for missing directory")
+	}
+}
+
+func TestWriteConfigRegionDefault(t *testing.T) {
+	t.Chdir(t.TempDir())
+	answers := setupAnswers{
+		cfgFile:      "ludus.yaml",
+		projectName:  "Game",
+		deployTarget: "gamelift",
+		instanceType: "c6i.large",
+	}
+	if err := writeConfig(answers, nil); err != nil {
+		t.Fatalf("writeConfig() error: %v", err)
+	}
+	data, err := os.ReadFile("ludus.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "region: us-east-1") {
+		t.Errorf("expected default region us-east-1:\n%s", data)
+	}
+}
+
+func TestWriteConfigProjectPath(t *testing.T) {
+	t.Chdir(t.TempDir())
+	answers := setupAnswers{
+		cfgFile:      "ludus.yaml",
+		projectName:  "Game",
+		projectPath:  "/games/Game.uproject",
+		deployTarget: "binary",
+		region:       "us-west-2",
+	}
+	if err := writeConfig(answers, nil); err != nil {
+		t.Fatalf("writeConfig() error: %v", err)
+	}
+	data, err := os.ReadFile("ludus.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "projectpath: /games/Game.uproject") {
+		t.Errorf("expected projectPath in config:\n%s", data)
+	}
+}
+
+func TestPreserveExistingTags(t *testing.T) {
+	t.Chdir(t.TempDir())
+	existing := &config.Config{}
+	existing.AWS.Tags = map[string]string{"Team": "games"}
+	answers := setupAnswers{
+		cfgFile:      "ludus.yaml",
+		projectName:  "Game",
+		deployTarget: "gamelift",
+		region:       "us-east-1",
+		instanceType: "c6i.large",
+	}
+	if err := writeConfig(answers, existing); err != nil {
+		t.Fatalf("writeConfig() error: %v", err)
+	}
+	data, err := os.ReadFile("ludus.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "Team: games") {
+		t.Errorf("expected preserved aws.tags:\n%s", data)
+	}
+}

--- a/cmd/setup/engine_discovery_branches_test.go
+++ b/cmd/setup/engine_discovery_branches_test.go
@@ -1,0 +1,61 @@
+package setup
+
+import (
+	"path/filepath"
+	"reflect"
+	"testing"
+)
+
+func TestPromptEnginePathDefaultBranches(t *testing.T) {
+	t.Run("no candidates prompts", func(t *testing.T) {
+		t.Chdir(t.TempDir())
+		setTestHome(t, t.TempDir())
+		withScannerInput(t, "\n")
+		if got := promptEnginePathDefault("fallback"); got != "fallback" {
+			t.Errorf("got %q, want fallback", got)
+		}
+	})
+	t.Run("enter different path", func(t *testing.T) {
+		_, _ = engineChoiceRoot(t)
+		withScannerInput(t, "2\n/manual/path\n")
+		if got := promptEnginePathDefault("defpath"); got != "/manual/path" {
+			t.Errorf("got %q, want /manual/path", got)
+		}
+	})
+	t.Run("invalid choice uses default", func(t *testing.T) {
+		_, _ = engineChoiceRoot(t)
+		withScannerInput(t, "9\n")
+		if got := promptEnginePathDefault("defpath"); got != "defpath" {
+			t.Errorf("got %q, want defpath", got)
+		}
+	})
+}
+
+func TestScanEnginePathsFiltersNonEngine(t *testing.T) {
+	root := t.TempDir()
+	working := filepath.Join(root, "project")
+	createDirectory(t, working)
+	createDirectory(t, filepath.Join(root, "UnrealEngine-no-setup"))
+	valid := createEngineCandidate(t, root, "UnrealEngine-real")
+	t.Chdir(working)
+	setTestHome(t, filepath.Join(root, "empty-home"))
+
+	got := scanEnginePaths()
+	if !reflect.DeepEqual(got, []string{valid}) {
+		t.Fatalf("scanEnginePaths() = %v, want [%s]", got, valid)
+	}
+}
+
+// TestScanHomeEnginePathsEmptyHome forces os.UserHomeDir to fail by blanking
+// every Windows home env var, exercising the home == "" early return.
+func TestScanHomeEnginePathsEmptyHome(t *testing.T) {
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("HOME", "")
+	called := false
+	scanHomeEnginePaths(func(string) { called = true })
+	if called {
+		t.Error("callback called with empty home")
+	}
+}

--- a/cmd/setup/project_test.go
+++ b/cmd/setup/project_test.go
@@ -1,0 +1,73 @@
+package setup
+
+import (
+	"path/filepath"
+	"testing"
+)
+
+func TestPromptLyraContentEngineSample(t *testing.T) {
+	t.Run("engine sample with discovered content accepted", func(t *testing.T) {
+		enginePath := t.TempDir()
+		createFile(t, filepath.Join(enginePath, "Samples", "Games", "Lyra", "Lyra.uproject"))
+		home := t.TempDir()
+		setTestHome(t, home)
+		content := filepath.Join(home, "Documents", "Unreal Projects", "LyraStarterGame")
+		createFile(t, filepath.Join(content, "Lyra.uproject"))
+		withScannerInput(t, "\n")
+		if got := promptLyraContent(enginePath); got != content {
+			t.Errorf("got %q, want %q", got, content)
+		}
+	})
+	t.Run("engine sample with declined content prompts", func(t *testing.T) {
+		enginePath := t.TempDir()
+		createFile(t, filepath.Join(enginePath, "Samples", "Games", "Lyra", "Lyra.uproject"))
+		home := t.TempDir()
+		setTestHome(t, home)
+		createFile(t, filepath.Join(home, "Documents", "Unreal Projects", "LyraStarterGame", "Lyra.uproject"))
+		withScannerInput(t, "n\n/manual/content\n")
+		if got := promptLyraContent(enginePath); got != "/manual/content" {
+			t.Errorf("got %q, want /manual/content", got)
+		}
+	})
+	t.Run("engine sample with no content skips", func(t *testing.T) {
+		enginePath := t.TempDir()
+		createFile(t, filepath.Join(enginePath, "Samples", "Games", "Lyra", "Lyra.uproject"))
+		setTestHome(t, t.TempDir())
+		withScannerInput(t, "\n")
+		if got := promptLyraContent(enginePath); got != "" {
+			t.Errorf("got %q, want empty", got)
+		}
+	})
+}
+
+func TestPromptGameProjectDefaultLyraWithEngine(t *testing.T) {
+	enginePath := t.TempDir()
+	setTestHome(t, t.TempDir())
+	withScannerInput(t, "Lyra\n/games/content\n")
+	name, projectPath, content := promptGameProjectDefault(enginePath, "Lyra", nil)
+	if name != "Lyra" || projectPath != "" || content != "/games/content" {
+		t.Errorf("answers = %q, %q, %q", name, projectPath, content)
+	}
+}
+
+func TestDiscoverLyraContentOneDrive(t *testing.T) {
+	home := t.TempDir()
+	setTestHome(t, home)
+	oneDrive := t.TempDir()
+	t.Setenv("OneDrive", oneDrive)
+	lyraDir := filepath.Join(oneDrive, "Documents", "Unreal Projects", "LyraStarterGame")
+	createFile(t, filepath.Join(lyraDir, "Lyra.uproject"))
+	if got := discoverLyraContent(); got != lyraDir {
+		t.Errorf("got %q, want %q", got, lyraDir)
+	}
+}
+
+func TestDiscoverLyraContentNoHome(t *testing.T) {
+	t.Setenv("USERPROFILE", "")
+	t.Setenv("HOMEDRIVE", "")
+	t.Setenv("HOMEPATH", "")
+	t.Setenv("HOME", "")
+	if got := discoverLyraContent(); got != "" {
+		t.Errorf("got %q, want empty", got)
+	}
+}

--- a/cmd/setup/project_test.go
+++ b/cmd/setup/project_test.go
@@ -2,6 +2,7 @@ package setup
 
 import (
 	"path/filepath"
+	"runtime"
 	"testing"
 )
 
@@ -57,8 +58,16 @@ func TestDiscoverLyraContentOneDrive(t *testing.T) {
 	t.Setenv("OneDrive", oneDrive)
 	lyraDir := filepath.Join(oneDrive, "Documents", "Unreal Projects", "LyraStarterGame")
 	createFile(t, filepath.Join(lyraDir, "Lyra.uproject"))
-	if got := discoverLyraContent(); got != lyraDir {
-		t.Errorf("got %q, want %q", got, lyraDir)
+	got := discoverLyraContent()
+	if runtime.GOOS == "windows" {
+		if got != lyraDir {
+			t.Errorf("got %q, want %q", got, lyraDir)
+		}
+		return
+	}
+	// OneDrive candidates are only scanned on Windows (source behavior).
+	if got != "" {
+		t.Errorf("got %q, want empty on non-Windows", got)
 	}
 }
 

--- a/cmd/setup/wizard_test.go
+++ b/cmd/setup/wizard_test.go
@@ -1,0 +1,220 @@
+package setup
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+// engineChoiceRoot builds a temp root containing a working dir and an engine
+// candidate with a Build.version, then chdirs into the working dir and points
+// the home dir at an empty location. This makes scanEnginePaths deterministic
+// (the controlled candidate is always candidates[0]).
+func engineChoiceRoot(t *testing.T) (string, string) {
+	t.Helper()
+	root := t.TempDir()
+	working := filepath.Join(root, "project")
+	createDirectory(t, working)
+	enginePath := createEngineCandidate(t, root, "UnrealEngine-5.8")
+	writeBuildVersion(t, enginePath, 5, 8, 1)
+	t.Chdir(working)
+	setTestHome(t, filepath.Join(root, "empty-home"))
+	return root, enginePath
+}
+
+// emptyEnvironment chdirs to an empty dir and points home at an empty location
+// so scanEnginePaths finds no engine candidates.
+func emptyEnvironment(t *testing.T) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	setTestHome(t, t.TempDir())
+}
+
+func TestCollectEngineAnswers(t *testing.T) {
+	t.Run("empty path skips detection", func(t *testing.T) {
+		emptyEnvironment(t)
+		withScannerInput(t, "\n")
+		var a setupAnswers
+		collectEngineAnswers(&a, nil)
+		if a.enginePath != "" || a.engineVersion != "" {
+			t.Errorf("answers = %q, %q; want empty", a.enginePath, a.engineVersion)
+		}
+	})
+	t.Run("path auto-detects version", func(t *testing.T) {
+		_, enginePath := engineChoiceRoot(t)
+		withScannerInput(t, "1\n")
+		var a setupAnswers
+		collectEngineAnswers(&a, nil)
+		if a.enginePath != enginePath || a.engineVersion != "5.8.1" {
+			t.Errorf("answers = %q, %q; want %q, 5.8.1", a.enginePath, a.engineVersion, enginePath)
+		}
+	})
+}
+
+func TestCollectProjectAnswers(t *testing.T) {
+	t.Run("custom project", func(t *testing.T) {
+		uproject := filepath.Join(t.TempDir(), "Game.uproject")
+		createFile(t, uproject)
+		withScannerInput(t, "MyGame\n"+uproject+"\n")
+		var a setupAnswers
+		a.enginePath = "/opt/engine"
+		collectProjectAnswers(&a, nil)
+		if a.projectName != "MyGame" || a.projectPath != uproject || a.contentSourcePath != "" {
+			t.Errorf("answers = %q, %q, %q", a.projectName, a.projectPath, a.contentSourcePath)
+		}
+	})
+	t.Run("lyra content fallback", func(t *testing.T) {
+		setTestHome(t, t.TempDir())
+		withScannerInput(t, "Lyra\n\n")
+		var a setupAnswers
+		a.enginePath = t.TempDir()
+		collectProjectAnswers(&a, nil)
+		if a.projectName != "Lyra" || a.projectPath != "" || a.contentSourcePath != "" {
+			t.Errorf("answers = %q, %q, %q", a.projectName, a.projectPath, a.contentSourcePath)
+		}
+	})
+}
+
+func TestCollectAWSAnswers(t *testing.T) {
+	t.Run("gamelift prompts instance", testCollectAWSGamelift)
+	t.Run("binary skips instance", testCollectAWSBinary)
+	t.Run("existing defaults", testCollectAWSExisting)
+}
+
+func testCollectAWSGamelift(t *testing.T) {
+	forceNoAWS(t)
+	withScannerInput(t, "eu-west-1\n123456789012\nc6i.2xlarge\n")
+	var a setupAnswers
+	a.deployTarget = "gamelift"
+	collectAWSAnswers(&a, nil)
+	if a.region != "eu-west-1" || a.accountID != "123456789012" || a.instanceType != "c6i.2xlarge" {
+		t.Errorf("answers = %q, %q, %q", a.region, a.accountID, a.instanceType)
+	}
+}
+
+func testCollectAWSBinary(t *testing.T) {
+	forceNoAWS(t)
+	withScannerInput(t, "\n\n")
+	var a setupAnswers
+	a.deployTarget = "binary"
+	collectAWSAnswers(&a, nil)
+	if a.instanceType != "c6i.large" || a.region != "us-east-1" {
+		t.Errorf("answers = %q, %q", a.region, a.instanceType)
+	}
+}
+
+func testCollectAWSExisting(t *testing.T) {
+	forceNoAWS(t)
+	existing := &config.Config{}
+	existing.AWS.Region = "ap-south-1"
+	existing.AWS.AccountID = "111122223333"
+	existing.GameLift.InstanceType = "m5.large"
+	withScannerInput(t, "\n\n\n")
+	var a setupAnswers
+	a.deployTarget = "gamelift"
+	collectAWSAnswers(&a, existing)
+	if a.region != "ap-south-1" || a.accountID != "111122223333" || a.instanceType != "m5.large" {
+		t.Errorf("answers = %q, %q, %q", a.region, a.accountID, a.instanceType)
+	}
+}
+
+func TestPrintSummaryInstanceType(t *testing.T) {
+	output := captureSetupStdout(t, func() {
+		printSummary(setupAnswers{
+			cfgFile: "ludus.yaml", projectName: "Game",
+			deployTarget: "gamelift", instanceType: "c6i.xlarge",
+		})
+	})
+	if !strings.Contains(output, "Instance type:  c6i.xlarge") {
+		t.Errorf("summary missing instance type:\n%s", output)
+	}
+}
+
+func TestRunSetupFullWizard(t *testing.T) {
+	engineChoiceRoot(t)
+	forceNoAWS(t)
+	withScannerInput(t, "1\nMyGame\n/custom/Game.uproject\n2\neu-central-1\n123456789012\nc6i.xlarge\ny\n")
+
+	if err := runSetup(nil, nil); err != nil {
+		t.Fatalf("runSetup() error: %v", err)
+	}
+
+	data, err := os.ReadFile("ludus.yaml")
+	if err != nil {
+		t.Fatalf("read ludus.yaml: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "UnrealEngine-5.8") || !strings.Contains(content, "sourcepath:") {
+		t.Errorf("config missing engine source path:\n%s", content)
+	}
+	for _, want := range []string{
+		"version: 5.8.1",
+		"projectname: MyGame",
+		"target: stack",
+		"region: eu-central-1",
+		"accountid: \"123456789012\"",
+		"instancetype: c6i.xlarge",
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("config missing %q:\n%s", want, content)
+		}
+	}
+}
+
+func TestRunSetupWriteDeclined(t *testing.T) {
+	engineChoiceRoot(t)
+	forceNoAWS(t)
+	withScannerInput(t, "1\nMyGame\n/custom/Game.uproject\n2\neu-central-1\n123456789012\nc6i.xlarge\nn\n")
+
+	if err := runSetup(nil, nil); err != nil {
+		t.Fatalf("runSetup() error: %v", err)
+	}
+	if _, err := os.Stat("ludus.yaml"); err == nil {
+		t.Error("expected no ludus.yaml when write declined")
+	}
+}
+
+func TestRunSetupOverwriteDeclined(t *testing.T) {
+	tmp := t.TempDir()
+	t.Chdir(tmp)
+	if err := os.WriteFile("ludus.yaml", []byte("existing: true\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withScannerInput(t, "n\n")
+	if err := runSetup(nil, nil); err != nil {
+		t.Fatalf("runSetup() error: %v", err)
+	}
+	data, err := os.ReadFile("ludus.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(data), "existing: true") {
+		t.Errorf("config was overwritten:\n%s", data)
+	}
+}
+
+func TestRunSetupOverwriteAccepted(t *testing.T) {
+	root, _ := engineChoiceRoot(t)
+	forceNoAWS(t)
+	existing := filepath.Join(root, "project", "ludus.yaml")
+	if err := os.WriteFile(existing, []byte("{}"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	withScannerInput(t, "y\n1\nMyGame\n/custom/Game.uproject\n2\neu-central-1\n123456789012\nc6i.xlarge\ny\n")
+
+	if err := runSetup(nil, nil); err != nil {
+		t.Fatalf("runSetup() error: %v", err)
+	}
+
+	data, err := os.ReadFile(existing)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "UnrealEngine-5.8") || !strings.Contains(content, "target: stack") {
+		t.Errorf("config missing wizard values:\n%s", content)
+	}
+}

--- a/internal/prereq/checker_aws_test.go
+++ b/internal/prereq/checker_aws_test.go
@@ -1,0 +1,42 @@
+package prereq
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestCheckAWSCredentials_Authenticated(t *testing.T) {
+	testsupport.FakeTool(t, "aws", testsupport.ToolBehavior{
+		Stdout: `{"Account": "123456789012", "Arn": "arn:aws:iam::123456789012:user/test"}`,
+	})
+	res := (&Checker{}).checkAWSCredentials()
+	if !res.Passed || res.Warning || !strings.Contains(res.Message, "authenticated") {
+		t.Fatalf("checkAWSCredentials() = %+v", res)
+	}
+}
+
+func TestCheckAWSCredentials_UnparseableOutput(t *testing.T) {
+	testsupport.FakeTool(t, "aws", testsupport.ToolBehavior{Stdout: "garbage"})
+	res := (&Checker{}).checkAWSCredentials()
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "unexpected output") {
+		t.Fatalf("checkAWSCredentials() = %+v", res)
+	}
+}
+
+func TestCheckAWSCredentials_NotConfigured(t *testing.T) {
+	testsupport.FakeTool(t, "aws", testsupport.ToolBehavior{ExitCode: 1})
+	res := (&Checker{}).checkAWSCredentials()
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "not configured or expired") {
+		t.Fatalf("checkAWSCredentials() = %+v", res)
+	}
+}
+
+func TestCheckAWSCredentials_CLINotInstalled(t *testing.T) {
+	t.Setenv("PATH", "")
+	res := (&Checker{}).checkAWSCredentials()
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "AWS CLI not installed") {
+		t.Fatalf("checkAWSCredentials() = %+v", res)
+	}
+}

--- a/internal/prereq/checker_lyra_linux_test.go
+++ b/internal/prereq/checker_lyra_linux_test.go
@@ -1,0 +1,29 @@
+//go:build linux
+
+package prereq
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestOverlayLyraContent_OnLinux(t *testing.T) {
+	src := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(src, "Content"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(src, "Content", "DefaultGameData.uasset"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	dst := filepath.Join(t.TempDir(), "Lyra")
+
+	res := (&Checker{}).overlayLyraContent(src, dst)
+	if !res.Passed || !strings.Contains(res.Message, "overlaid from") {
+		t.Fatalf("overlayLyraContent() = %+v", res)
+	}
+	if _, err := os.Stat(filepath.Join(dst, "Content", "DefaultGameData.uasset")); err != nil {
+		t.Fatalf("overlay did not copy content: %v", err)
+	}
+}

--- a/internal/prereq/checker_runtime_fakes_test.go
+++ b/internal/prereq/checker_runtime_fakes_test.go
@@ -1,0 +1,156 @@
+package prereq
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestCheckGoVersion_TooOld(t *testing.T) {
+	testsupport.FakeTool(t, "go", testsupport.ToolBehavior{Stdout: "go version go1.19.5 windows/amd64"})
+	res := (&Checker{Backend: "docker"}).checkGoVersion()
+	if res.Passed || !strings.Contains(res.Message, "requires Go") {
+		t.Fatalf("checkGoVersion() = %+v", res)
+	}
+}
+
+func TestCheckGoVersion_Unreadable(t *testing.T) {
+	testsupport.FakeTool(t, "go", testsupport.ToolBehavior{ExitCode: 1})
+	res := (&Checker{Backend: "docker"}).checkGoVersion()
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "could not determine Go version") {
+		t.Fatalf("checkGoVersion() = %+v", res)
+	}
+}
+
+func TestCheckWSL2_NoDistros(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("wsl.exe stubbing requires Windows")
+	}
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	res := (&Checker{Backend: "wsl2"}).checkWSL2()
+	if res.Passed || !strings.Contains(res.Message, "no distros found") {
+		t.Fatalf("checkWSL2() = %+v", res)
+	}
+}
+
+func TestCheckContainerRuntime_PodmanBackendNotReady(t *testing.T) {
+	t.Setenv("PATH", "")
+	res := (&Checker{Backend: "podman"}).checkContainerRuntime()
+	if res.Passed || !strings.Contains(res.Message, "podman backend selected but not ready") {
+		t.Fatalf("checkContainerRuntime() = %+v", res)
+	}
+}
+
+func TestCheckContainerRuntime_DockerBackendNotReady(t *testing.T) {
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
+	res := (&Checker{Backend: "docker"}).checkContainerRuntime()
+	if res.Passed || !strings.Contains(res.Message, "docker backend selected but not ready") {
+		t.Fatalf("checkContainerRuntime() = %+v", res)
+	}
+}
+
+func TestCheckDocker_DaemonDownOtherBackend(t *testing.T) {
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
+	res := (&Checker{Backend: "podman"}).checkDocker()
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "not needed for podman backend") {
+		t.Fatalf("checkDocker() = %+v", res)
+	}
+}
+
+func TestCheckPodman_MachineNotRunning(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("podman machine path only applies on Windows/macOS")
+	}
+	testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{ExitCode: 1})
+	res := (&Checker{}).checkPodman()
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "machine not running") {
+		t.Fatalf("checkPodman() = %+v", res)
+	}
+}
+
+func TestCheckBuildxEmulation(t *testing.T) {
+	for _, tt := range []struct {
+		name   string
+		stdout string
+		pass   bool
+	}{
+		{"registered", "platforms: linux/arm64, linux/amd64", true},
+		{"missing platform", "platforms: linux/amd64", false},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{Stdout: tt.stdout})
+			res := checkBuildxEmulation("Cross-Arch Emulation", "docker", "arm64", "linux/arm64")
+			if res.Passed != tt.pass {
+				t.Fatalf("checkBuildxEmulation() = %+v", res)
+			}
+		})
+	}
+}
+
+func TestCheckPodmanEmulation_InfoUnavailable(t *testing.T) {
+	testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{ExitCode: 1})
+	res := checkPodmanEmulation("Cross-Arch Emulation", "arm64", "linux/arm64")
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "podman info unavailable") {
+		t.Fatalf("checkPodmanEmulation() = %+v", res)
+	}
+}
+
+func TestCheckLyraContent_AllPresent(t *testing.T) {
+	root := testsupport.FakeEngineTree(t)
+	content := filepath.Join(root, "Samples", "Games", "Lyra", "Content")
+	if err := os.MkdirAll(content, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(content, "DefaultGameData.uasset"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	for _, plugin := range []string{"ShooterCore", "ShooterMaps", "TopDownArena"} {
+		dir := filepath.Join(root, "Samples", "Games", "Lyra", "Plugins", "GameFeatures", plugin, "Content")
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	res := (&Checker{EngineSourcePath: root}).checkLyraContent()
+	if !res.Passed || !strings.Contains(res.Message, "found at") {
+		t.Fatalf("checkLyraContent() = %+v", res)
+	}
+}
+
+func TestCheckCandidates_NoneMatch(t *testing.T) {
+	if got := checkCandidates([]string{t.TempDir(), filepath.Join(t.TempDir(), "missing")}); got != "" {
+		t.Fatalf("checkCandidates() = %q, want empty", got)
+	}
+}
+
+func TestDiscoverLyraContent_NoMatches(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("OneDrive", "")
+	t.Setenv("USERPROFILE", home)
+	t.Setenv("HOME", home)
+	if got := discoverLyraContent(); got != "" {
+		t.Fatalf("discoverLyraContent() = %q, want empty", got)
+	}
+}
+
+func TestResolveEmulationCLI(t *testing.T) {
+	if cli, ok := (&Checker{Backend: "podman"}).resolveEmulationCLI(); !ok || cli != "podman" {
+		t.Fatalf("resolveEmulationCLI(backend) = (%q, %v)", cli, ok)
+	}
+
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {},
+		"podman": {},
+	})
+	if cli, ok := (&Checker{Backend: ""}).resolveEmulationCLI(); !ok || cli != "docker" {
+		t.Fatalf("resolveEmulationCLI(probe) = (%q, %v)", cli, ok)
+	}
+
+	t.Setenv("PATH", t.TempDir())
+	if cli, ok := (&Checker{Backend: ""}).resolveEmulationCLI(); ok || cli != "" {
+		t.Fatalf("resolveEmulationCLI(none) = (%q, %v)", cli, ok)
+	}
+}

--- a/internal/prereq/checker_win_extras_test.go
+++ b/internal/prereq/checker_win_extras_test.go
@@ -1,0 +1,225 @@
+//go:build windows
+
+package prereq
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+	"github.com/jpvelasco/ludus/internal/toolchain"
+)
+
+// sacBatchFake writes a raw powershell.bat stub whose stdout is made of one
+// echo line per line in content, then restricts PATH to that stub dir so the
+// fake wins over the real powershell.exe in System32. Bare lines in a .bat are
+// executed as commands by cmd.exe, so the stub must use explicit echo lines.
+func sacBatchFake(t *testing.T, content string, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	var sb strings.Builder
+	sb.WriteString("@echo off\r\n")
+	for _, line := range strings.Split(content, "\n") {
+		if line != "" {
+			sb.WriteString("echo " + line + "\r\n")
+		}
+	}
+	if exitCode != 0 {
+		fmt.Fprintf(&sb, "exit /b %d\r\n", exitCode)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "powershell.bat"), []byte(sb.String()), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+func TestCheckSmartAppControl_Off(t *testing.T) {
+	sacBatchFake(t, "0", 0)
+	res := (&Checker{}).checkSmartAppControl()
+	if !res.Passed || !strings.Contains(res.Message, "Smart App Control is off") {
+		t.Fatalf("checkSmartAppControl() = %+v", res)
+	}
+}
+
+func TestCheckSmartAppControl_ActiveWithBlocks(t *testing.T) {
+	// Policy reports enforcement ("1") on the first powershell read; the block
+	// scan sees the same output and turns the trailing line into a block entry.
+	// The state parser switches on the full trimmed output, so the fake must
+	// output exactly "1" for the enforcement path.
+	sacBatchFake(t, "1", 0)
+	res := (&Checker{}).checkSmartAppControl()
+	if res.Passed {
+		t.Fatalf("expected SAC failure when enforcing, got %+v", res)
+	}
+	if !strings.Contains(res.Message, "enforcement mode") {
+		t.Fatalf("checkSmartAppControl() = %+v", res)
+	}
+}
+
+func TestCheckSmartAppControl_PolicyUnreadable(t *testing.T) {
+	sacBatchFake(t, "", 1)
+	res := (&Checker{}).checkSmartAppControl()
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "could not read Code Integrity policy") {
+		t.Fatalf("checkSmartAppControl() = %+v", res)
+	}
+}
+
+func TestScanCodeIntegrityBlocks_DedupesAndNames(t *testing.T) {
+	sacBatchFake(t, "A.dll\n\nB.dll\nB.dll\n", 0)
+	got := (&Checker{}).scanCodeIntegrityBlocks()
+	if len(got) != 2 || got[0] != "A.dll" || got[1] != "B.dll" {
+		t.Fatalf("scanCodeIntegrityBlocks() = %v", got)
+	}
+}
+
+// sdkEngineFixture builds an engine tree and a fake Windows SDK host dir, both
+// under temp dirs, and returns a Checker whose platformChecks will take the
+// SDK >= 26100 engine-patch branches.
+func sdkEngineFixture(t *testing.T, version string) *Checker {
+	t.Helper()
+	progFiles := t.TempDir()
+	sdkDir := filepath.Join(progFiles, "Windows Kits", "10", "Include", "10.0.26100.0")
+	if err := os.MkdirAll(sdkDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("ProgramFiles(x86)", progFiles)
+	t.Setenv("APPDATA", t.TempDir())
+	sacBatchFake(t, "0", 0)
+	return &Checker{EngineSourcePath: testsupport.FakeEngineTree(t, testsupport.WithVersion(version))}
+}
+
+func TestPlatformChecks_SDK26100PatchBranches(t *testing.T) {
+	for _, version := range []string{"5.4", "5.6"} {
+		t.Run(version, func(t *testing.T) {
+			c := sdkEngineFixture(t, version)
+			results := c.platformChecks()
+			for _, res := range results {
+				if res.Name == "C4756 Patch" || res.Name == "NNERuntimeORT Patch" {
+					return
+				}
+			}
+			t.Fatalf("platformChecks() missing version patch for %s: %+v", version, results)
+		})
+	}
+}
+
+func TestFixCrossCompileToolchain_UsesCachedInstaller(t *testing.T) {
+	root := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.6"))
+	spec := toolchain.LookupToolchain("5.6")
+	installer := filepath.Join(os.TempDir(), fmt.Sprintf("ludus-toolchain-%s.exe", spec.SDKVersion))
+	if err := os.WriteFile(installer, []byte("installer"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LINUX_MULTIARCH_ROOT", "")
+	sacBatchFake(t, "", 0)
+
+	res := (&Checker{EngineSourcePath: root, Fix: true}).checkToolchain()
+	if !res.Passed || !res.Warning || !strings.Contains(res.Message, "toolchain installer completed") {
+		t.Fatalf("checkToolchain() with --fix = %+v", res)
+	}
+}
+
+func TestDownloadFile_StatusError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	if err := downloadFile(filepath.Join(t.TempDir(), "out.exe"), srv.URL); err == nil || !strings.Contains(err.Error(), "HTTP 500") {
+		t.Fatalf("downloadFile() error = %v, want HTTP 500", err)
+	}
+}
+
+// robocopyFake writes a robocopy.bat stub that returns the given exit code and
+// restricts PATH to that stub dir so the fake wins over the real robocopy.exe.
+func robocopyFake(t *testing.T, exitCode int) {
+	t.Helper()
+	dir := t.TempDir()
+	script := fmt.Sprintf("@echo off\r\nexit /b %d\r\n", exitCode)
+	if err := os.WriteFile(filepath.Join(dir, "robocopy.bat"), []byte(script), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+// overlayFixture returns a checker whose overlay destination already contains
+// the required DefaultGameData.uasset so overlayLyraContent can report success.
+func overlayFixture(t *testing.T) *Checker {
+	t.Helper()
+	dst := filepath.Join(t.TempDir(), "Lyra")
+	content := filepath.Join(dst, "Content")
+	if err := os.MkdirAll(content, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(content, "DefaultGameData.uasset"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return &Checker{EngineSourcePath: filepath.Dir(dst)}
+}
+
+func TestOverlayLyraContent_OnWindows(t *testing.T) {
+	robocopyFake(t, 0)
+	c := overlayFixture(t)
+	res := c.overlayLyraContent(t.TempDir(), filepath.Join(c.EngineSourcePath, "Lyra"))
+	if !res.Passed || !strings.Contains(res.Message, "overlaid from") {
+		t.Fatalf("overlayLyraContent() = %+v", res)
+	}
+}
+
+func TestOverlayLyraContent_GameDataStillMissing(t *testing.T) {
+	robocopyFake(t, 0)
+	dst := filepath.Join(t.TempDir(), "Lyra")
+	res := (&Checker{}).overlayLyraContent(t.TempDir(), dst)
+	if res.Passed || !strings.Contains(res.Message, "still missing") {
+		t.Fatalf("overlayLyraContent() = %+v", res)
+	}
+}
+
+func TestOverlayLyraContent_SourceMissing(t *testing.T) {
+	res := (&Checker{}).overlayLyraContent(filepath.Join(t.TempDir(), "missing"), t.TempDir())
+	if res.Passed || !strings.Contains(res.Message, "content source path does not exist") {
+		t.Fatalf("overlayLyraContent() = %+v", res)
+	}
+}
+
+func TestRobocopyOverlay_ExitCodes(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		exit    int
+		wantErr bool
+	}{
+		{"success", 0, false},
+		{"minor error", 7, false},
+		{"fatal error", 9, true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			robocopyFake(t, tt.exit)
+			err := (&Checker{}).robocopyOverlay(t.TempDir(), t.TempDir())
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("robocopyOverlay() exit=%d err=%v, wantErr=%v", tt.exit, err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestFixMissingPluginContent_OverlayBranch(t *testing.T) {
+	robocopyFake(t, 0)
+	lyraDir := t.TempDir()
+	content := filepath.Join(lyraDir, "Content")
+	if err := os.MkdirAll(content, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(content, "DefaultGameData.uasset"), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	s := lyraContentState{lyraDir: lyraDir, missingPlugins: []string{"ShooterCore"}}
+	res := (&Checker{Fix: true}).fixMissingPluginContent(s, t.TempDir())
+	if !res.Passed {
+		t.Fatalf("fixMissingPluginContent() = %+v", res)
+	}
+}


### PR DESCRIPTION
## What

Raises statement coverage across five packages from ~67% to 72% overall **without touching any production code** (all changes are \_test.go\ files). This is batch 1 of a multi-PR push toward 80%+ coverage.

| Package | Before | After |
|---|---|---|
| \cmd/deploy\ | 28.2% | **82.1%** |
| \cmd/globals\ | 73.7% | **96.9%** |
| \cmd/setup\ | 71.1% | **95.9%** |
| \cmd/mcp\ | 79.9% | **82.0%** |
| \internal/prereq\ | 76.0% | **85.9%** |
| **Overall** | **67.1%** | **72.0%** |

## Highlights

- \cmd/deploy\: dry-run seams, a fake \deploy.Target\/\SessionManager\ factory, flag-override coverage, destroy sweep, session flows. The real \ws\ CLI is stubbed via \	estsupport.FakeTool\ so the prereq AWS-readiness check (\ws sts get-caller-identity\) stays hermetic — deploy tests dropped from ~45s to ~7s.
- \cmd/globals\: \ResolveTarget\/\ResolveSessionTarget\ factory switch, \InitTracing\/nil/no-op paths, DDC and runner branch top-ups.
- \cmd/setup\: wizard run flows, AWS account prompts, config writer, engine discovery, project/Lyra prompts.
- \cmd/mcp\: deploy tool error/result branches and the \ludus_resources\ tool.
- \internal/prereq\: AWS credentials, container-runtime fakes, Windows extras (Smart App Control, SDK>=26100 patches, Lyra overlay, cross-compile toolchain), runtime.FakeTool-stubbed checks.

## Quality

- Uses shared infra: \internal/testsupport\, \globals.SetGlobals\/\SwapResolveTarget\.
- Every test function under cyclomatic complexity 8 (Lizard gate); \gofmt\, \go vet\, and \golangci-lint\ clean.
- No AWS/network calls from tests; subprocess checks are PATH-stubbed.

Follow-ups: batch 2 (game/engine/ci/container/ddc/wsl) and batch 3 (AWS-target pure surfaces, misc internal) are in progress.