### PR TITLE
test: cover awsenv, status, ci, deploy session error paths (Batch 4)

### DIFF
--- a/cmd/ci/ci_test.go
+++ b/cmd/ci/ci_test.go
@@ -176,3 +176,13 @@ func TestResolveRepoFromGitRemote(t *testing.T) {
 		t.Fatalf("resolveRepo() = %q, want example/project", got)
 	}
 }
+
+func TestResolveRepoErrorWhenNoOrigin(t *testing.T) {
+	resetCIGlobals(t)
+	t.Chdir(t.TempDir())
+
+	_, err := resolveRepo(context.Background(), runner.NewRunner(false, false))
+	if err == nil {
+		t.Fatal("expected error when no origin remote is configured")
+	}
+}

--- a/internal/awsenv/resolve_test.go
+++ b/internal/awsenv/resolve_test.go
@@ -38,102 +38,189 @@ func newTestResolver(dryRun bool, region string, id *fakeIdentity) *Resolver {
 }
 
 func TestResolve(t *testing.T) {
-	t.Run("explicit config wins, no STS", func(t *testing.T) {
-		id := &fakeIdentity{account: "999999999999"}
-		r := newTestResolver(false, "", id)
-		cfg := &config.Config{}
-		cfg.AWS.AccountID = "123456789012"
-		cfg.AWS.Region = "us-west-2"
+	tests := []resolveCase{
+		{
+			name:        "explicit config wins, no STS",
+			region:      "us-west-2",
+			cfgAccount:  "123456789012",
+			cfgRegion:   "us-west-2",
+			req:         Requirements{Account: true, Region: true},
+			id:          &fakeIdentity{account: "999999999999"},
+			wantAccount: "123456789012",
+			wantRegion:  "us-west-2",
+		},
+		{
+			name:        "account falls back to STS",
+			region:      "eu-west-1",
+			req:         Requirements{Account: true, Region: true},
+			id:          &fakeIdentity{account: "555555555555"},
+			wantAccount: "555555555555",
+			wantRegion:  "eu-west-1",
+			wantSTSCall: true,
+		},
+		{
+			name:       "region-only requirement skips STS",
+			region:     "us-east-2",
+			req:        Requirements{Region: true},
+			id:         &fakeIdentity{account: "x"},
+			wantRegion: "us-east-2",
+		},
+		{
+			name:        "dry-run returns placeholders without STS",
+			dryRun:      true,
+			req:         Requirements{Account: true, Region: true},
+			id:          &fakeIdentity{err: errors.New("no creds")},
+			wantAccount: PlaceholderAccountID,
+			wantRegion:  placeholderRegion,
+		},
+		{
+			name:    "account unresolved yields field error",
+			region:  "us-west-2",
+			req:     Requirements{Account: true},
+			id:      &fakeIdentity{err: errors.New("no creds")},
+			wantErr: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assertResolveCase(t, tt)
+		})
+	}
+}
 
-		env, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true})
+type resolveCase struct {
+	name        string
+	dryRun      bool
+	region      string
+	cfgAccount  string
+	cfgRegion   string
+	req         Requirements
+	id          *fakeIdentity
+	wantAccount string
+	wantRegion  string
+	wantErr     bool
+	wantSTSCall bool
+}
+
+func assertResolveCase(t *testing.T, tt resolveCase) {
+	t.Helper()
+	r := newTestResolver(tt.dryRun, tt.region, tt.id)
+	cfg := &config.Config{}
+	cfg.AWS.AccountID = tt.cfgAccount
+	cfg.AWS.Region = tt.cfgRegion
+
+	env, err := r.Resolve(context.Background(), cfg, tt.req)
+	if err != nil {
+		if tt.wantErr {
+			return
+		}
+		t.Fatalf("Resolve() unexpected error: %v", err)
+	}
+	if tt.wantErr {
+		t.Fatal("expected error, got nil")
+	}
+	if env.AccountID != tt.wantAccount {
+		t.Errorf("account = %q, want %q", env.AccountID, tt.wantAccount)
+	}
+	if env.Region != tt.wantRegion {
+		t.Errorf("region = %q, want %q", env.Region, tt.wantRegion)
+	}
+	if (tt.id.calls == 0) != (tt.wantSTSCall == false) {
+		t.Errorf("STS called %d times, wantSTSCall=%v", tt.id.calls, tt.wantSTSCall)
+	}
+}
+
+func TestResolve_Memoizes(t *testing.T) {
+	id := &fakeIdentity{account: "111111111111"}
+	r := newTestResolver(false, "us-west-2", id)
+	cfg := &config.Config{}
+
+	for i := 0; i < 3; i++ {
+		if _, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true}); err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+	}
+	if id.calls != 1 {
+		t.Errorf("STS called %d times, want 1", id.calls)
+	}
+}
+
+func TestResolveRegionWrapper(t *testing.T) {
+	id := &fakeIdentity{account: "000"}
+	r := newTestResolver(false, "ap-southeast-1", id)
+	cfg := &config.Config{}
+
+	region, err := r.ResolveRegion(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if region != "ap-southeast-1" {
+		t.Errorf("got region %q, want 'ap-southeast-1'", region)
+	}
+	if id.calls != 0 {
+		t.Errorf("STS called %d times, want 0 (region-only)", id.calls)
+	}
+}
+
+func TestResolveAccountIDWrapper(t *testing.T) {
+	id := &fakeIdentity{account: "222222222222"}
+	r := newTestResolver(false, "us-east-1", id)
+	cfg := &config.Config{}
+
+	account, err := r.ResolveAccountID(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if account != "222222222222" {
+		t.Errorf("got account %q, want '222222222222'", account)
+	}
+}
+
+func TestResolve_LoadConfigError(t *testing.T) {
+	r := newTestResolver(false, "us-west-2", &fakeIdentity{})
+	r.loadConfig = func(_ context.Context, _ string, _ bool) (aws.Config, error) {
+		return aws.Config{}, errors.New("no config")
+	}
+	cfg := &config.Config{}
+
+	_, err := r.Resolve(context.Background(), cfg, Requirements{Region: true})
+	if err == nil {
+		t.Fatal("expected error from failed config load, got nil")
+	}
+}
+
+func TestResolve_EmptyRegionNonDryRun(t *testing.T) {
+	r := newTestResolver(false, "", &fakeIdentity{})
+	cfg := &config.Config{}
+
+	_, err := r.Resolve(context.Background(), cfg, Requirements{Region: true})
+	if err == nil {
+		t.Fatal("expected error for unresolved region without dry-run, got nil")
+	}
+}
+
+func TestAccountID(t *testing.T) {
+	t.Run("returns account", func(t *testing.T) {
+		id, err := AccountID(context.Background(), &fakeIdentity{account: "123456789012"})
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		if env.AccountID != "123456789012" || env.Region != "us-west-2" {
-			t.Errorf("got %+v", env)
-		}
-		if id.calls != 0 {
-			t.Errorf("STS called %d times, want 0", id.calls)
+		if id != "123456789012" {
+			t.Errorf("got %q, want '123456789012'", id)
 		}
 	})
 
-	t.Run("account falls back to STS", func(t *testing.T) {
-		id := &fakeIdentity{account: "555555555555"}
-		r := newTestResolver(false, "eu-west-1", id)
-		cfg := &config.Config{}
-
-		env, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if env.AccountID != "555555555555" {
-			t.Errorf("got account %q", env.AccountID)
-		}
-		if env.Region != "eu-west-1" {
-			t.Errorf("got region %q", env.Region)
-		}
-	})
-
-	t.Run("region-only requirement skips STS", func(t *testing.T) {
-		id := &fakeIdentity{account: "x"}
-		r := newTestResolver(false, "us-east-2", id)
-		cfg := &config.Config{}
-
-		env, err := r.Resolve(context.Background(), cfg, Requirements{Region: true})
-		if err != nil {
-			t.Fatalf("unexpected error: %v", err)
-		}
-		if env.Region != "us-east-2" {
-			t.Errorf("got region %q", env.Region)
-		}
-		if id.calls != 0 {
-			t.Errorf("STS called %d times, want 0", id.calls)
-		}
-	})
-
-	t.Run("dry-run returns placeholders without STS", func(t *testing.T) {
-		id := &fakeIdentity{err: errors.New("no creds")}
-		r := newTestResolver(true, "", id)
-		cfg := &config.Config{}
-
-		env, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true})
-		if err != nil {
-			t.Fatalf("dry-run must not error: %v", err)
-		}
-		if env.AccountID != PlaceholderAccountID {
-			t.Errorf("got account %q, want placeholder", env.AccountID)
-		}
-		if env.Region != placeholderRegion {
-			t.Errorf("got region %q, want placeholder", env.Region)
-		}
-		if id.calls != 0 {
-			t.Errorf("STS called %d times in dry-run, want 0", id.calls)
-		}
-	})
-
-	t.Run("memoizes — STS called at most once", func(t *testing.T) {
-		id := &fakeIdentity{account: "111111111111"}
-		r := newTestResolver(false, "us-west-2", id)
-		cfg := &config.Config{}
-
-		for i := 0; i < 3; i++ {
-			if _, err := r.Resolve(context.Background(), cfg, Requirements{Account: true, Region: true}); err != nil {
-				t.Fatalf("call %d: %v", i, err)
-			}
-		}
-		if id.calls != 1 {
-			t.Errorf("STS called %d times, want 1", id.calls)
-		}
-	})
-
-	t.Run("account unresolved yields field error", func(t *testing.T) {
-		id := &fakeIdentity{err: errors.New("no creds")}
-		r := newTestResolver(false, "us-west-2", id)
-		cfg := &config.Config{}
-
-		_, err := r.Resolve(context.Background(), cfg, Requirements{Account: true})
+	t.Run("surfaces sts error", func(t *testing.T) {
+		_, err := AccountID(context.Background(), &fakeIdentity{err: errors.New("denied")})
 		if err == nil {
-			t.Fatal("expected error, got nil")
+			t.Fatal("expected error from sts, got nil")
+		}
+	})
+
+	t.Run("rejects empty account", func(t *testing.T) {
+		_, err := AccountID(context.Background(), &fakeIdentity{account: "   "})
+		if err == nil {
+			t.Fatal("expected error for empty account ID, got nil")
 		}
 	})
 }

--- a/internal/ci/runner_test.go
+++ b/internal/ci/runner_test.go
@@ -1,9 +1,14 @@
 package ci
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
 )
 
 var parseRepoFromRemoteTests = []struct {
@@ -87,5 +92,35 @@ func TestExpandHome(t *testing.T) {
 				t.Errorf("got %q, want %q", got, want)
 			}
 		})
+	}
+}
+
+func TestDownloadRunnerName(t *testing.T) {
+	dir := t.TempDir()
+	ri := &RunnerInstaller{Runner: runner.NewRunner(false, true)}
+	got, err := ri.downloadRunner(context.Background(), dir, "v2.311.0")
+	if err != nil {
+		t.Fatalf("dry-run download must not error: %v", err)
+	}
+	if want := "actions-runner-linux-x64-2.311.0.tar.gz"; got != want {
+		t.Errorf("tarball = %q, want %q", got, want)
+	}
+}
+
+func TestRunnerInstaller_NonLinuxPlatforms(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("non-linux error paths not exercised on linux")
+	}
+	ri := &RunnerInstaller{Runner: runner.NewRunner(false, false)}
+	ctx := context.Background()
+
+	if err := ri.Install(ctx); err == nil || !strings.Contains(err.Error(), "only supported on Linux") {
+		t.Errorf("Install error = %v, want linux-only message", err)
+	}
+	if _, err := ri.Status(ctx); err == nil || !strings.Contains(err.Error(), "only supported on Linux") {
+		t.Errorf("Status error = %v, want linux-only message", err)
+	}
+	if err := ri.Uninstall(ctx, false); err == nil || !strings.Contains(err.Error(), "only supported on Linux") {
+		t.Errorf("Uninstall error = %v, want linux-only message", err)
 	}
 }

