### PR TITLE
test: cover ddc pruneIfOld walk error and ci runInit write branches (Batch 5)

### DIFF
--- a/cmd/ci/ci_test.go
+++ b/cmd/ci/ci_test.go
@@ -65,6 +65,23 @@ func TestRunInitWritesConfiguredWorkflow(t *testing.T) {
 	}
 }
 
+func TestRunInitWriteWorkflowError(t *testing.T) {
+	resetCIGlobals(t)
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	writeCIFile(t, blocker)
+	outputPath = filepath.Join(blocker, "workflow.yml")
+	globals.Cfg = &config.Config{}
+
+	_, err := captureCIStdout(t, func() error { return runInit(initCmd, nil) })
+	if err == nil {
+		t.Fatal("runInit() should error when the workflow cannot be written")
+	}
+	if !strings.Contains(err.Error(), "creating directory") && !strings.Contains(err.Error(), "workflow") {
+		t.Errorf("error = %v, want it to describe the write failure", err)
+	}
+	outputPath = ""
+}
+
 func TestRunnerResolvers(t *testing.T) {
 	resetCIGlobals(t)
 	globals.Cfg = &config.Config{}
@@ -111,6 +128,13 @@ func TestResolveRepoExplicit(t *testing.T) {
 	}
 	if got != runnerRepo {
 		t.Fatalf("resolveRepo() = %q, want %q", got, runnerRepo)
+	}
+}
+
+func writeCIFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("blocker"), 0644); err != nil {
+		t.Fatal(err)
 	}
 }
 

--- a/internal/ddc/ddc_ops_test.go
+++ b/internal/ddc/ddc_ops_test.go
@@ -1,6 +1,8 @@
 package ddc
 
 import (
+	"errors"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -157,6 +159,99 @@ func TestPrune_InvalidDays(t *testing.T) {
 				t.Errorf("error should mention minimum, got: %v", err)
 			}
 		})
+	}
+}
+
+func TestPruneIfOld_InfoError(t *testing.T) {
+	cutoff := time.Now()
+	for name, tt := range map[string]struct {
+		entry       fakeDirEntry
+		wantErrLike string
+	}{
+		"vanished": {fakeDirEntry{err: fs.ErrNotExist}, ""},
+		"generic":  {fakeDirEntry{err: errors.New("stat failed")}, "stat failed"},
+	} {
+		t.Run(name, func(t *testing.T) {
+			freed := int64(7)
+			err := pruneIfOld("whatever", tt.entry, cutoff, &freed)
+			if tt.wantErrLike == "" {
+				if err != nil {
+					t.Fatalf("pruneIfOld() = %v, want nil for vanished entry", err)
+				}
+			} else if err == nil || !strings.Contains(err.Error(), tt.wantErrLike) {
+				t.Fatalf("pruneIfOld() = %v, want error containing %q", err, tt.wantErrLike)
+			}
+			if freed != 7 {
+				t.Errorf("freed = %d, want unchanged 7", freed)
+			}
+		})
+	}
+}
+
+func TestPruneIfOld_RemoveError(t *testing.T) {
+	cutoff := time.Now().Add(24 * time.Hour)
+	info := oldTestFileInfo(t)
+
+	for name, tt := range map[string]struct {
+		path      string
+		info      fs.FileInfo
+		wantError bool
+	}{
+		"missing": {filepath.Join(t.TempDir(), "gone.bin"), info, false},
+		"invalid": {filepath.Join(t.TempDir(), "\x00"), info, true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			entry := fakeDirEntry{info: tt.info}
+			freed := int64(0)
+			err := pruneIfOld(tt.path, entry, cutoff, &freed)
+			switch {
+			case tt.wantError && err == nil:
+				t.Errorf("pruneIfOld() = nil, want error")
+			case !tt.wantError && err != nil:
+				t.Errorf("pruneIfOld() = %v, want nil", err)
+			}
+			if !tt.wantError && freed != 0 {
+				t.Errorf("freed = %d, want 0", freed)
+			}
+		})
+	}
+}
+
+func oldTestFileInfo(t *testing.T) fs.FileInfo {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "old.bin")
+	writeTestFile(t, path, 16)
+	old := time.Now().Add(-10 * 24 * time.Hour)
+	if err := os.Chtimes(path, old, old); err != nil {
+		t.Fatal(err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return info
+}
+
+type fakeDirEntry struct {
+	info fs.FileInfo
+	err  error
+}
+
+func (f fakeDirEntry) Name() string               { return "entry" }
+func (f fakeDirEntry) IsDir() bool                { return false }
+func (f fakeDirEntry) Type() fs.FileMode          { return 0 }
+func (f fakeDirEntry) Info() (fs.FileInfo, error) { return f.info, f.err }
+
+func TestPrune_NonNotExistWalkError(t *testing.T) {
+	// A directory path containing a NUL byte makes WalkDir fail with a
+	// non-ErrNotExist error, so Prune surfaces the walk failure instead of
+	// treating the path as missing.
+	freed, err := Prune(filepath.Join(t.TempDir(), "\x00"), 7)
+	if err == nil {
+		t.Fatal("Prune() should error for a path WalkDir cannot traverse")
+	}
+	if freed != 0 {
+		t.Errorf("Prune() freed = %d, want 0 on error", freed)
 	}
 }
 


### PR DESCRIPTION
## Summary
Batch C coverage: closes deterministic branch gaps in \internal/ddc\ and \cmd/ci\.

- \internal/ddc\: \pruneIfOld\ (57.1% -> 100%) via a fake \s.DirEntry\ covering the \Info()\ vanish/generic error branches and the \os.Remove\ missing/invalid-path branches; \emoveOldFiles\ -> 100%; ddc package 80.0% -> 86.4% via a \Prune\ NUL-byte walk-error test.
- \cmd/ci\: \unInit\ -> 100% by covering the \WriteWorkflow\ failure branch.

Deferred (not deterministically unit-testable / E2E- or Linux-only, per AGENTS.md): \wsenv.NewResolver\/\defaultLoadConfig\ (real AWS SDK), \	oolchain.checkToolchainLinux\ (Linux CI), \ci\ install/status/uninstall (\os.Hostname\ error + Linux runner installer).

Diff is 100% \*_test.go\ so \codecov/patch\ stays green.

## Validation
- \go build ./...\, \go vet\, \golangci-lint run\ (0 issues), \go test -count=1 ./...\ all pass
- gocyclo 0 on modified test files