### PR TITLE
test: cover buildgraph, buildlog, cache, state, logs error paths (Batch D)

### DIFF
--- a/cmd/buildgraph/buildgraph_errors_test.go
+++ b/cmd/buildgraph/buildgraph_errors_test.go
@@ -1,0 +1,110 @@
+package buildgraph
+
+import (
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/config"
+)
+
+func TestWriteBuildGraph_MkdirAllFails(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "blocker")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeBuildGraph([]byte("<graph/>"), filepath.Join(blocker, "out.xml"), "")
+	if err == nil {
+		t.Fatal("expected error when output dir path is a file")
+	}
+	if !strings.Contains(err.Error(), "creating output directory") {
+		t.Errorf("error = %v, want it to describe the directory failure", err)
+	}
+}
+
+func TestWriteBuildGraph_WriteFileFails(t *testing.T) {
+	// Put a directory at the target path; writing to a directory path fails.
+	dir := t.TempDir()
+	outPath := filepath.Join(dir, "out.xml")
+	if err := os.Mkdir(outPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := writeBuildGraph([]byte("<graph/>"), outPath, "")
+	if err == nil {
+		t.Fatal("expected error when output path is a directory")
+	}
+	if !strings.Contains(err.Error(), "writing") {
+		t.Errorf("error = %v, want it to describe the write failure", err)
+	}
+}
+
+func TestRunBuildGraph_ToStdout(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Engine.SourcePath = "/opt/unreal-engine"
+	cfg.Game.ProjectPath = "/opt/unreal-engine/Samples/Games/Lyra/Lyra.uproject"
+	globals.SetGlobals(t, cfg)
+	toStdout = true
+	t.Cleanup(func() { toStdout = false })
+
+	output, err := captureStdout(t, func() error { return runBuildGraph(nil, nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "Engine") {
+		t.Errorf("stdout missing Engine agent, got: %q", output)
+	}
+}
+
+func TestRunBuildGraph_WritesFile(t *testing.T) {
+	cfg := config.Defaults()
+	cfg.Engine.SourcePath = "/opt/unreal-engine"
+	cfg.Game.ProjectPath = filepath.Join(t.TempDir(), "MyGame", "MyGame.uproject")
+	globals.SetGlobals(t, cfg)
+	toStdout = false
+
+	if err := runBuildGraph(nil, nil); err != nil {
+		t.Fatalf("runBuildGraph() error = %v", err)
+	}
+	// Default output resolves under the project dir.
+	got, err := os.ReadFile(filepath.Join(filepath.Dir(cfg.Game.ProjectPath), "Build", "BuildGraph.xml"))
+	if err != nil {
+		t.Fatalf("expected BuildGraph.xml to be written: %v", err)
+	}
+	if !strings.Contains(string(got), "Engine") {
+		t.Errorf("file missing Engine agent, got: %q", got)
+	}
+}
+
+func TestRunBuildGraph_ValidationError(t *testing.T) {
+	globals.SetGlobals(t, config.Defaults())
+
+	if err := runBuildGraph(nil, nil); err == nil {
+		t.Fatal("expected validation error when engine source path is empty")
+	}
+}
+
+func captureStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	previous := os.Stdout
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = writer
+	runErr := run()
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	os.Stdout = previous
+	t.Cleanup(func() { os.Stdout = previous })
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data), runErr
+}

--- a/cmd/logs/logs_test.go
+++ b/cmd/logs/logs_test.go
@@ -53,6 +53,17 @@ func TestLogFilesMissingDirectoryIsEmpty(t *testing.T) {
 	}
 }
 
+func TestLogFiles_ReadDirError(t *testing.T) {
+	// A directory path containing a NUL byte makes ReadDir fail with a
+	// non-IsNotExist error, which logFiles surfaces.
+	dir := filepath.Join(t.TempDir(), "\x00")
+	setLogsConfig(t, dir)
+
+	if _, _, err := logFiles(); err == nil {
+		t.Fatal("expected error when logs dir cannot be read")
+	}
+}
+
 func TestLogCommands(t *testing.T) {
 	dir := t.TempDir()
 	setLogsConfig(t, dir)

--- a/internal/buildgraph/generator_test.go
+++ b/internal/buildgraph/generator_test.go
@@ -185,3 +185,19 @@ func TestGenerate_MissingProjectPath(t *testing.T) {
 		t.Errorf("error should mention project path, got: %v", err)
 	}
 }
+
+func TestDefaultMaxJobs(t *testing.T) {
+	tt := []struct {
+		in   int
+		want int
+	}{
+		{0, 4},
+		{8, 8},
+		{2, 2},
+	}
+	for _, tc := range tt {
+		if got := defaultMaxJobs(tc.in); got != tc.want {
+			t.Errorf("defaultMaxJobs(%d) = %d, want %d", tc.in, got, tc.want)
+		}
+	}
+}

