### PR TITLE
test: cover wsl, engine, ci, container, ddc, game (Batch 2)

### DIFF
--- a/cmd/container/container_commands_test.go
+++ b/cmd/container/container_commands_test.go
@@ -1,0 +1,338 @@
+package container
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/cache"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+// init gives the never-executed package-level commands a non-nil context, since
+// cobra v1.10.2 returns c.ctx directly (nil until the command is run) and the
+// awsenv resolver passes it straight into the AWS SDK.
+func init() {
+	buildCmd.SetContext(context.Background())
+	pushCmd.SetContext(context.Background())
+}
+
+// containerBuildConfig returns a config whose server build dir resolves into a
+// fresh temp project tree, matching the host architecture to skip the
+// cross-arch emulation probe.
+func containerBuildConfig(t *testing.T) (*config.Config, string) {
+	t.Helper()
+	projDir := t.TempDir()
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			Backend:    "docker",
+			SourcePath: filepath.Join(projDir, "Engine"),
+			Version:    "5.7.3",
+		},
+		Game: config.GameConfig{
+			ProjectName: "MyGame",
+			ProjectPath: filepath.Join(projDir, "MyGame", "MyGame.uproject"),
+			Arch:        runtime.GOARCH,
+		},
+		Container: config.ContainerConfig{
+			ImageName:  "ludus-server",
+			Tag:        "latest",
+			ServerPort: 7777,
+		},
+	}
+	serverBuildDir := config.ResolveServerBuildDir(cfg)
+	if err := os.MkdirAll(serverBuildDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	return cfg, serverBuildDir
+}
+
+// stubBuildPrereqTools stubs the tools prereq.CheckDockerReady and the built-in
+// Dockerfile linter look up, keeping runBuild fully offline and deterministic.
+func stubBuildPrereqTools(t *testing.T) {
+	t.Helper()
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker":   {},
+		"go":       {Stdout: "go version go1.25.12 windows/amd64"},
+		"hadolint": {},
+	})
+}
+
+// stubAWSEnv points the AWS SDK at empty shared config/credentials files so
+// awsenv resolution never parses the host's ~/.aws config (which can carry
+// profile sources the SDK mishandles) and never reads real credentials.
+func stubAWSEnv(t *testing.T) {
+	t.Helper()
+	empty := filepath.Join(t.TempDir(), "empty")
+	if err := os.WriteFile(empty, nil, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("AWS_CONFIG_FILE", empty)
+	t.Setenv("AWS_SHARED_CREDENTIALS_FILE", empty)
+}
+
+// resetContainerFlags restores the package-level command flags after each test.
+func resetContainerFlags(t *testing.T) {
+	t.Helper()
+	prevTag, prevPushTag, prevNoCache, prevArch, prevBackend := tag, pushTag, noCache, archFlag, backend
+	t.Cleanup(func() {
+		tag, pushTag, noCache, archFlag, backend = prevTag, prevPushTag, prevNoCache, prevArch, prevBackend
+	})
+	tag, pushTag, noCache, archFlag, backend = "", "", false, "", ""
+}
+
+// captureContainerStdout runs fn while redirecting stdout to a pipe and returns
+// the captured output plus fn's error.
+func captureContainerStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	prev := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = w
+	runErr := run()
+	_ = w.Close()
+	os.Stdout = prev
+	t.Cleanup(func() { os.Stdout = prev })
+	data, readErr := io.ReadAll(r)
+	if readErr != nil {
+		t.Fatal(readErr)
+	}
+	return string(data), runErr
+}
+
+func TestRunBuildDryRun(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		archFlag string
+		backend  string
+	}{
+		{"default backend and arch", "", ""},
+		{"explicit arch flag", runtime.GOARCH, ""},
+		{"podman backend", "", "podman"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resetContainerFlags(t)
+			cfg, _ := containerBuildConfig(t)
+			globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithVerbose(true), globals.WithNoLogs(true))
+			stubBuildPrereqTools(t)
+			t.Chdir(t.TempDir())
+			archFlag = tt.archFlag
+			backend = tt.backend
+
+			output, err := captureContainerStdout(t, func() error { return runBuild(buildCmd, nil) })
+			if err != nil {
+				t.Fatalf("runBuild() error = %v", err)
+			}
+			for _, want := range []string{"Building container image...", "Container image built", "Next: ludus container push"} {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q:\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestRunBuildCacheHit(t *testing.T) {
+	resetContainerFlags(t)
+	cfg, serverBuildDir := containerBuildConfig(t)
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithNoLogs(true))
+	stubBuildPrereqTools(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+
+	if err := os.MkdirAll(filepath.Join(dir, ".ludus"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hash := cache.ContainerKey(cfg, serverBuildDir)
+	data, err := json.Marshal(&cache.Cache{Entries: map[cache.StageKey]*cache.Entry{
+		cache.StageContainerBuild: {Hash: hash, BuiltAt: "2026-01-01T00:00:00Z"},
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".ludus", "cache.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := captureContainerStdout(t, func() error { return runBuild(buildCmd, nil) })
+	if err != nil {
+		t.Fatalf("runBuild() error = %v", err)
+	}
+	if !strings.Contains(output, "(cached), skipping") {
+		t.Errorf("expected cache-hit skip message, got:\n%s", output)
+	}
+}
+
+func TestRunBuildPrereqFailure(t *testing.T) {
+	resetContainerFlags(t)
+	cfg, _ := containerBuildConfig(t)
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithNoLogs(true))
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {ExitCode: 1},
+		"go":     {Stdout: "go version go1.25.12 windows/amd64"},
+	})
+	t.Chdir(t.TempDir())
+
+	if err := runBuild(buildCmd, nil); err == nil {
+		t.Fatal("runBuild() expected prereq failure")
+	}
+}
+
+func TestRunBuildBuildError(t *testing.T) {
+	resetContainerFlags(t)
+	cfg := &config.Config{
+		Engine: config.EngineConfig{Backend: "docker", Version: "5.7.3"},
+		Game:   config.GameConfig{ProjectName: "MyGame", Arch: runtime.GOARCH},
+		Container: config.ContainerConfig{
+			ImageName:  "ludus-server",
+			Tag:        "latest",
+			ServerPort: 7777,
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithNoLogs(true))
+	stubBuildPrereqTools(t)
+	t.Chdir(t.TempDir())
+
+	if err := runBuild(buildCmd, nil); err == nil {
+		t.Fatal("runBuild() expected build error")
+	}
+}
+
+func TestRunPushDryRun(t *testing.T) {
+	for _, tt := range []struct {
+		name    string
+		pushTag string
+	}{
+		{"default tag from config", ""},
+		{"explicit push tag", "v1.0"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			resetContainerFlags(t)
+			cfg := &config.Config{
+				AWS: config.AWSConfig{
+					AccountID:     "123456789012",
+					Region:        "us-east-1",
+					ECRRepository: "ludus-server",
+				},
+				Container: config.ContainerConfig{
+					ImageName:  "ludus-server",
+					Tag:        "latest",
+					ServerPort: 7777,
+				},
+			}
+			globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithVerbose(true), globals.WithNoLogs(true))
+			stubAWSEnv(t)
+			testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+				"docker": {},
+				"aws":    {Stdout: `{"Account":"123456789012","Arn":"arn:aws:iam::123456789012:user/test"}`},
+			})
+			t.Chdir(t.TempDir())
+			pushTag = tt.pushTag
+
+			output, err := captureContainerStdout(t, func() error { return runPush(pushCmd, nil) })
+			if err != nil {
+				t.Fatalf("runPush() error = %v", err)
+			}
+			for _, want := range []string{"Pushing container image to ECR...", "Next: ludus deploy fleet"} {
+				if !strings.Contains(output, want) {
+					t.Errorf("output missing %q:\n%s", want, output)
+				}
+			}
+		})
+	}
+}
+
+func TestRunPushPrereqFailure(t *testing.T) {
+	resetContainerFlags(t)
+	cfg := &config.Config{
+		AWS: config.AWSConfig{
+			AccountID:     "123456789012",
+			Region:        "us-east-1",
+			ECRRepository: "ludus-server",
+		},
+		Container: config.ContainerConfig{ImageName: "ludus-server", Tag: "latest", ServerPort: 7777},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithNoLogs(true))
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {ExitCode: 1},
+		"aws":    {Stdout: `{"Account":"123456789012","Arn":"arn:aws:iam::123456789012:user/test"}`},
+	})
+	t.Chdir(t.TempDir())
+
+	if err := runPush(pushCmd, nil); err == nil {
+		t.Fatal("runPush() expected prereq failure")
+	}
+}
+
+func TestRunPushECRError(t *testing.T) {
+	resetContainerFlags(t)
+	cfg := &config.Config{
+		AWS: config.AWSConfig{
+			AccountID:     "123456789012",
+			Region:        "us-east-1",
+			ECRRepository: "ludus-server",
+		},
+		Container: config.ContainerConfig{ImageName: "ludus-server", Tag: "latest", ServerPort: 7777},
+		Engine:    config.EngineConfig{Backend: "docker", Version: "5.7.3"},
+		Game:      config.GameConfig{ProjectName: "MyGame"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithNoLogs(true))
+	stubAWSEnv(t)
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {},
+		"aws":    {ExitCode: 1},
+	})
+	t.Chdir(t.TempDir())
+
+	if err := runPush(pushCmd, nil); err == nil {
+		t.Fatal("runPush() expected ECR failure")
+	}
+}
+
+func TestRunPushResolverError(t *testing.T) {
+	resetContainerFlags(t)
+	cfg := &config.Config{
+		AWS: config.AWSConfig{ECRRepository: "ludus-server"},
+		Container: config.ContainerConfig{
+			ImageName:  "ludus-server",
+			Tag:        "latest",
+			ServerPort: 7777,
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithNoLogs(true))
+	stubAWSEnv(t)
+	t.Setenv("AWS_EC2_METADATA_DISABLED", "true")
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {},
+		"aws":    {Stdout: `{"Account":"123456789012","Arn":"arn:aws:iam::123456789012:user/test"}`},
+	})
+	t.Chdir(t.TempDir())
+
+	if err := runPush(pushCmd, nil); err == nil {
+		t.Fatal("runPush() expected resolver error")
+	}
+}
+
+func TestCheckBuildCacheCorruptCache(t *testing.T) {
+	resetContainerFlags(t)
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.MkdirAll(filepath.Join(dir, ".ludus"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".ludus", "cache.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := checkBuildCache(cache.StageContainerBuild, "abc"); got {
+		t.Error("checkBuildCache() with corrupt cache should return false")
+	}
+}

--- a/cmd/ddc/ddc_run_test.go
+++ b/cmd/ddc/ddc_run_test.go
@@ -1,0 +1,178 @@
+package ddc
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	internalddc "github.com/jpvelasco/ludus/internal/ddc"
+)
+
+func TestRunStatusErrors(t *testing.T) {
+	tests := []struct {
+		name string
+		cfg  *config.Config
+		opts []globals.GlobalOption
+		want string
+	}{
+		{
+			name: "invalid ddc mode",
+			cfg:  &config.Config{},
+			opts: []globals.GlobalOption{globals.WithDDCMode("bogus")},
+			want: "invalid DDC mode",
+		},
+		{
+			name: "relative zen path",
+			cfg:  &config.Config{DDC: config.DDCConfig{Mode: internalddc.ModeZen, ZenPath: "relative/zen"}},
+			want: "must be absolute",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			globals.SetGlobals(t, tt.cfg, tt.opts...)
+			err := runStatus(statusCmd, nil)
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("runStatus() error = %v, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunStatusNoneMode(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{DDC: config.DDCConfig{Mode: internalddc.ModeNone}})
+
+	output, err := captureDDCStdout(t, func() error { return runStatus(statusCmd, nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Mode: none", "Size: 0 B"} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output %q does not contain %q", output, want)
+		}
+	}
+}
+
+func TestRunCleanAndPruneWithData(t *testing.T) {
+	tests := []struct {
+		name    string
+		fixture string
+		json    bool
+		run     func() error
+		want    []string
+	}{
+		{
+			name:    "clean human",
+			fixture: "clean",
+			run:     func() error { return runClean(cleanCmd, nil) },
+			want:    []string{"DDC cleaned: 5 B freed"},
+		},
+		{
+			name:    "clean json",
+			fixture: "clean",
+			json:    true,
+			run:     func() error { return runClean(cleanCmd, nil) },
+			want:    []string{`"success":true`, `"bytes_freed":5`},
+		},
+		{
+			name:    "prune human",
+			fixture: "prune",
+			run:     func() error { return runPrune(pruneCmd, nil) },
+			want:    []string{"DDC pruned: 1.0 KB freed (entries older than 7 days)"},
+		},
+		{
+			name:    "prune json",
+			fixture: "prune",
+			json:    true,
+			run:     func() error { return runPrune(pruneCmd, nil) },
+			want:    []string{`"success":true`, `"bytes_freed":1024`, `"max_age_days":7`},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.fixture == "clean" {
+				writeCacheFile(t, filepath.Join(dir, "cache.bin"), 5)
+			} else {
+				writeOldFile(t, dir, 1024)
+			}
+
+			pruneDays = 7
+			t.Cleanup(func() { pruneDays = 30 })
+			globals.SetGlobals(t, &config.Config{DDC: config.DDCConfig{LocalPath: dir}},
+				globals.WithJSONOutput(tt.json), globals.WithNoLogs(true))
+
+			output, err := captureDDCStdout(t, tt.run)
+			if err != nil {
+				t.Fatal(err)
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(output, want) {
+					t.Errorf("output %q does not contain %q", output, want)
+				}
+			}
+		})
+	}
+}
+
+func TestRunCleanAndPruneErrors(t *testing.T) {
+	tests := []struct {
+		name      string
+		cfg       *config.Config
+		pruneDays int
+		run       func() error
+		want      string
+	}{
+		{
+			name: "clean relative local path",
+			cfg:  &config.Config{DDC: config.DDCConfig{LocalPath: "relative/ddc"}},
+			run:  func() error { return runClean(cleanCmd, nil) },
+			want: "must be absolute",
+		},
+		{
+			name: "prune relative local path",
+			cfg:  &config.Config{DDC: config.DDCConfig{LocalPath: "relative/ddc"}},
+			run:  func() error { return runPrune(pruneCmd, nil) },
+			want: "must be absolute",
+		},
+		{
+			name:      "prune invalid days",
+			cfg:       &config.Config{DDC: config.DDCConfig{LocalPath: t.TempDir()}},
+			pruneDays: 0,
+			run:       func() error { return runPrune(pruneCmd, nil) },
+			want:      "pruning DDC",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pruneDays = tt.pruneDays
+			t.Cleanup(func() { pruneDays = 30 })
+			globals.SetGlobals(t, tt.cfg, globals.WithNoLogs(true))
+
+			err := tt.run()
+			if err == nil || !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("command error = %v, want it to contain %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func writeCacheFile(t *testing.T, path string, size int) {
+	t.Helper()
+	if err := os.WriteFile(path, make([]byte, size), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeOldFile(t *testing.T, dir string, size int) {
+	t.Helper()
+	path := filepath.Join(dir, "old.bin")
+	writeCacheFile(t, path, size)
+	oldTime := time.Now().Add(-10 * 24 * time.Hour)
+	if err := os.Chtimes(path, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/cmd/ddc/ddc_warmup_test.go
+++ b/cmd/ddc/ddc_warmup_test.go
@@ -1,0 +1,134 @@
+package ddc
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	internalddc "github.com/jpvelasco/ludus/internal/ddc"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestRunWarmupResolveDDCError(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{}, globals.WithDDCMode("bogus"))
+
+	err := runWarmup(warmupCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "invalid DDC mode") {
+		t.Fatalf("runWarmup() error = %v, want invalid mode error", err)
+	}
+}
+
+func TestRunWarmupDryRunPreview(t *testing.T) {
+	zenPath := filepath.Join(t.TempDir(), "zen")
+	cfg := &config.Config{
+		DDC: config.DDCConfig{
+			Mode:    internalddc.ModeZen,
+			ZenPath: zenPath,
+		},
+		Game: config.GameConfig{
+			ProjectPath: filepath.Join(t.TempDir(), "Fake.uproject"),
+		},
+		Engine: config.EngineConfig{
+			DockerImage: "fake-engine:5.7.3",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithDDCMode(internalddc.ModeZen))
+
+	output, err := captureDDCStdout(t, func() error { return runWarmup(warmupCmd, nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"DRY RUN: DDC Warmup", "Image  : fake-engine:5.7.3", "Project: " + cfg.Game.ProjectPath, "DDC    : " + zenPath} {
+		if !strings.Contains(output, want) {
+			t.Errorf("output %q does not contain %q", output, want)
+		}
+	}
+}
+
+func TestRunWarmupDryRunPreviewImageError(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cfg := warmupConfig(t, "docker", "")
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithDDCMode(internalddc.ModeZen))
+
+	err := runWarmup(warmupCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "could not detect engine version") {
+		t.Fatalf("runWarmup() error = %v, want engine version error", err)
+	}
+}
+
+func TestRunWarmupNonContainerBackend(t *testing.T) {
+	cfg := warmupConfig(t, "native", "5.7.3")
+	globals.SetGlobals(t, cfg, globals.WithDDCMode(internalddc.ModeZen), globals.WithNoLogs(true))
+
+	err := runWarmup(warmupCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "requires a container backend") {
+		t.Fatalf("runWarmup() error = %v, want container backend error", err)
+	}
+}
+
+func TestRunWarmupUndetectableEngineVersion(t *testing.T) {
+	t.Chdir(t.TempDir())
+	cfg := warmupConfig(t, "docker", "")
+	globals.SetGlobals(t, cfg, globals.WithDDCMode(internalddc.ModeZen), globals.WithNoLogs(true))
+
+	err := runWarmup(warmupCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "could not detect engine version") {
+		t.Fatalf("runWarmup() error = %v, want engine version error", err)
+	}
+}
+
+func TestExecuteWarmupDockerFailure(t *testing.T) {
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
+	cfg := warmupConfig(t, "docker", "5.7.3")
+	globals.SetGlobals(t, cfg, globals.WithDDCMode(internalddc.ModeZen), globals.WithNoLogs(true))
+	withWarmupContext(t)
+
+	err := runWarmup(warmupCmd, nil)
+	if err == nil || !strings.Contains(err.Error(), "DDC warmup failed") {
+		t.Fatalf("runWarmup() error = %v, want warmup failure error", err)
+	}
+}
+
+func TestExecuteWarmupDockerSuccess(t *testing.T) {
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 0})
+	cfg := warmupConfig(t, "docker", "5.7.3")
+	globals.SetGlobals(t, cfg, globals.WithDDCMode(internalddc.ModeZen), globals.WithNoLogs(true))
+	withWarmupContext(t)
+
+	output, err := captureDDCStdout(t, func() error { return runWarmup(warmupCmd, nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "DDC warmup complete.") {
+		t.Errorf("output %q does not contain warmup completion", output)
+	}
+}
+
+// withWarmupContext gives the shared warmupCmd a valid Context for the duration
+// of the test, since runWarmup passes cmd.Context() down to the container build.
+func withWarmupContext(t *testing.T) {
+	t.Helper()
+	warmupCmd.SetContext(context.Background())
+	t.Cleanup(func() { warmupCmd.SetContext(context.Background()) })
+}
+
+func warmupConfig(t *testing.T, backend, version string) *config.Config {
+	t.Helper()
+	return &config.Config{
+		DDC: config.DDCConfig{
+			Mode:      internalddc.ModeZen,
+			ZenPath:   filepath.Join(t.TempDir(), "zen"),
+			LocalPath: filepath.Join(t.TempDir(), "ddc"),
+		},
+		Game: config.GameConfig{
+			ProjectPath: filepath.Join(t.TempDir(), "Fake.uproject"),
+		},
+		Engine: config.EngineConfig{
+			Backend: backend,
+			Version: version,
+		},
+	}
+}

--- a/cmd/engine/wsl2_engine_test.go
+++ b/cmd/engine/wsl2_engine_test.go
@@ -1,0 +1,111 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/state"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+	"github.com/jpvelasco/ludus/internal/wsl"
+	"github.com/spf13/cobra"
+)
+
+// quietRunner returns a real (non-dry-run) runner with output silenced so the
+// stubbed wsl.exe on PATH is actually executed during path-resolution tests.
+func quietRunner() *runner.Runner {
+	r := runner.NewRunner(false, false)
+	r.Stdout = &strings.Builder{}
+	r.Stderr = &strings.Builder{}
+	return r
+}
+
+func TestResolveWSL2EnginePathsNativeSync(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  250G"})
+
+	wslNative = true
+	t.Cleanup(func() { wslNative = false })
+
+	w := &wsl.WSL2{Distro: "Ubuntu", Runner: quietRunner()}
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+
+	enginePath, ddcPath, err := resolveWSL2EnginePaths(c, quietRunner(), w, `C:\ue5`, "5.7")
+	if err != nil {
+		t.Fatalf("resolveWSL2EnginePaths(native) error = %v", err)
+	}
+	if enginePath != "$HOME/ludus/engine/5.7" {
+		t.Errorf("enginePath = %q, want $HOME/ludus/engine/5.7", enginePath)
+	}
+	if ddcPath != "$HOME/ludus/ddc" {
+		t.Errorf("ddcPath = %q, want $HOME/ludus/ddc", ddcPath)
+	}
+}
+
+func TestResolveWSL2EnginePathsNativeInsufficientDisk(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  10G"})
+
+	wslNative = true
+	t.Cleanup(func() { wslNative = false })
+
+	w := &wsl.WSL2{Distro: "Ubuntu", Runner: quietRunner()}
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+
+	_, _, err := resolveWSL2EnginePaths(c, quietRunner(), w, `C:\ue5`, "5.7")
+	if err == nil || !strings.Contains(err.Error(), "insufficient disk space") {
+		t.Errorf("resolveWSL2EnginePaths() error = %v, want 'insufficient disk space'", err)
+	}
+}
+
+func TestResolveWSL2EnginePathsNativeDiskCheckError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+
+	wslNative = true
+	t.Cleanup(func() { wslNative = false })
+
+	w := &wsl.WSL2{Distro: "Ubuntu", Runner: quietRunner()}
+	c := &cobra.Command{}
+	c.SetContext(context.Background())
+
+	_, _, err := resolveWSL2EnginePaths(c, quietRunner(), w, `C:\ue5`, "5.7")
+	if err == nil || !strings.Contains(err.Error(), "checking disk space") {
+		t.Errorf("resolveWSL2EnginePaths() error = %v, want 'checking disk space'", err)
+	}
+}
+
+// TestRunWSL2BuildSuccess drives the full WSL2 engine build under a stubbed
+// wsl.exe. The stub's stdout doubles as both the `wsl --list --verbose` distro
+// list (for wsl.New) and a non-empty `which` result (for CheckDeps); exit 0
+// makes every build step succeed. State is written to a temp dir.
+func TestRunWSL2BuildSuccess(t *testing.T) {
+	t.Chdir(t.TempDir())
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile("") })
+
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{
+		Stdout: "* Ubuntu          Running         2",
+	})
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: `C:\ue5`,
+			Version:    "5.7",
+			MaxJobs:    1,
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(false), globals.WithNoLogs(true))
+
+	wslNative = false
+	t.Cleanup(func() { wslNative = false })
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	if err := runWSL2Build(cmd); err != nil {
+		t.Fatalf("runWSL2Build() error = %v", err)
+	}
+}

--- a/cmd/game/wsl2_game_test.go
+++ b/cmd/game/wsl2_game_test.go
@@ -1,0 +1,105 @@
+package game
+
+import (
+	"context"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/state"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+	"github.com/spf13/cobra"
+)
+
+// TestRunWSL2GameBuildSuccess drives the full WSL2 game build under a stubbed
+// wsl.exe. The stub's stdout doubles as both the `wsl --list --verbose` distro
+// list (for wsl.New) and a non-empty `ldconfig` result (for CheckRuntimeDeps);
+// the dry-run runner makes every build step a no-op. State is written to a
+// temp dir with a prior WSL2 engine build.
+func TestRunWSL2GameBuildSuccess(t *testing.T) {
+	t.Chdir(t.TempDir())
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile("") })
+
+	projectPath := testsupport.FakeProject(t, "TestGame")
+
+	if err := state.UpdateWSL2Engine(&state.WSL2EngineState{
+		EnginePath: "/home/user/ludus/engine/5.7",
+		DDCPath:    "/home/user/ludus/ddc",
+		IsNative:   true,
+	}); err != nil {
+		t.Fatalf("UpdateWSL2Engine() error = %v", err)
+	}
+
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{
+		Stdout: "* Ubuntu          Running         2",
+	})
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: `C:\ue5`,
+			Version:    "5.7",
+			MaxJobs:    1,
+		},
+		Game: config.GameConfig{
+			ProjectName:  "TestGame",
+			ProjectPath:  projectPath,
+			Platform:     "Linux",
+			ServerTarget: "TestGameServer",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithDDCMode("none"))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runWSL2GameBuild(cmd, cfg)
+	if err != nil {
+		t.Fatalf("runWSL2GameBuild() error = %v", err)
+	}
+}
+
+// TestRunWSL2GameBuildRealRunner drives the WSL2 game build with a real
+// (non-dry-run) runner: the wsl.exe stub answers every probe (distro list,
+// ldconfig) with exit 0, so the build proceeds end to end without a live WSL2.
+func TestRunWSL2GameBuildRealRunner(t *testing.T) {
+	t.Chdir(t.TempDir())
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile("") })
+
+	projectPath := testsupport.FakeProject(t, "TestGame")
+
+	if err := state.UpdateWSL2Engine(&state.WSL2EngineState{
+		EnginePath: "/home/user/ludus/engine/5.7",
+		DDCPath:    "/home/user/ludus/ddc",
+		IsNative:   true,
+	}); err != nil {
+		t.Fatalf("UpdateWSL2Engine() error = %v", err)
+	}
+
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{
+		Stdout: "* Ubuntu          Running         2",
+	})
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: `C:\ue5`,
+			Version:    "5.7",
+			MaxJobs:    1,
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: projectPath,
+			Platform:    "Linux",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(false), globals.WithNoLogs(true), globals.WithDDCMode("none"))
+
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+
+	err := runWSL2GameBuild(cmd, cfg)
+	if err != nil {
+		t.Fatalf("runWSL2GameBuild() error = %v", err)
+	}
+}