--- a/internal/deploy/session_test.go
+++ b/internal/deploy/session_test.go
@@ -1,6 +1,7 @@
 package deploy
 
 import (
+	"os"
 	"testing"
 	"time"
 
@@ -66,6 +67,39 @@ func TestClearFleetState(t *testing.T) {
 	if got.Session != nil {
 		t.Errorf("session state = %#v after clear, want nil", got.Session)
 	}
+}
+
+// blockStateWrite makes .ludus/state.json unwritable by placing a file where the
+// state directory should be, so Save fails and the warning branch runs.
+func blockStateWrite(t *testing.T) {
+	t.Helper()
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(".ludus", []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupWarnTest chdirs to a temp dir whose state path cannot be written and
+// isolates the profile so the save/clear warning branches run.
+func setupWarnTest(t *testing.T) {
+	t.Helper()
+	previous := state.ActiveProfile()
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile(previous) })
+	blockStateWrite(t)
+}
+
+func TestSaveSessionState_WarnOnWriteFailure(t *testing.T) {
+	setupWarnTest(t)
+
+	SaveSessionState(&SessionInfo{SessionID: "session-123", IPAddress: "192.0.2.10", Port: 7777})
+}
+
+func TestClearFleetState_WarnOnWriteFailure(t *testing.T) {
+	setupWarnTest(t)
+
+	ClearFleetState()
 }
 
 func setupSessionTest(t *testing.T) {

--- a/internal/status/status_gaps_test.go
+++ b/internal/status/status_gaps_test.go
@@ -1,0 +1,83 @@
+package status
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/deploy"
+	"github.com/jpvelasco/ludus/internal/state"
+)
+
+// writeCorruptState drops an unparsable state.json into the cwd's .ludus folder
+// so state.Load() returns an error.
+func writeCorruptState(t *testing.T) {
+	t.Helper()
+	dir := chdirTemp(t)
+	if err := os.MkdirAll(filepath.Join(dir, ".ludus"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".ludus", "state.json"), []byte("{not valid json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestCheckClientBuild_StateReadError(t *testing.T) {
+	writeCorruptState(t)
+
+	s := CheckClientBuild("TestGame")
+	if s.Status != "unknown" || s.Detail != "could not read state" {
+		t.Errorf("got %+v, want unknown/could not read state", s)
+	}
+}
+
+func TestCheckGameSession_StateReadError(t *testing.T) {
+	writeCorruptState(t)
+
+	cfg := &config.Config{Deploy: config.DeployConfig{Target: "gamelift"}}
+	s := CheckGameSession(cfg)
+	if s.Status != "unknown" || s.Detail != "could not read state" {
+		t.Errorf("got %+v, want unknown/could not read state", s)
+	}
+}
+
+func TestCheckGameSession_DetailFormatting(t *testing.T) {
+	dir := chdirTemp(t)
+	writeState(t, dir, &state.State{
+		Session: &state.SessionState{
+			SessionID: "gsess-123",
+			IPAddress: "1.2.3.4",
+			Port:      7777,
+		},
+	})
+
+	cfg := &config.Config{Deploy: config.DeployConfig{Target: "gamelift"}}
+	s := CheckGameSession(cfg)
+	if s.Detail != "gsess-123 (1.2.3.4:7777)" {
+		t.Errorf("detail = %q, want 'gsess-123 (1.2.3.4:7777)'", s.Detail)
+	}
+}
+
+func TestCheckAll_LyraFallbackOutputDir(t *testing.T) {
+	dir := chdirTemp(t)
+	writeState(t, dir, &state.State{})
+	cfg := &config.Config{}
+	cfg.Engine.SourcePath = t.TempDir()
+	cfg.Game.ProjectName = "Lyra"
+
+	stages := CheckAll(context.Background(), cfg, &stubTarget{status: &deploy.DeployStatus{Status: "not_deployed"}})
+	found := false
+	for _, st := range stages {
+		if st.Name == "Lyra Server Build" {
+			found = true
+			if st.Status != "fail" || st.Detail != "not built" {
+				t.Errorf("got %+v, want fail/not built", st)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a 'Lyra Server Build' stage")
+	}
+}


### PR DESCRIPTION
Coverage drive Batch 4.

## Summary
Closes remaining pure-logic gaps in tractable packages:
- **internal/awsenv**: cover \ResolveRegion\/\ResolveAccountID\ wrappers, \loadConfig\ and empty-region error paths, \AccountID\ STS error + empty-account branches. Refactored \TestResolve\ to table-driven to stay under gocyclo 8.
- **internal/status**: cover state-read-error branches in \CheckClientBuild\/\CheckGameSession\, session detail formatting, and the Lyra fallback output-dir branch in \CheckAll\.
- **internal/deploy**: cover the state-write-failure warning branches of \SaveSessionState\/\ClearFleetState\.
- **internal/ci** + **cmd/ci**: cover \downloadRunner\ tarball naming (dry-run), non-Linux error paths, and \esolveRepo\ no-origin error.

## Notes
- E2E-bound surface (docker/podman/wsl/AWS subprocess) left untouched per AGENTS.md.
- Local coverage 79.0% -> 79.2%.
- Touch quality: clean (dedup'd helper extraction, simplify applied).