--- a/internal/buildlog/buildlog_test.go
+++ b/internal/buildlog/buildlog_test.go
@@ -114,7 +114,7 @@ func TestSection_NilReceiverIsNoop(t *testing.T) {
 }
 
 func TestNew_MkdirAllFails(t *testing.T) {
-	blocker := t.TempDir() + `\blocker`
+	blocker := filepath.Join(t.TempDir(), "blocker")
 	if err := os.WriteFile(blocker, []byte("file"), 0o644); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/buildlog/buildlog_test.go
+++ b/internal/buildlog/buildlog_test.go
@@ -99,6 +99,35 @@ func TestNew_DoesNotClobberSameSecond(t *testing.T) {
 	}
 }
 
+func TestSection_NilReceiverIsNoop(t *testing.T) {
+	var lg *Logger
+	lg.Section("never written") // must not panic
+	if err := lg.Close(); err != nil {
+		t.Errorf("Close() on nil logger = %v, want nil", err)
+	}
+
+	empty := &Logger{}
+	empty.Section("never written")
+	if err := empty.Close(); err != nil {
+		t.Errorf("Close() on empty logger = %v, want nil", err)
+	}
+}
+
+func TestNew_MkdirAllFails(t *testing.T) {
+	blocker := t.TempDir() + `\blocker`
+	if err := os.WriteFile(blocker, []byte("file"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := New(filepath.Join(blocker, "logs"), "run", testTime())
+	if err == nil {
+		t.Fatal("expected error when log dir path is a file")
+	}
+	if !strings.Contains(err.Error(), "creating log dir") {
+		t.Errorf("error = %v, want it to describe the dir failure", err)
+	}
+}
+
 func TestSection_WritesHeader(t *testing.T) {
 	dir := t.TempDir()
 	lg, err := New(dir, "run", testTime())

--- a/internal/buildlog/retention_test.go
+++ b/internal/buildlog/retention_test.go
@@ -107,3 +107,30 @@ func TestPrune_MissingDirIsNoError(t *testing.T) {
 		t.Errorf("Prune() on missing dir should be nil, got: %v", err)
 	}
 }
+
+func TestPrune_KeepZeroOrNegativeNoop(t *testing.T) {
+	dir := t.TempDir()
+	names := writeLogFiles(t, dir, 3)
+
+	for _, keep := range []int{0, -5} {
+		if err := Prune(dir, keep); err != nil {
+			t.Errorf("Prune(dir, %d) = %v, want nil", keep, err)
+		}
+		if got := countLogs(t, dir); got != 3 {
+			t.Errorf("after Prune(keep=%d) got %d logs, want 3 (untouched)", keep, got)
+		}
+	}
+	// Sanity: files still present.
+	if _, err := os.Stat(names[0]); err != nil {
+		t.Errorf("expected files untouched after keep<=0, got: %v", err)
+	}
+}
+
+func TestPrune_CollectError(t *testing.T) {
+	// A directory path containing a NUL byte makes ReadDir fail with a
+	// non-IsNotExist error, which Prune surfaces.
+	blocker := filepath.Join(t.TempDir(), "\x00")
+	if err := Prune(blocker, 5); err == nil {
+		t.Fatal("expected error when the dir path cannot be read")
+	}
+}

--- a/internal/cache/cache_errors_test.go
+++ b/internal/cache/cache_errors_test.go
@@ -20,6 +20,24 @@ func TestSave_MkdirAllFails(t *testing.T) {
 	}
 }
 
+// TestSave_WriteFileFails covers the WriteFile error branch: .ludus exists as a
+// directory but cache.json is occupied by a directory, so writing fails.
+func TestSave_WriteFileFails(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	if err := os.MkdirAll(cacheDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(cachePath(), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	c := &Cache{Entries: make(map[StageKey]*Entry)}
+	if err := Save(c); err == nil {
+		t.Fatal("expected error when cache.json path is occupied by a directory")
+	}
+}
+
 // TestRecordBuild_LoadFailsIsNoop verifies that RecordBuild silently no-ops
 // (does not panic, does not write) when the existing cache.json is corrupted.
 func TestRecordBuild_LoadFailsIsNoop(t *testing.T) {

--- a/internal/cache/cache_keys_test.go
+++ b/internal/cache/cache_keys_test.go
@@ -8,6 +8,70 @@ import (
 	"github.com/jpvelasco/ludus/internal/config"
 )
 
+func TestGameServerKey_LyraDefaultProjectPath(t *testing.T) {
+	engineDir := t.TempDir()
+	lyraPath := filepath.Join(engineDir, "Samples", "Games", "Lyra", "Lyra.uproject")
+	if err := os.MkdirAll(filepath.Dir(lyraPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lyraPath, []byte(`{"FileVersion": 3}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{SourcePath: engineDir, Version: "5.7.3"},
+		Game: config.GameConfig{
+			ProjectName:  "Lyra",
+			ServerTarget: "LyraServer",
+			GameTarget:   "Lyra",
+			ServerMap:    "/Game/Maps/TestMap",
+			Arch:         "amd64",
+		},
+	}
+
+	key := GameServerKey(cfg, "engine-hash")
+	if key == "" {
+		t.Fatal("GameServerKey with Lyra default project path should be non-empty")
+	}
+
+	// Changing the engine source path must change the key (the Lyra default
+	// project path is derived from it, and now points at a missing file).
+	cfg.Engine.SourcePath = filepath.Join(t.TempDir(), "different")
+	if changed := GameServerKey(cfg, "engine-hash"); changed == key {
+		t.Error("GameServerKey should differ when the derived Lyra path changes")
+	}
+}
+
+func TestGameClientKey_LyraDefaultProjectPath(t *testing.T) {
+	engineDir := t.TempDir()
+	lyraPath := filepath.Join(engineDir, "Samples", "Games", "Lyra", "Lyra.uproject")
+	if err := os.MkdirAll(filepath.Dir(lyraPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(lyraPath, []byte(`{"FileVersion": 3}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{SourcePath: engineDir, Version: "5.7.3"},
+		Game: config.GameConfig{
+			ProjectName:  "Lyra",
+			ClientTarget: "LyraClient",
+			ServerMap:    "/Game/Maps/TestMap",
+			Arch:         "amd64",
+		},
+	}
+
+	key := GameClientKey(cfg, "engine-hash", "Windows")
+	if key == "" {
+		t.Fatal("GameClientKey with Lyra default empty path should be non-empty")
+	}
+	cfg.Engine.SourcePath = filepath.Join(t.TempDir(), "different")
+	if changed := GameClientKey(cfg, "engine-hash", "Windows"); changed == key {
+		t.Error("GameClientKey should change when the derived Lyra path changes")
+	}
+}
+
 func TestEngineKey_Deterministic(t *testing.T) {
 	cfg := &config.Config{
 		Engine: config.EngineConfig{

--- a/internal/state/state_io_test.go
+++ b/internal/state/state_io_test.go
@@ -82,3 +82,62 @@ func TestLoadEmptyJSON(t *testing.T) {
 		t.Error("expected all nil fields for empty JSON state")
 	}
 }
+
+func TestSave_MkdirAllFails(t *testing.T) {
+	setupTest(t)
+
+	if err := os.WriteFile(stateDir, []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Save(&State{}); err == nil {
+		t.Fatal("expected error when stateDir path is occupied by a file")
+	}
+}
+
+func TestSave_WriteFileFails(t *testing.T) {
+	setupTest(t)
+
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Mkdir(filepath.Join(stateDir, stateFile), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Save(&State{}); err == nil {
+		t.Fatal("expected error when state.json path is occupied by a directory")
+	}
+}
+
+func TestListProfiles_SortedSkipsDirectories(t *testing.T) {
+	setupTest(t)
+
+	profilesDir := filepath.Join(stateDir, "profiles")
+	for _, name := range []string{"qa.json", "staging.json", "ignored-dir"} {
+		p := filepath.Join(profilesDir, name)
+		var err error
+		if name == "ignored-dir" {
+			err = os.MkdirAll(p, 0755)
+		} else {
+			if mkErr := os.MkdirAll(filepath.Dir(p), 0755); mkErr != nil {
+				t.Fatal(mkErr)
+			}
+			err = os.WriteFile(p, []byte("{}"), 0644)
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	got := mustListProfiles(t)
+	want := []string{"qa", "staging"}
+	if len(got) != len(want) {
+		t.Fatalf("ListProfiles = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("ListProfiles[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
Raises full-suite coverage 79.5% -> 79.8% by covering error/edge branches:

- \cmd/buildgraph\: \unBuildGraph\ (0% -> 92.3%), \writeBuildGraph\ (->100%)
- \internal/buildlog\: \Section\/\Close\ nil-guard ->100%, \New\/\Prune\ error branches (80% -> 93.9%)
- \internal/cache\: \GameServerKey\/\GameClientKey\ Lyra branch ->100%, \Save\ WriteFile error (96.2%)
- \internal/state\: \Save\ MkdirAll/WriteFile errors (97.2%)
- \internal/buildgraph\: \defaultMaxJobs\ ->100%
- \cmd/logs\: \logFiles\ ->100%

Diff is 100% \*_test.go\. Deferred per AGENTS.md: pure-E2E/AWS/Linux branches (gitHEAD exec, container deploy, resolve target errors, New/Marshal unreachable error branches).