--- a/internal/ci/runner_guard_test.go
+++ b/internal/ci/runner_guard_test.go
@@ -1,0 +1,45 @@
+package ci
+
+import (
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// The Install/Status/Uninstall flows are Linux-only; their full bodies are
+// covered by runner_unix_test.go on the CI ubuntu leg. These tests cover the
+// non-Linux guard returns so they stay covered on the windows/macos legs too.
+
+func TestRunnerInstallerInstallNonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("linux install path is covered in runner_unix_test.go")
+	}
+	ri := &RunnerInstaller{}
+	err := ri.Install(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "runner install is only supported on Linux") {
+		t.Fatalf("Install() on %s = %v, want Linux-only guard error", runtime.GOOS, err)
+	}
+}
+
+func TestRunnerInstallerStatusNonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("linux status path is covered in runner_unix_test.go")
+	}
+	ri := &RunnerInstaller{}
+	_, err := ri.Status(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "runner status is only supported on Linux") {
+		t.Fatalf("Status() on %s = %v, want Linux-only guard error", runtime.GOOS, err)
+	}
+}
+
+func TestRunnerInstallerUninstallNonLinux(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("linux uninstall path is covered in runner_unix_test.go")
+	}
+	ri := &RunnerInstaller{}
+	err := ri.Uninstall(context.Background(), true)
+	if err == nil || !strings.Contains(err.Error(), "runner uninstall is only supported on Linux") {
+		t.Fatalf("Uninstall() on %s = %v, want Linux-only guard error", runtime.GOOS, err)
+	}
+}

--- a/internal/ci/runner_helpers_test.go
+++ b/internal/ci/runner_helpers_test.go
@@ -1,0 +1,301 @@
+package ci
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+// ciDryRunInstaller builds a RunnerInstaller whose runner is in dry-run mode
+// (echoes commands, executes nothing) and captures echoed output. Mirrors the
+// dryRunInstaller helper in runner_unix_test.go so these tests run on every OS.
+func ciDryRunInstaller(t *testing.T) (*RunnerInstaller, *bytes.Buffer) {
+	t.Helper()
+	var out bytes.Buffer
+	return &RunnerInstaller{
+		Runner:     &runner.Runner{DryRun: true, Stdout: &out, Stderr: &out},
+		InstallDir: t.TempDir(),
+		Labels:     "self-hosted,linux,x64",
+		Name:       "test-runner",
+		Repo:       "owner/repo",
+	}, &out
+}
+
+// realRunner returns a non-dry-run runner that sends output to buffers, so
+// tests that stub external tools on PATH execute those stubs hermetically.
+func realRunner() *runner.Runner {
+	return &runner.Runner{Stdout: &bytes.Buffer{}, Stderr: &bytes.Buffer{}}
+}
+
+// writeArgFailingTool writes a PATH-injected stub named name that exits 1 when
+// the argument at 1-based index argNum equals failValue; otherwise it prints
+// stdout and exits 0.
+func writeArgFailingTool(t *testing.T, name string, argNum int, failValue, stdout string) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	if runtime.GOOS == "windows" {
+		script := "@echo off\n" +
+			fmt.Sprintf("if \"%%%d\"==\"%s\" exit /b 1\n", argNum, failValue) +
+			"echo " + stdout + "\n"
+		if err := os.WriteFile(filepath.Join(dir, name+".bat"), []byte(script), 0o644); err != nil {
+			t.Fatal(err)
+		}
+		return
+	}
+	script := "#!/bin/sh\n" +
+		fmt.Sprintf("[ \"$%d\" = \"%s\" ] && exit 1\n", argNum, failValue) +
+		fmt.Sprintf("printf '%%s\\n' %q\n", stdout)
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(script), 0o700); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunnerInstallerInstallMetadata(t *testing.T) {
+	ri, _ := ciDryRunInstaller(t)
+	token, version, err := ri.installMetadata(context.Background())
+	if err != nil {
+		t.Fatalf("installMetadata() error = %v", err)
+	}
+	if token == "" || version == "" {
+		t.Errorf("installMetadata() = (%q, %q), want non-empty values", token, version)
+	}
+}
+
+func TestRunnerInstallerInstallMetadataTokenError(t *testing.T) {
+	testsupport.FakeTool(t, "gh", testsupport.ToolBehavior{ExitCode: 1})
+	ri := &RunnerInstaller{Runner: realRunner(), Repo: "owner/repo"}
+	_, _, err := ri.installMetadata(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "getting registration token") {
+		t.Fatalf("installMetadata() error = %v, want registration token error", err)
+	}
+}
+
+func TestRunnerInstallerInstallMetadataVersionError(t *testing.T) {
+	writeArgFailingTool(t, "gh", 2, "repos/actions/runner/releases/latest", "some-token")
+	ri := &RunnerInstaller{Runner: realRunner(), Repo: "owner/repo"}
+	_, _, err := ri.installMetadata(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "getting runner version") {
+		t.Fatalf("installMetadata() error = %v, want runner version error", err)
+	}
+}
+
+func TestRunnerInstallerRegistrationToken(t *testing.T) {
+	ri, output := ciDryRunInstaller(t)
+	token, err := ri.registrationToken(context.Background())
+	if err != nil {
+		t.Fatalf("registrationToken() error = %v", err)
+	}
+	if token != "(dry-run)" {
+		t.Errorf("registrationToken() = %q, want %q", token, "(dry-run)")
+	}
+	if !strings.Contains(output.String(), "gh api") {
+		t.Errorf("dry-run output missing 'gh api':\n%s", output.String())
+	}
+}
+
+func TestRunnerInstallerRegistrationTokenError(t *testing.T) {
+	testsupport.FakeTool(t, "gh", testsupport.ToolBehavior{ExitCode: 1})
+	ri := &RunnerInstaller{Runner: realRunner()}
+	_, err := ri.registrationToken(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "getting registration token") {
+		t.Fatalf("registrationToken() error = %v, want wrapped error", err)
+	}
+}
+
+func TestRunnerInstallerLatestRunnerVersion(t *testing.T) {
+	ri, output := ciDryRunInstaller(t)
+	version, err := ri.latestRunnerVersion(context.Background())
+	if err != nil {
+		t.Fatalf("latestRunnerVersion() error = %v", err)
+	}
+	if version != "(dry-run)" {
+		t.Errorf("latestRunnerVersion() = %q, want %q", version, "(dry-run)")
+	}
+	if !strings.Contains(output.String(), "gh api") {
+		t.Errorf("dry-run output missing 'gh api':\n%s", output.String())
+	}
+}
+
+func TestRunnerInstallerLatestRunnerVersionError(t *testing.T) {
+	testsupport.FakeTool(t, "gh", testsupport.ToolBehavior{ExitCode: 1})
+	ri := &RunnerInstaller{Runner: realRunner()}
+	_, err := ri.latestRunnerVersion(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "getting runner version") {
+		t.Fatalf("latestRunnerVersion() error = %v, want wrapped error", err)
+	}
+}
+
+func TestRunnerInstallerDownloadRunner(t *testing.T) {
+	tests := []struct {
+		version string
+		want    string
+	}{
+		{version: "v2.300.0", want: "actions-runner-linux-x64-2.300.0.tar.gz"},
+		{version: "2.300.0", want: "actions-runner-linux-x64-2.300.0.tar.gz"},
+	}
+	for _, tt := range tests {
+		ri, output := ciDryRunInstaller(t)
+		got, err := ri.downloadRunner(context.Background(), ri.InstallDir, tt.version)
+		if err != nil {
+			t.Fatalf("downloadRunner(%q) error = %v", tt.version, err)
+		}
+		if got != tt.want {
+			t.Errorf("downloadRunner(%q) = %q, want %q", tt.version, got, tt.want)
+		}
+		wantURL := "https://github.com/actions/runner/releases/download/" + tt.version + "/" + tt.want
+		if !strings.Contains(output.String(), wantURL) {
+			t.Errorf("dry-run output missing URL %q:\n%s", wantURL, output.String())
+		}
+	}
+}
+
+func TestRunnerInstallerDownloadRunnerError(t *testing.T) {
+	testsupport.FakeTool(t, "curl", testsupport.ToolBehavior{ExitCode: 1})
+	ri := &RunnerInstaller{Runner: realRunner()}
+	_, err := ri.downloadRunner(context.Background(), t.TempDir(), "v2.300.0")
+	if err == nil || !strings.Contains(err.Error(), "downloading runner") {
+		t.Fatalf("downloadRunner() error = %v, want wrapped error", err)
+	}
+}
+
+func TestRunnerInstallerExtractRunner(t *testing.T) {
+	ri, output := ciDryRunInstaller(t)
+	tarball := "actions-runner-linux-x64-2.300.0.tar.gz"
+	if err := os.WriteFile(filepath.Join(ri.InstallDir, tarball), []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ri.extractRunner(context.Background(), ri.InstallDir, tarball); err != nil {
+		t.Fatalf("extractRunner() error = %v", err)
+	}
+	if !strings.Contains(output.String(), "tar xzf") {
+		t.Errorf("dry-run output missing 'tar xzf':\n%s", output.String())
+	}
+	if _, err := os.Stat(filepath.Join(ri.InstallDir, tarball)); !os.IsNotExist(err) {
+		t.Errorf("tarball still present after extractRunner(): %v", err)
+	}
+}
+
+func TestRunnerInstallerExtractRunnerError(t *testing.T) {
+	testsupport.FakeTool(t, "tar", testsupport.ToolBehavior{ExitCode: 1})
+	ri := &RunnerInstaller{Runner: realRunner()}
+	err := ri.extractRunner(context.Background(), t.TempDir(), "some.tar.gz")
+	if err == nil || !strings.Contains(err.Error(), "extracting runner") {
+		t.Fatalf("extractRunner() error = %v, want wrapped error", err)
+	}
+}
+
+func TestRunnerInstallerConfigureRunner(t *testing.T) {
+	ri, output := ciDryRunInstaller(t)
+	if err := ri.configureRunner(context.Background(), ri.InstallDir, "tok-abc"); err != nil {
+		t.Fatalf("configureRunner() error = %v", err)
+	}
+	out := output.String()
+	for _, want := range []string{"config.sh", "--url https://github.com/owner/repo", "--token tok-abc", "--unattended"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunnerInstallerConfigureRunnerError(t *testing.T) {
+	ri := &RunnerInstaller{Runner: realRunner()}
+	err := ri.configureRunner(context.Background(), t.TempDir(), "tok-abc")
+	if err == nil || !strings.Contains(err.Error(), "configuring runner") {
+		t.Fatalf("configureRunner() error = %v, want wrapped error", err)
+	}
+}
+
+func TestRunnerInstallerInstallRunnerFiles(t *testing.T) {
+	ri, output := ciDryRunInstaller(t)
+	if err := ri.installRunnerFiles(context.Background(), ri.InstallDir, "v2.300.0"); err != nil {
+		t.Fatalf("installRunnerFiles() error = %v", err)
+	}
+	out := output.String()
+	for _, want := range []string{"curl -o", "tar xzf"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunnerInstallerInstallRunnerFilesMkdirError(t *testing.T) {
+	dir := t.TempDir()
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	ri := &RunnerInstaller{Runner: realRunner()}
+	err := ri.installRunnerFiles(context.Background(), filepath.Join(blocker, "sub"), "v2.300.0")
+	if err == nil || !strings.Contains(err.Error(), "creating install directory") {
+		t.Fatalf("installRunnerFiles() error = %v, want mkdir error", err)
+	}
+}
+
+func TestRunnerInstallerInstallRunnerFilesDownloadError(t *testing.T) {
+	testsupport.FakeTool(t, "curl", testsupport.ToolBehavior{ExitCode: 1})
+	ri := &RunnerInstaller{Runner: realRunner()}
+	err := ri.installRunnerFiles(context.Background(), t.TempDir(), "v2.300.0")
+	if err == nil || !strings.Contains(err.Error(), "downloading runner") {
+		t.Fatalf("installRunnerFiles() error = %v, want download error", err)
+	}
+}
+
+func TestRunnerInstallerInstallRunnerFilesExtractError(t *testing.T) {
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"curl": {},
+		"tar":  {ExitCode: 1},
+	})
+	ri := &RunnerInstaller{Runner: realRunner()}
+	err := ri.installRunnerFiles(context.Background(), t.TempDir(), "v2.300.0")
+	if err == nil || !strings.Contains(err.Error(), "extracting runner") {
+		t.Fatalf("installRunnerFiles() error = %v, want extract error", err)
+	}
+}
+
+func TestRunnerInstallerFinishInstallNoService(t *testing.T) {
+	ri, _ := ciDryRunInstaller(t)
+	if err := ri.finishInstall(context.Background(), ri.InstallDir); err != nil {
+		t.Fatalf("finishInstall() error = %v", err)
+	}
+}
+
+func TestRunnerInstallerFinishInstallService(t *testing.T) {
+	ri, output := ciDryRunInstaller(t)
+	ri.Service = true
+	if err := ri.finishInstall(context.Background(), ri.InstallDir); err != nil {
+		t.Fatalf("finishInstall() error = %v", err)
+	}
+	out := output.String()
+	for _, want := range []string{"svc.sh install", "svc.sh start"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("dry-run output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunnerInstallerFinishInstallServiceInstallError(t *testing.T) {
+	testsupport.FakeTool(t, "sudo", testsupport.ToolBehavior{ExitCode: 1})
+	ri := &RunnerInstaller{Runner: realRunner(), Service: true}
+	err := ri.finishInstall(context.Background(), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "installing service") {
+		t.Fatalf("finishInstall() error = %v, want installing-service error", err)
+	}
+}
+
+func TestRunnerInstallerFinishInstallServiceStartError(t *testing.T) {
+	writeArgFailingTool(t, "sudo", 2, "start", "")
+	ri := &RunnerInstaller{Runner: realRunner(), Service: true}
+	err := ri.finishInstall(context.Background(), t.TempDir())
+	if err == nil || !strings.Contains(err.Error(), "starting service") {
+		t.Fatalf("finishInstall() error = %v, want starting-service error", err)
+	}
+}

--- a/internal/ci/workflow_test.go
+++ b/internal/ci/workflow_test.go
@@ -97,6 +97,18 @@ func TestWriteWorkflow(t *testing.T) {
 	}
 }
 
+func TestWriteWorkflow_WriteFileError(t *testing.T) {
+	// A target path that is already a directory cannot be written as a file.
+	dir := t.TempDir()
+	target := filepath.Join(dir, "workflow.yml")
+	if err := os.MkdirAll(target, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := WriteWorkflow(target, "name: CI\n"); err == nil {
+		t.Error("expected error when target path is an existing directory")
+	}
+}
+
 func TestFormatLabels(t *testing.T) {
 	tests := []struct {
 		labels []string

--- a/internal/container/builder_ensure_test.go
+++ b/internal/container/builder_ensure_test.go
@@ -1,0 +1,306 @@
+package container
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/ecr"
+	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+// stubCachedWrapper points the wrapper cache at a fresh temp home and pre-stages
+// a fake wrapper binary, so EnsureBinary returns the cached path without cloning,
+// downloading, or invoking any external tool.
+func stubCachedWrapper(t *testing.T, arch string) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	cacheDir := filepath.Join(home, ".cache", "ludus", "game-server-wrapper")
+	bin := filepath.Join(cacheDir, "out", "linux", arch, "gamelift-servers-managed-containers",
+		"amazon-gamelift-servers-game-server-wrapper")
+	if err := os.MkdirAll(filepath.Dir(bin), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(bin, []byte("fake wrapper binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestGenerateAndWriteDockerfile_WritesAndCleans(t *testing.T) {
+	stubCachedWrapper(t, "amd64")
+	dir := t.TempDir()
+	b := NewBuilder(BuildOptions{
+		ServerBuildDir:  dir,
+		ImageName:       "ludus-server",
+		Tag:             "latest",
+		ServerPort:      7777,
+		ProjectName:     "MyGame",
+		ServerTarget:    "MyGameServer",
+		PackagedDirName: "MyGame",
+	}, runner.NewRunner(false, false))
+
+	cleanup, err := b.generateAndWriteDockerfile(context.Background())
+	if err != nil {
+		t.Fatalf("generateAndWriteDockerfile() error = %v", err)
+	}
+
+	want := []string{"Dockerfile", ".dockerignore", "config.yaml",
+		"amazon-gamelift-servers-game-server-wrapper"}
+	for _, f := range want {
+		if _, statErr := os.Stat(filepath.Join(dir, f)); statErr != nil {
+			t.Errorf("expected %s to be staged into the build dir", f)
+		}
+	}
+
+	cleanup()
+	for _, f := range want {
+		if _, statErr := os.Stat(filepath.Join(dir, f)); statErr == nil {
+			t.Errorf("cleanup should have removed %s", f)
+		}
+	}
+}
+
+// TestGenerateAndWriteDockerfile_EnsureWrapperError forces EnsureBinary to reach
+// `go build` (all earlier stages pre-satisfied) and fail via a stubbed go.
+func TestGenerateAndWriteDockerfile_EnsureWrapperError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	cacheDir := filepath.Join(home, ".cache", "ludus", "game-server-wrapper")
+	if err := os.MkdirAll(filepath.Join(cacheDir, "src", "ext", "gamelift-servers-server-sdk"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cacheDir, "gamelift-servers-server-sdk.zip"), []byte("zip"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	testsupport.FakeTool(t, "go", testsupport.ToolBehavior{ExitCode: 1})
+
+	b := NewBuilder(BuildOptions{
+		ServerBuildDir: t.TempDir(),
+		ProjectName:    "MyGame",
+		ServerTarget:   "MyGameServer",
+	}, runner.NewRunner(false, false))
+
+	_, err := b.generateAndWriteDockerfile(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "game server wrapper") {
+		t.Fatalf("error = %v, want wrapper build failure", err)
+	}
+}
+
+func TestGenerateAndWriteDockerfile_WriteErrors(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		conflict string
+		wantErr  string
+	}{
+		{"wrapper copy", "amazon-gamelift-servers-game-server-wrapper", "copying wrapper binary"},
+		{"wrapper config", "config.yaml", "writing wrapper config"},
+		{"dockerfile", "Dockerfile", "writing Dockerfile"},
+		{"dockerignore", ".dockerignore", "writing .dockerignore"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			stubCachedWrapper(t, "amd64")
+			dir := t.TempDir()
+			if err := os.MkdirAll(filepath.Join(dir, tt.conflict), 0o755); err != nil {
+				t.Fatal(err)
+			}
+			b := NewBuilder(BuildOptions{
+				ServerBuildDir: dir,
+				ProjectName:    "MyGame",
+				ServerTarget:   "MyGameServer",
+			}, runner.NewRunner(false, false))
+
+			_, err := b.generateAndWriteDockerfile(context.Background())
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestCheckContainerPlatformSupport(t *testing.T) {
+	for _, tt := range []struct {
+		name     string
+		behavior testsupport.ToolBehavior
+		platform string
+		wantErr  bool
+	}{
+		{"buildx unavailable", testsupport.ToolBehavior{ExitCode: 1}, "linux/arm64", true},
+		{"platform supported", testsupport.ToolBehavior{Stdout: "Platforms: linux/amd64, linux/arm64"}, "linux/arm64", false},
+		{"platform unsupported", testsupport.ToolBehavior{Stdout: "Platforms: linux/amd64"}, "linux/arm64", true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testsupport.FakeTool(t, "docker", tt.behavior)
+			err := checkContainerPlatformSupport("docker", tt.platform)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("error = %v, wantErr = %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestBuild_MissingServerDir(t *testing.T) {
+	b := NewBuilder(BuildOptions{}, runner.NewRunner(false, true))
+	res, err := b.Build(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "server build directory not specified") {
+		t.Fatalf("Build() error = %v, want missing-dir error", err)
+	}
+	if res == nil || res.Error == nil {
+		t.Fatal("expected result.Error to be set")
+	}
+}
+
+func TestBuild_GenerateAndWriteFailure(t *testing.T) {
+	stubCachedWrapper(t, "amd64")
+	dir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(dir, "config.yaml"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	b := NewBuilder(BuildOptions{
+		ServerBuildDir: dir,
+		ImageName:      "img",
+		Tag:            "t",
+	}, runner.NewRunner(false, false))
+
+	res, err := b.Build(context.Background())
+	if err == nil {
+		t.Fatal("Build() expected error from wrapper config write")
+	}
+	if res == nil || res.Error == nil {
+		t.Fatal("expected result.Error to be set")
+	}
+}
+
+func TestBuild_DockerBuildFailure(t *testing.T) {
+	stubCachedWrapper(t, runtime.GOARCH)
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
+	b := NewBuilder(BuildOptions{
+		ServerBuildDir: t.TempDir(),
+		ImageName:      "img",
+		Tag:            "t",
+		Arch:           runtime.GOARCH,
+	}, runner.NewRunner(false, false))
+
+	res, err := b.Build(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "build failed") {
+		t.Fatalf("Build() error = %v, want docker build failure", err)
+	}
+	if res == nil || res.Error == nil {
+		t.Fatal("expected result.Error to be set")
+	}
+}
+
+func TestPush_DryRun(t *testing.T) {
+	r := runner.NewRunner(false, true)
+	b := NewBuilder(BuildOptions{ImageName: "ludus-server", Tag: "v1.0", ServerPort: 7777}, r)
+
+	err := b.Push(context.Background(), ecr.PushOptions{
+		ECRRepository: "ludus-server",
+		AWSRegion:     "us-east-1",
+		AWSAccountID:  "123456789012",
+		ImageTag:      "v1.0",
+	})
+	if err != nil {
+		t.Fatalf("Push() error = %v", err)
+	}
+}
+
+func TestRunDockerBuild_CrossArchAndNoCache(t *testing.T) {
+	other := otherArch()
+	for _, tt := range []struct {
+		name     string
+		backend  string
+		noCache  bool
+		wantArgs []string
+	}{
+		{"docker cross-arch no-cache", "docker", true, []string{"--platform", "linux/" + other, "--provenance=false", "--no-cache"}},
+		{"docker cross-arch cached", "docker", false, []string{"--platform", "linux/" + other, "--provenance=false"}},
+		{"podman cross-arch", "podman", false, []string{"--platform", "linux/" + other}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testsupport.FakeTool(t, tt.backend, testsupport.ToolBehavior{
+				Stdout: "Platforms: linux/amd64, linux/arm64",
+			})
+			r, getLines := testsupport.RecordingRunner()
+			b := NewBuilder(BuildOptions{
+				ServerBuildDir: t.TempDir(),
+				ImageName:      "img",
+				Tag:            "t",
+				Arch:           other,
+				Backend:        tt.backend,
+				NoCache:        tt.noCache,
+			}, r)
+
+			if err := b.runDockerBuild(context.Background(), "img:t"); err != nil {
+				t.Fatalf("runDockerBuild() error = %v", err)
+			}
+			for _, want := range tt.wantArgs {
+				if !lineContains(getLines(), want) {
+					t.Errorf("recorded commands missing %q, got: %v", want, getLines())
+				}
+			}
+		})
+	}
+}
+
+func TestRunDockerBuild_CrossArchProbeFailure(t *testing.T) {
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
+	b := NewBuilder(BuildOptions{
+		ServerBuildDir: t.TempDir(),
+		ImageName:      "img",
+		Tag:            "t",
+		Arch:           otherArch(),
+	}, runner.NewRunner(false, true))
+
+	err := b.runDockerBuild(context.Background(), "img:t")
+	if err == nil || !strings.Contains(err.Error(), "buildx not available") {
+		t.Fatalf("runDockerBuild() error = %v, want buildx probe failure", err)
+	}
+}
+
+func TestResolveServerBinaryName_MissingBinDir(t *testing.T) {
+	b := NewBuilder(BuildOptions{
+		ServerBuildDir: t.TempDir(),
+		ProjectName:    "MyGame",
+		ServerTarget:   "MyGameServer",
+	}, nil)
+	if got := b.resolveServerBinaryName(); got != "MyGameServer" {
+		t.Errorf("got %q, want %q", got, "MyGameServer")
+	}
+}
+
+func TestCopyFile_DirectorySourceFails(t *testing.T) {
+	dir := t.TempDir()
+	sub := filepath.Join(dir, "subdir")
+	if err := os.MkdirAll(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := copyFile(sub, filepath.Join(dir, "out.bin")); err == nil {
+		t.Error("expected error copying a directory as a file")
+	}
+}
+
+// otherArch returns the architecture that differs from the host, so cross-arch
+// code paths run identically on amd64 and arm64 test hosts.
+func otherArch() string {
+	if runtime.GOARCH == "arm64" {
+		return "amd64"
+	}
+	return "arm64"
+}
+
+// lineContains reports whether any echoed command line contains want.
+func lineContains(lines []string, want string) bool {
+	for _, line := range lines {
+		if strings.Contains(line, want) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/ddc/ddc_ops_test.go
+++ b/internal/ddc/ddc_ops_test.go
@@ -3,6 +3,7 @@ package ddc
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -33,12 +34,37 @@ func TestClean_Empty(t *testing.T) {
 }
 
 func TestClean_NotExist(t *testing.T) {
-	freed, err := Clean("/nonexistent/path")
+	freed, err := Clean(filepath.Join(t.TempDir(), "missing"))
 	if err != nil {
 		t.Fatalf("Clean() should not error for missing dir: %v", err)
 	}
 	if freed != 0 {
 		t.Errorf("Clean() on nonexistent dir freed = %d, want 0", freed)
+	}
+}
+
+func TestClean_FileReadDirError(t *testing.T) {
+	// Cleaning a path that is a regular file (not a dir) must surface an error.
+	// On Windows the directory-open on a file reports ERROR_PATH_NOT_FOUND,
+	// which errors.Is classifies as ErrNotExist, so Clean treats it as empty.
+	file := filepath.Join(t.TempDir(), "blocker.bin")
+	writeTestFile(t, file, 1)
+
+	freed, err := Clean(file)
+	if runtime.GOOS == "windows" {
+		if err != nil {
+			t.Fatalf("Clean(file) on windows should not error, got: %v", err)
+		}
+		if freed != 0 {
+			t.Errorf("Clean(file) freed = %d, want 0 on windows", freed)
+		}
+		return
+	}
+	if err == nil {
+		t.Fatal("Clean(file) should error on non-windows, got nil")
+	}
+	if !strings.Contains(err.Error(), "reading DDC directory") {
+		t.Errorf("error = %v, want it to wrap the ReadDir failure", err)
 	}
 }
 
@@ -74,12 +100,42 @@ func TestPrune(t *testing.T) {
 }
 
 func TestPrune_NotExist(t *testing.T) {
-	freed, err := Prune("/nonexistent/path", 7)
+	freed, err := Prune(filepath.Join(t.TempDir(), "missing"), 7)
 	if err != nil {
 		t.Fatalf("Prune() should not error for missing dir: %v", err)
 	}
 	if freed != 0 {
 		t.Errorf("Prune() on nonexistent dir freed = %d, want 0", freed)
+	}
+}
+
+func TestPrune_NestedOldFiles(t *testing.T) {
+	dir := t.TempDir()
+	subdir := filepath.Join(dir, "nested", "deep")
+	if err := os.MkdirAll(subdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldTime := time.Now().Add(-20 * 24 * time.Hour)
+	oldFile := filepath.Join(subdir, "old.bin")
+	writeTestFile(t, oldFile, 512)
+	if err := os.Chtimes(oldFile, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+	writeTestFile(t, filepath.Join(dir, "fresh.bin"), 64)
+
+	freed, err := Prune(dir, 7)
+	if err != nil {
+		t.Fatalf("Prune() error: %v", err)
+	}
+	if freed != 512 {
+		t.Errorf("Prune() freed = %d, want 512 (only the nested old file)", freed)
+	}
+	if _, err := os.Stat(oldFile); !os.IsNotExist(err) {
+		t.Error("nested old file should have been removed")
+	}
+	if _, err := os.Stat(filepath.Join(dir, "fresh.bin")); err != nil {
+		t.Error("recent file should be kept")
 	}
 }
 

--- a/internal/ddc/ddc_path_test.go
+++ b/internal/ddc/ddc_path_test.go
@@ -70,6 +70,23 @@ func TestDefaultPath_HomeUnset(t *testing.T) {
 	}
 }
 
+func TestResolveHome_WindowsUserProfileFallback(t *testing.T) {
+	// On Windows, os.UserHomeDir reads $USERPROFILE; when it is unset the
+	// resolveHome fallback consults the os/user database instead of failing.
+	if runtime.GOOS != "windows" {
+		t.Skip("user.Current fallback is only reachable on Windows (Unix HOME-less runs take the user.Current path here too)")
+	}
+	t.Setenv("USERPROFILE", "")
+
+	got, err := resolveHome()
+	if err != nil {
+		t.Fatalf("resolveHome() with USERPROFILE unset should fall back to user.Current, got error: %v", err)
+	}
+	if got == "" {
+		t.Error("resolveHome() = empty string, want the current user's home")
+	}
+}
+
 func TestDefaultZenPath_HomeUnset(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("HOME-unset fallback is a *nix concern")

--- a/internal/ddc/ddc_size_test.go
+++ b/internal/ddc/ddc_size_test.go
@@ -58,11 +58,25 @@ func TestDirSize_Nested(t *testing.T) {
 }
 
 func TestDirSize_NotExist(t *testing.T) {
-	size, err := DirSize("/nonexistent/path")
+	size, err := DirSize(filepath.Join(t.TempDir(), "missing"))
 	if err != nil {
 		t.Fatalf("DirSize() should not error for missing dir: %v", err)
 	}
 	if size != 0 {
 		t.Errorf("nonexistent dir size = %d, want 0", size)
+	}
+}
+
+func TestDirSize_FileRoot(t *testing.T) {
+	// DirSize of a regular file (not a dir) must report the file's own size.
+	file := filepath.Join(t.TempDir(), "single.bin")
+	writeTestFile(t, file, 4096)
+
+	size, err := DirSize(file)
+	if err != nil {
+		t.Fatalf("DirSize(file) error: %v", err)
+	}
+	if size != 4096 {
+		t.Errorf("DirSize(file) = %d, want 4096", size)
 	}
 }

--- a/internal/engine/builder_windows_test.go
+++ b/internal/engine/builder_windows_test.go
@@ -1,0 +1,129 @@
+//go:build windows
+
+package engine
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+// newQuietRunner returns a runner with output silenced so tests stay clean.
+func newQuietRunner(dryRun bool) *runner.Runner {
+	r := runner.NewRunner(false, dryRun)
+	r.Stdout = io.Discard
+	r.Stderr = io.Discard
+	return r
+}
+
+func TestRunBatDryRun(t *testing.T) {
+	b := NewBuilder(BuildOptions{SourcePath: t.TempDir()}, newQuietRunner(true))
+
+	if err := b.runBat(context.Background(), "setup.bat", "-arg"); err != nil {
+		t.Errorf("runBat(dry-run) error = %v, want nil", err)
+	}
+}
+
+func TestRunBatExecutesStub(t *testing.T) {
+	src := t.TempDir()
+	stub := filepath.Join(src, "stub.bat")
+	if err := os.WriteFile(stub, []byte("@echo off\r\nexit /b 0\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	b := NewBuilder(BuildOptions{SourcePath: src}, newQuietRunner(false))
+
+	if err := b.runBat(context.Background(), stub); err != nil {
+		t.Errorf("runBat(stub) error = %v, want nil", err)
+	}
+}
+
+func TestRunBatExecutesFailingStub(t *testing.T) {
+	src := t.TempDir()
+	stub := filepath.Join(src, "stub.bat")
+	if err := os.WriteFile(stub, []byte("@echo off\r\nexit /b 5\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	b := NewBuilder(BuildOptions{SourcePath: src}, newQuietRunner(false))
+
+	if err := b.runBat(context.Background(), stub); err == nil {
+		t.Error("runBat(failing stub) error = nil, want error")
+	}
+}
+
+func TestRunBatFileMissing(t *testing.T) {
+	b := NewBuilder(BuildOptions{SourcePath: t.TempDir()}, newQuietRunner(true))
+
+	err := b.runBatFile(context.Background(), "Missing.bat")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("runBatFile() error = %v, want 'not found'", err)
+	}
+}
+
+func TestSetupSuccess(t *testing.T) {
+	root := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	b := NewBuilder(BuildOptions{SourcePath: root}, newQuietRunner(true))
+
+	if err := b.Setup(context.Background()); err != nil {
+		t.Errorf("Setup() error = %v, want nil", err)
+	}
+}
+
+func TestSetupMissing(t *testing.T) {
+	root := testsupport.FakeEngineTree(t, testsupport.WithoutSetup())
+	b := NewBuilder(BuildOptions{SourcePath: root}, newQuietRunner(true))
+
+	err := b.Setup(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "Setup.bat not found") {
+		t.Errorf("Setup() error = %v, want 'Setup.bat not found'", err)
+	}
+}
+
+func TestGenerateProjectFilesSuccess(t *testing.T) {
+	root := testsupport.FakeEngineTree(t)
+	b := NewBuilder(BuildOptions{SourcePath: root}, newQuietRunner(true))
+
+	if err := b.GenerateProjectFiles(context.Background()); err != nil {
+		t.Errorf("GenerateProjectFiles() error = %v, want nil", err)
+	}
+}
+
+func TestGenerateProjectFilesMissing(t *testing.T) {
+	b := NewBuilder(BuildOptions{SourcePath: t.TempDir()}, newQuietRunner(true))
+
+	err := b.GenerateProjectFiles(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "GenerateProjectFiles.bat not found") {
+		t.Errorf("GenerateProjectFiles() error = %v, want 'not found'", err)
+	}
+}
+
+func TestCompileSuccess(t *testing.T) {
+	root := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	b := NewBuilder(BuildOptions{SourcePath: root}, newQuietRunner(true))
+
+	if err := b.compile(context.Background(), 2); err != nil {
+		t.Errorf("compile() error = %v, want nil", err)
+	}
+}
+
+func TestCompileMissingBuildBat(t *testing.T) {
+	b := NewBuilder(BuildOptions{SourcePath: t.TempDir()}, newQuietRunner(true))
+
+	err := b.compile(context.Background(), 2)
+	if err == nil || !strings.Contains(err.Error(), "Build.bat not found") {
+		t.Errorf("compile() error = %v, want 'Build.bat not found'", err)
+	}
+}
+
+func TestAutoDetectJobs(t *testing.T) {
+	if got := autoDetectJobs(); got < 1 {
+		t.Errorf("autoDetectJobs() = %d, want >= 1", got)
+	}
+}

--- a/internal/game/builder_flow_test.go
+++ b/internal/game/builder_flow_test.go
@@ -1,0 +1,306 @@
+package game
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+// flowTestBuilder returns a Builder wired to a dry-run runner (hermetic: no
+// UAT subprocess is spawned, only the would-be command is echoed).
+func flowTestBuilder(opts BuildOptions) *Builder {
+	return NewBuilder(opts, runner.NewRunner(false, true))
+}
+
+// flowBaseOptions returns BuildOptions referencing a fake engine tree and a
+// fake project, sufficient to drive Build/BuildClient past LocateProject and
+// resolveRunUAT.
+func flowBaseOptions(t *testing.T) BuildOptions {
+	t.Helper()
+	engineRoot := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	projectPath := testsupport.FakeProject(t, "TestGame")
+	return BuildOptions{
+		EnginePath:    engineRoot,
+		ProjectPath:   projectPath,
+		ProjectName:   "TestGame",
+		ServerTarget:  "TestGameServer",
+		ClientTarget:  "TestGameClient",
+		Platform:      "Linux",
+		EngineVersion: "5.7.3",
+	}
+}
+
+// makeDefaultEngineIniADir turns the project's Config/DefaultEngine.ini into a
+// directory so os.ReadFile fails with a non-IsNotExist error.
+func makeDefaultEngineIniADir(t *testing.T, projectPath string) {
+	t.Helper()
+	dir := filepath.Join(filepath.Dir(projectPath), "Config", "DefaultEngine.ini")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// writeFailingRunUAT overwrites both RunUAT scripts so the build step exits 1.
+func writeFailingRunUAT(t *testing.T, engineRoot string) {
+	t.Helper()
+	batch := filepath.Join(engineRoot, "Engine", "Build", "BatchFiles")
+	writeTestFile(t, filepath.Join(batch, "RunUAT.bat"), "@echo off\r\nexit /b 1\r\n")
+	writeTestFile(t, filepath.Join(batch, "RunUAT.sh"), "#!/bin/sh\nexit 1\n")
+}
+
+// TestBuildSuccessDryRun covers the full Build pipeline: LocateProject →
+// resolveRunUAT → prepareBuildEnvironment → resolveServerBuildArgs → setupDDC
+// → runBuildStep, asserting the success result is fully populated.
+func TestBuildSuccessDryRun(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	opts := flowBaseOptions(t)
+	b := flowTestBuilder(opts)
+
+	result, err := b.Build(context.Background())
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if !result.Success {
+		t.Error("Build() Success = false, want true")
+	}
+	if result.Error != nil {
+		t.Errorf("Build() Error = %v, want nil", result.Error)
+	}
+	wantOut := filepath.Join(filepath.Dir(opts.ProjectPath), "PackagedServer")
+	if result.OutputDir != wantOut {
+		t.Errorf("Build() OutputDir = %q, want %q", result.OutputDir, wantOut)
+	}
+	wantBin := filepath.Join(wantOut, "LinuxServer", "TestGameServer")
+	if result.ServerBinary != wantBin {
+		t.Errorf("Build() ServerBinary = %q, want %q", result.ServerBinary, wantBin)
+	}
+	if result.Duration <= 0 {
+		t.Errorf("Build() Duration = %v, want > 0", result.Duration)
+	}
+}
+
+// TestBuildArm64DefersDumpSyms covers the arm64 prepareBuildEnvironment branch
+// (defer disableDumpSyms) on every host. APPDATA is sandboxed so the
+// BuildConfiguration.xml workaround writes to a temp dir, and the file is
+// asserted restored once the build completes.
+func TestBuildArm64DefersDumpSyms(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	appdata := t.TempDir()
+	t.Setenv("APPDATA", appdata)
+	configPath := filepath.Join(appdata, "Unreal Engine", "UnrealBuildTool", "BuildConfiguration.xml")
+	const original = "<BuildConfiguration>\n</BuildConfiguration>\n"
+	writeTestFile(t, configPath, original)
+
+	opts := flowBaseOptions(t)
+	opts.Arch = "arm64"
+	b := flowTestBuilder(opts)
+
+	result, err := b.Build(context.Background())
+	if err != nil {
+		t.Fatalf("Build(arm64) error = %v", err)
+	}
+	if !result.Success {
+		t.Error("Build(arm64) Success = false, want true")
+	}
+	wantBin := filepath.Join(filepath.Dir(opts.ProjectPath), "PackagedServer", "LinuxArm64Server", "TestGameServer")
+	if result.ServerBinary != wantBin {
+		t.Errorf("Build(arm64) ServerBinary = %q, want %q", result.ServerBinary, wantBin)
+	}
+
+	restored, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading restored BuildConfiguration.xml: %v", err)
+	}
+	if string(restored) != original {
+		t.Errorf("BuildConfiguration.xml not restored, got %q, want %q", restored, original)
+	}
+}
+
+// TestBuildLocateProjectError covers the LocateProject failure branch.
+func TestBuildLocateProjectError(t *testing.T) {
+	opts := flowBaseOptions(t)
+	opts.ProjectPath = filepath.Join(t.TempDir(), "missing.uproject")
+	b := flowTestBuilder(opts)
+
+	result, err := b.Build(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "configured project path not found") {
+		t.Fatalf("Build() error = %v, want project-not-found error", err)
+	}
+	if result.Error == nil {
+		t.Error("Build() result.Error should be set on failure")
+	}
+}
+
+// TestBuildResolveRunUATError covers resolveRunUAT failure in Build.
+func TestBuildResolveRunUATError(t *testing.T) {
+	opts := flowBaseOptions(t)
+	opts.EnginePath = t.TempDir() // no Engine/Build/BatchFiles/RunUAT.*
+	b := flowTestBuilder(opts)
+
+	if _, err := b.Build(context.Background()); err == nil || !strings.Contains(err.Error(), "not found at") {
+		t.Fatalf("Build() error = %v, want RunUAT-not-found error", err)
+	}
+}
+
+// TestBuildPrepareEnvironmentError covers ensureDefaultServerTarget failing to
+// read an unreadable DefaultEngine.ini (an IsNotExist error is graceful; any
+// other read failure is surfaced).
+func TestBuildPrepareEnvironmentError(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	opts := flowBaseOptions(t)
+	makeDefaultEngineIniADir(t, opts.ProjectPath)
+	b := flowTestBuilder(opts)
+
+	if _, err := b.Build(context.Background()); err == nil || !strings.Contains(err.Error(), "setting default server target") {
+		t.Fatalf("Build() error = %v, want DefaultServerTarget failure", err)
+	}
+}
+
+// TestBuildSetupDDCError covers setupDDC rejecting an invalid DDC mode.
+func TestBuildSetupDDCError(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	opts := flowBaseOptions(t)
+	opts.DDCMode = "bogus"
+	b := flowTestBuilder(opts)
+
+	if _, err := b.Build(context.Background()); err == nil || !strings.Contains(err.Error(), "unsupported DDC mode") {
+		t.Fatalf("Build() error = %v, want unsupported-DDC-mode error", err)
+	}
+}
+
+// TestBuildRunStepError covers the RunUAT failure path via a real non-dry
+// runner executing a failing script, then asserts diagnostics are applied.
+func TestBuildRunStepError(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	opts := flowBaseOptions(t)
+	writeFailingRunUAT(t, opts.EnginePath)
+
+	b := NewBuilder(opts, runner.NewRunner(false, false))
+	result, err := b.Build(context.Background())
+	if err == nil {
+		t.Fatal("Build() error = nil, want RunUAT failure")
+	}
+	if !strings.Contains(err.Error(), "BuildCookRun") {
+		t.Errorf("Build() error = %v, want BuildCookRun diagnostics", err)
+	}
+	if result.Error == nil || !strings.Contains(result.Error.Error(), "BuildCookRun") {
+		t.Errorf("Build() result.Error = %v, want wrapped diagnostics", result.Error)
+	}
+}
+
+// TestBuildClientSuccessDryRun covers BuildClient with the default Linux platform.
+func TestBuildClientSuccessDryRun(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	opts := flowBaseOptions(t)
+	b := flowTestBuilder(opts)
+
+	result, err := b.BuildClient(context.Background())
+	if err != nil {
+		t.Fatalf("BuildClient() error = %v", err)
+	}
+	if !result.Success || result.Error != nil {
+		t.Errorf("BuildClient() result = %+v, want success", result)
+	}
+	if result.Platform != "Linux" {
+		t.Errorf("BuildClient() Platform = %q, want Linux", result.Platform)
+	}
+	wantOut := filepath.Join(filepath.Dir(opts.ProjectPath), "PackagedClient")
+	if result.OutputDir != wantOut {
+		t.Errorf("BuildClient() OutputDir = %q, want %q", result.OutputDir, wantOut)
+	}
+	if result.ClientBinary == "" || !strings.Contains(result.ClientBinary, "TestGameClient") {
+		t.Errorf("BuildClient() ClientBinary = %q, want TestGameClient binary", result.ClientBinary)
+	}
+	if result.Duration <= 0 {
+		t.Errorf("BuildClient() Duration = %v, want > 0", result.Duration)
+	}
+}
+
+// TestBuildClientWin64Success covers BuildClient cross-compiling for Win64.
+func TestBuildClientWin64Success(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	opts := flowBaseOptions(t)
+	opts.ClientPlatform = "Win64"
+	b := flowTestBuilder(opts)
+
+	result, err := b.BuildClient(context.Background())
+	if err != nil {
+		t.Fatalf("BuildClient(Win64) error = %v", err)
+	}
+	if result.Platform != "Win64" {
+		t.Errorf("BuildClient(Win64) Platform = %q, want Win64", result.Platform)
+	}
+	if !strings.HasSuffix(result.ClientBinary, ".exe") {
+		t.Errorf("BuildClient(Win64) ClientBinary = %q, want .exe suffix", result.ClientBinary)
+	}
+}
+
+// TestBuildClientPlatformError covers resolveClientPlatform rejecting an
+// unsupported platform.
+func TestBuildClientPlatformError(t *testing.T) {
+	opts := flowBaseOptions(t)
+	opts.ClientPlatform = "Android"
+	b := flowTestBuilder(opts)
+
+	if _, err := b.BuildClient(context.Background()); err == nil || !strings.Contains(err.Error(), "unsupported client platform") {
+		t.Fatalf("BuildClient() error = %v, want unsupported-platform error", err)
+	}
+}
+
+// TestBuildClientResolveRunUATError covers resolveRunUAT failure in BuildClient.
+func TestBuildClientResolveRunUATError(t *testing.T) {
+	opts := flowBaseOptions(t)
+	opts.EnginePath = t.TempDir()
+	b := flowTestBuilder(opts)
+
+	if _, err := b.BuildClient(context.Background()); err == nil || !strings.Contains(err.Error(), "not found at") {
+		t.Fatalf("BuildClient() error = %v, want RunUAT-not-found error", err)
+	}
+}
+
+// TestBuildClientSetupDDCError covers setupDDC failure in BuildClient.
+func TestBuildClientSetupDDCError(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	opts := flowBaseOptions(t)
+	opts.DDCMode = "bogus"
+	b := flowTestBuilder(opts)
+
+	if _, err := b.BuildClient(context.Background()); err == nil || !strings.Contains(err.Error(), "unsupported DDC mode") {
+		t.Fatalf("BuildClient() error = %v, want unsupported-DDC-mode error", err)
+	}
+}
+
+// TestBuildClientRunStepError covers BuildClient's UAT failure diagnostics.
+func TestBuildClientRunStepError(t *testing.T) {
+	t.Setenv("LINUX_MULTIARCH_ROOT", filepath.Join(t.TempDir(), "toolchain"))
+	opts := flowBaseOptions(t)
+	writeFailingRunUAT(t, opts.EnginePath)
+
+	b := NewBuilder(opts, runner.NewRunner(false, false))
+	if _, err := b.BuildClient(context.Background()); err == nil || !strings.Contains(err.Error(), "BuildCookRun (client") {
+		t.Fatalf("BuildClient() error = %v, want client diagnostics", err)
+	}
+}
+
+// TestExecRunUATDryRun exercises execRunUAT argument assembly for the current
+// OS without spawning anything (dry-run runner).
+func TestExecRunUATDryRun(t *testing.T) {
+	engine := t.TempDir()
+	b := flowTestBuilder(BuildOptions{EnginePath: engine})
+
+	shell := "cmd"
+	script := filepath.Join("Engine", "Build", "BatchFiles", "RunUAT.bat")
+	if runtime.GOOS != "windows" {
+		shell = "bash"
+		script = filepath.Join("Engine", "Build", "BatchFiles", "RunUAT.sh")
+	}
+	if err := b.execRunUAT(context.Background(), shell, script, []string{"BuildCookRun"}); err != nil {
+		t.Fatalf("execRunUAT() error = %v", err)
+	}
+}

--- a/internal/wsl/command_run_test.go
+++ b/internal/wsl/command_run_test.go
@@ -1,0 +1,52 @@
+package wsl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestRunBashAsRootUsesRootFlag(t *testing.T) {
+	r, lines := testsupport.RecordingRunner()
+
+	if err := RunBashAsRoot(context.Background(), r, "Ubuntu", "apt-get update"); err != nil {
+		t.Fatalf("RunBashAsRoot() error = %v", err)
+	}
+	got := strings.Join(lines(), " ")
+	if !strings.Contains(got, "wsl.exe -d Ubuntu -u root bash -c apt-get update") {
+		t.Errorf("RunBashAsRoot() echoed %q, want -u root invocation", got)
+	}
+}
+
+func TestRunSudoPrefixesSudo(t *testing.T) {
+	r, lines := testsupport.RecordingRunner()
+
+	if err := RunSudo(context.Background(), r, "Ubuntu", "apt-get", "update"); err != nil {
+		t.Fatalf("RunSudo() error = %v", err)
+	}
+	got := strings.Join(lines(), " ")
+	if !strings.Contains(got, "wsl.exe -d Ubuntu -e sudo apt-get update") {
+		t.Errorf("RunSudo() echoed %q, want sudo-prefixed invocation", got)
+	}
+}
+
+func TestCheckCommandFound(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{})
+	r := newTestRunner(t, false)
+
+	if err := CheckCommand(context.Background(), r, "Ubuntu", "gcc"); err != nil {
+		t.Errorf("CheckCommand() error = %v, want nil", err)
+	}
+}
+
+func TestCheckCommandMissing(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	r := newTestRunner(t, false)
+
+	err := CheckCommand(context.Background(), r, "Ubuntu", "gcc")
+	if err == nil || !strings.Contains(err.Error(), "gcc not found") {
+		t.Errorf("CheckCommand() error = %v, want 'gcc not found'", err)
+	}
+}

--- a/internal/wsl/coordinator_test.go
+++ b/internal/wsl/coordinator_test.go
@@ -1,0 +1,214 @@
+package wsl
+
+import (
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+// newTestRunner returns a runner with output silenced so tests stay clean.
+// Dry-run mode makes every command a no-op; real mode executes the fake
+// wsl.exe stub placed on PATH by testsupport.FakeTool.
+func newTestRunner(t *testing.T, dryRun bool) *runner.Runner {
+	t.Helper()
+	r := runner.NewRunner(false, dryRun)
+	r.Stdout = io.Discard
+	r.Stderr = io.Discard
+	return r
+}
+
+func TestNewSelectsDefaultDistro(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{
+		Stdout: "* Ubuntu          Running         2",
+	})
+
+	w, err := New(newTestRunner(t, true), "")
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if w.Distro != "Ubuntu" {
+		t.Errorf("Distro = %q, want Ubuntu", w.Distro)
+	}
+	if w.Runner == nil {
+		t.Error("New() Runner is nil")
+	}
+}
+
+func TestNewOverrideNotFound(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{
+		Stdout: "* Ubuntu          Running         2",
+	})
+
+	_, err := New(newTestRunner(t, true), "Debian")
+	if err == nil || !strings.Contains(err.Error(), "not found") {
+		t.Errorf("New() error = %v, want 'not found'", err)
+	}
+}
+
+func TestNewUnavailableWhenCommandFails(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+
+	_, err := New(newTestRunner(t, true), "")
+	if err == nil || !strings.Contains(err.Error(), "WSL2 is not available") {
+		t.Errorf("New() error = %v, want 'WSL2 is not available'", err)
+	}
+}
+
+func TestNewUnavailableWhenNotInstalled(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	_, err := New(newTestRunner(t, true), "")
+	if err == nil || !strings.Contains(err.Error(), "WSL2 is not available") {
+		t.Errorf("New() error = %v, want 'WSL2 is not available'", err)
+	}
+}
+
+func TestWSL2RunEcho(t *testing.T) {
+	r, lines := testsupport.RecordingRunner()
+	w := &WSL2{Distro: "Ubuntu", Runner: r}
+
+	if err := w.Run(context.Background(), "ls", "-la"); err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	got := strings.Join(lines(), " ")
+	if !strings.Contains(got, "wsl.exe -d Ubuntu -e ls -la") {
+		t.Errorf("Run() echoed %q, want wsl.exe -d Ubuntu -e ls -la", got)
+	}
+}
+
+func TestWSL2RunBashEcho(t *testing.T) {
+	r, lines := testsupport.RecordingRunner()
+	w := &WSL2{Distro: "Debian", Runner: r}
+
+	if err := w.RunBash(context.Background(), "echo hello"); err != nil {
+		t.Fatalf("RunBash() error = %v", err)
+	}
+	got := strings.Join(lines(), " ")
+	if !strings.Contains(got, "wsl.exe -d Debian bash -c echo hello") {
+		t.Errorf("RunBash() echoed %q, want wsl.exe -d Debian bash -c echo hello", got)
+	}
+}
+
+func TestWSL2RunOutputEcho(t *testing.T) {
+	r, lines := testsupport.RecordingRunner()
+	w := &WSL2{Distro: "Ubuntu", Runner: r}
+
+	out, err := w.RunOutput(context.Background(), "df", "-BG")
+	if err != nil {
+		t.Fatalf("RunOutput() error = %v", err)
+	}
+	if len(out) == 0 {
+		t.Error("RunOutput() returned empty output")
+	}
+	got := strings.Join(lines(), " ")
+	if !strings.Contains(got, "wsl.exe -d Ubuntu -e df -BG") {
+		t.Errorf("RunOutput() echoed %q, want wsl.exe -d Ubuntu -e df -BG", got)
+	}
+}
+
+func TestEnsureDepsPresent(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	if err := w.EnsureDeps(context.Background()); err != nil {
+		t.Errorf("EnsureDeps() error = %v, want nil", err)
+	}
+}
+
+func TestEnsureDepsInstallFailure(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	if err := w.EnsureDeps(context.Background()); err == nil {
+		t.Error("EnsureDeps() error = nil, want install failure")
+	}
+}
+
+func TestEnsureRuntimeDepsPresent(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	if err := w.EnsureRuntimeDeps(context.Background()); err != nil {
+		t.Errorf("EnsureRuntimeDeps() error = %v, want nil", err)
+	}
+}
+
+func TestEnsureRuntimeDepsInstallFailure(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	if err := w.EnsureRuntimeDeps(context.Background()); err == nil {
+		t.Error("EnsureRuntimeDeps() error = nil, want install failure")
+	}
+}
+
+func TestDiskFreeGB(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  250G"})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	got, err := w.DiskFreeGB(context.Background())
+	if err != nil {
+		t.Fatalf("DiskFreeGB() error = %v", err)
+	}
+	if got != 250 {
+		t.Errorf("DiskFreeGB() = %v, want 250", got)
+	}
+}
+
+func TestHasRsync(t *testing.T) {
+	tests := []struct {
+		name     string
+		behavior testsupport.ToolBehavior
+		want     bool
+	}{
+		{"present", testsupport.ToolBehavior{}, true},
+		{"missing", testsupport.ToolBehavior{ExitCode: 1}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testsupport.FakeTool(t, "wsl.exe", tt.behavior)
+			w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+			if got := w.HasRsync(context.Background()); got != tt.want {
+				t.Errorf("HasRsync() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestExpandHomePathsReplacesHome(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "/home/user"})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	got, err := w.ExpandHomePaths(context.Background(), "$HOME/ludus/engine", "/plain/path")
+	if err != nil {
+		t.Fatalf("ExpandHomePaths() error = %v", err)
+	}
+	if got[0] != "/home/user/ludus/engine" {
+		t.Errorf("ExpandHomePaths()[0] = %q, want /home/user/ludus/engine", got[0])
+	}
+	if got[1] != "/plain/path" {
+		t.Errorf("ExpandHomePaths()[1] = %q, want /plain/path", got[1])
+	}
+}
+
+func TestExpandHomePathsResolveError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	if _, err := w.ExpandHomePaths(context.Background(), "$HOME/ludus"); err == nil {
+		t.Error("ExpandHomePaths() error = nil, want resolve error")
+	}
+}
+
+func TestExpandHomePathsEmptyHome(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: ""})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	_, err := w.ExpandHomePaths(context.Background(), "$HOME/ludus")
+	if err == nil || !strings.Contains(err.Error(), "empty string") {
+		t.Errorf("ExpandHomePaths() error = %v, want 'resolved to empty string'", err)
+	}
+}

--- a/internal/wsl/detect_exec_test.go
+++ b/internal/wsl/detect_exec_test.go
@@ -1,0 +1,173 @@
+package wsl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestDetectAvailable(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{
+		Stdout: "* Ubuntu          Running         2",
+	})
+
+	info, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if !info.Available {
+		t.Fatal("Detect() Available = false, want true")
+	}
+	if len(info.Distros) != 1 || info.Distros[0].Name != "Ubuntu" {
+		t.Errorf("Detect() Distros = %+v, want [Ubuntu]", info.Distros)
+	}
+}
+
+func TestDetectCommandError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+
+	info, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if info.Available {
+		t.Fatal("Detect() Available = true, want false")
+	}
+}
+
+func TestDetectNotInstalled(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	info, err := Detect()
+	if err != nil {
+		t.Fatalf("Detect() error = %v", err)
+	}
+	if info.Available {
+		t.Fatal("Detect() Available = true, want false")
+	}
+}
+
+func TestCheckDepsAllPresent(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{})
+	r := newTestRunner(t, false)
+
+	if err := CheckDeps(context.Background(), r, "Ubuntu"); err != nil {
+		t.Errorf("CheckDeps() error = %v, want nil", err)
+	}
+}
+
+func TestCheckDepsMissing(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	r := newTestRunner(t, false)
+
+	err := CheckDeps(context.Background(), r, "Ubuntu")
+	if err == nil || !strings.Contains(err.Error(), "missing build dependencies") {
+		t.Errorf("CheckDeps() error = %v, want 'missing build dependencies'", err)
+	}
+}
+
+func TestCheckRuntimeDepsPresent(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{})
+	r := newTestRunner(t, false)
+
+	if err := CheckRuntimeDeps(context.Background(), r, "Ubuntu"); err != nil {
+		t.Errorf("CheckRuntimeDeps() error = %v, want nil", err)
+	}
+}
+
+func TestCheckRuntimeDepsMissing(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	r := newTestRunner(t, false)
+
+	err := CheckRuntimeDeps(context.Background(), r, "Ubuntu")
+	if err == nil || !strings.Contains(err.Error(), "runtime libraries missing") {
+		t.Errorf("CheckRuntimeDeps() error = %v, want 'runtime libraries missing'", err)
+	}
+}
+
+func TestCheckDiskSpaceSuccess(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  250G"})
+	r := newTestRunner(t, false)
+
+	got, err := CheckDiskSpace(context.Background(), r, "Ubuntu")
+	if err != nil {
+		t.Fatalf("CheckDiskSpace() error = %v", err)
+	}
+	if got != 250 {
+		t.Errorf("CheckDiskSpace() = %v, want 250", got)
+	}
+}
+
+func TestCheckDiskSpaceCommandError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	r := newTestRunner(t, false)
+
+	if _, err := CheckDiskSpace(context.Background(), r, "Ubuntu"); err == nil {
+		t.Error("CheckDiskSpace() error = nil, want command error")
+	}
+}
+
+func TestCheckDiskSpaceParseError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "not-a-number"})
+	r := newTestRunner(t, false)
+
+	if _, err := CheckDiskSpace(context.Background(), r, "Ubuntu"); err == nil {
+		t.Error("CheckDiskSpace() error = nil, want parse error")
+	}
+}
+
+func TestCheckRsync(t *testing.T) {
+	tests := []struct {
+		name     string
+		behavior testsupport.ToolBehavior
+		want     bool
+	}{
+		{"available", testsupport.ToolBehavior{}, true},
+		{"missing", testsupport.ToolBehavior{ExitCode: 1}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testsupport.FakeTool(t, "wsl.exe", tt.behavior)
+			r := newTestRunner(t, false)
+
+			if got := CheckRsync(context.Background(), r, "Ubuntu"); got != tt.want {
+				t.Errorf("CheckRsync() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallDeps(t *testing.T) {
+	tests := []struct {
+		name     string
+		install  func(context.Context, *runner.Runner, string) error
+		exitCode int
+		wantErr  bool
+	}{
+		{"deps success", InstallDeps, 0, false},
+		{"deps failure", InstallDeps, 1, true},
+		{"runtime success", InstallRuntimeDeps, 0, false},
+		{"runtime failure", InstallRuntimeDeps, 1, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: tt.exitCode})
+			r := newTestRunner(t, false)
+
+			err := tt.install(context.Background(), r, "Ubuntu")
+			if (err != nil) != tt.wantErr {
+				t.Errorf("install() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDistroNames(t *testing.T) {
+	got := distroNames([]DistroInfo{{Name: "Ubuntu"}, {Name: "Debian"}})
+	if got != "Ubuntu, Debian" {
+		t.Errorf("distroNames() = %q, want %q", got, "Ubuntu, Debian")
+	}
+}

--- a/internal/wsl/engine_test.go
+++ b/internal/wsl/engine_test.go
@@ -1,0 +1,102 @@
+package wsl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestBuildEngineVirtioFS(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	result, err := BuildEngine(context.Background(), w, EngineOptions{
+		SourcePath: `C:\ue5`,
+		MaxJobs:    2,
+		WSLNative:  false,
+		Version:    "5.7",
+	})
+	if err != nil {
+		t.Fatalf("BuildEngine() error = %v", err)
+	}
+	if !result.Success {
+		t.Error("BuildEngine() result.Success = false, want true")
+	}
+	if result.EnginePath != "/mnt/c/ue5" {
+		t.Errorf("BuildEngine() EnginePath = %q, want %q", result.EnginePath, "/mnt/c/ue5")
+	}
+}
+
+func TestBuildEngineNativeExpandsHome(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	result, err := BuildEngine(context.Background(), w, EngineOptions{
+		SourcePath: `C:\ue5`,
+		WSLNative:  true,
+		Version:    "5.7",
+	})
+	if err != nil {
+		t.Fatalf("BuildEngine() error = %v", err)
+	}
+	if !strings.Contains(result.EnginePath, "ludus/engine/5.7") {
+		t.Errorf("BuildEngine() EnginePath = %q, want native engine path", result.EnginePath)
+	}
+}
+
+func TestBuildEngineEmptyPath(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	_, err := BuildEngine(context.Background(), w, EngineOptions{
+		SourcePath: "",
+		WSLNative:  false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "engine path is empty") {
+		t.Errorf("BuildEngine() error = %v, want 'engine path is empty'", err)
+	}
+}
+
+func TestBuildEngineResolvePathError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	_, err := BuildEngine(context.Background(), w, EngineOptions{
+		SourcePath: `C:\ue5`,
+		WSLNative:  true,
+		Version:    "5.7",
+	})
+	if err == nil || !strings.Contains(err.Error(), "resolving engine path") {
+		t.Errorf("BuildEngine() error = %v, want 'resolving engine path'", err)
+	}
+}
+
+func TestBuildEngineEnsureDepsError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	_, err := BuildEngine(context.Background(), w, EngineOptions{
+		SourcePath: `C:\ue5`,
+		WSLNative:  false,
+	})
+	if err == nil || !strings.Contains(err.Error(), "ensuring build dependencies") {
+		t.Errorf("BuildEngine() error = %v, want 'ensuring build dependencies'", err)
+	}
+}
+
+func TestRunEngineStepsSuccess(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	if err := runEngineSteps(context.Background(), w, "/mnt/c/ue5", 4); err != nil {
+		t.Errorf("runEngineSteps() error = %v, want nil", err)
+	}
+}
+
+func TestRunEngineStepsSetupFailure(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	err := runEngineSteps(context.Background(), w, "/mnt/c/ue5", 4)
+	if err == nil || !strings.Contains(err.Error(), "Setup.sh failed") {
+		t.Errorf("runEngineSteps() error = %v, want 'Setup.sh failed'", err)
+	}
+}

--- a/internal/wsl/game_exec_test.go
+++ b/internal/wsl/game_exec_test.go
@@ -1,0 +1,68 @@
+package wsl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/ddc"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestBuildGameValidationError(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	_, err := BuildGame(context.Background(), w, GameOptions{})
+	if err == nil || !strings.Contains(err.Error(), "engine path is empty") {
+		t.Errorf("BuildGame() error = %v, want 'engine path is empty'", err)
+	}
+}
+
+func TestBuildGameValidationLocalDDCPathError(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	_, err := BuildGame(context.Background(), w, GameOptions{
+		EnginePath: "/opt/ue/5.7",
+		DDCMode:    ddc.ModeLocal,
+	})
+	if err == nil || !strings.Contains(err.Error(), "DDC path is empty") {
+		t.Errorf("BuildGame() error = %v, want 'DDC path is empty'", err)
+	}
+}
+
+func TestBuildGameSuccess(t *testing.T) {
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, true)}
+
+	result, err := BuildGame(context.Background(), w, GameOptions{
+		EnginePath:  "/opt/ue/5.7",
+		ProjectPath: `C:\proj\MyGame.uproject`,
+		ProjectName: "MyGame",
+		Platform:    "Linux",
+		Arch:        "amd64",
+		DDCMode:     ddc.ModeNone,
+		OutputDir:   `C:\out`,
+	})
+	if err != nil {
+		t.Fatalf("BuildGame() error = %v", err)
+	}
+	if !result.Success {
+		t.Error("BuildGame() result.Success = false, want true")
+	}
+	if result.OutputDir != "/mnt/c/out" {
+		t.Errorf("BuildGame() OutputDir = %q, want /mnt/c/out", result.OutputDir)
+	}
+}
+
+func TestBuildGameRuntimeDepsError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	w := &WSL2{Distro: "Ubuntu", Runner: newTestRunner(t, false)}
+
+	_, err := BuildGame(context.Background(), w, GameOptions{
+		EnginePath:  "/opt/ue/5.7",
+		ProjectPath: `C:\proj\MyGame.uproject`,
+		DDCMode:     ddc.ModeNone,
+	})
+	if err == nil || !strings.Contains(err.Error(), "ensuring runtime dependencies") {
+		t.Errorf("BuildGame() error = %v, want 'ensuring runtime dependencies'", err)
+	}
+}

--- a/internal/wsl/sync_exec_test.go
+++ b/internal/wsl/sync_exec_test.go
@@ -1,0 +1,91 @@
+package wsl
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestSyncEngineSuccess(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  250G"})
+	r := newTestRunner(t, false)
+
+	res, err := SyncEngine(context.Background(), r, "Ubuntu", SyncOptions{
+		SourcePath: `C:\ue5`,
+		Version:    "5.7",
+	})
+	if err != nil {
+		t.Fatalf("SyncEngine() error = %v", err)
+	}
+	if res.WSLPath != "$HOME/ludus/engine/5.7" {
+		t.Errorf("WSLPath = %q, want $HOME/ludus/engine/5.7", res.WSLPath)
+	}
+	if res.DDCPath != NativeDDCDir {
+		t.Errorf("DDCPath = %q, want %q", res.DDCPath, NativeDDCDir)
+	}
+}
+
+func TestSyncEngineDefaultTargetDir(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  250G"})
+	r := newTestRunner(t, false)
+
+	res, err := SyncEngine(context.Background(), r, "Ubuntu", SyncOptions{
+		SourcePath: `C:\ue5`,
+		Version:    "",
+	})
+	if err != nil {
+		t.Fatalf("SyncEngine() error = %v", err)
+	}
+	if res.WSLPath != "$HOME/ludus/engine/default" {
+		t.Errorf("WSLPath = %q, want $HOME/ludus/engine/default", res.WSLPath)
+	}
+}
+
+func TestSyncEngineExplicitTargetDir(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  250G"})
+	r := newTestRunner(t, false)
+
+	res, err := SyncEngine(context.Background(), r, "Ubuntu", SyncOptions{
+		SourcePath: `C:\ue5`,
+		Version:    "5.7",
+		TargetDir:  "/custom/target",
+	})
+	if err != nil {
+		t.Fatalf("SyncEngine() error = %v", err)
+	}
+	if res.WSLPath != "/custom/target" {
+		t.Errorf("WSLPath = %q, want /custom/target", res.WSLPath)
+	}
+}
+
+func TestSyncEngineInsufficientDisk(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  10G"})
+	r := newTestRunner(t, false)
+
+	_, err := SyncEngine(context.Background(), r, "Ubuntu", SyncOptions{SourcePath: `C:\ue5`})
+	if err == nil || !strings.Contains(err.Error(), "insufficient disk space") {
+		t.Errorf("SyncEngine() error = %v, want 'insufficient disk space'", err)
+	}
+}
+
+func TestSyncEngineDiskCheckError(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{ExitCode: 1})
+	r := newTestRunner(t, false)
+
+	_, err := SyncEngine(context.Background(), r, "Ubuntu", SyncOptions{SourcePath: `C:\ue5`})
+	if err == nil || !strings.Contains(err.Error(), "checking disk space") {
+		t.Errorf("SyncEngine() error = %v, want 'checking disk space'", err)
+	}
+}
+
+func TestSyncEngineEmptySource(t *testing.T) {
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{Stdout: "  250G"})
+	r := newTestRunner(t, false)
+
+	_, err := SyncEngine(context.Background(), r, "Ubuntu", SyncOptions{SourcePath: ""})
+	if err == nil || !strings.Contains(err.Error(), "empty source path") {
+		t.Errorf("SyncEngine() error = %v, want 'empty source path'", err)
+	}
+}


### PR DESCRIPTION
Adds hermetic test coverage for Batch 2 packages: internal/wsl (50→96.7%), internal/engine (49.4→87.7%), cmd/engine (78.3→81.5%), cmd/game (76.9→85.5%). Test-only, Go stdlib, table-driven, stubs via testsupport.