### PR TITLE
test: cover awsutil operation errors and dockerbuild/game error branches (Batch E)

### DIFF
--- a/internal/awsutil/errors_test.go
+++ b/internal/awsutil/errors_test.go
@@ -35,6 +35,9 @@ func TestIsNotFound(t *testing.T) {
 		{"NotFound", &testAPIError{code: "NotFound"}, true},
 		{"unrelated API error", &testAPIError{code: "ValidationException"}, false},
 		{"wrapped not-found", fmt.Errorf("operation failed: %w", &testAPIError{code: "NotFoundException"}), true},
+		{"operation error wraps 404", &smithy.OperationError{ServiceID: "S3", OperationName: "HeadBucket", Err: errors.New("404")}, false},
+		{"operation error with not found code", &smithy.OperationError{ServiceID: "S3", OperationName: "GetObject", Err: errors.New("NotFound")}, false},
+		{"wrapped operation error", fmt.Errorf("list failed: %w", &smithy.OperationError{ServiceID: "S3", OperationName: "ListBuckets", Err: errors.New("boom")}), false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/internal/dockerbuild/engine_test.go
+++ b/internal/dockerbuild/engine_test.go
@@ -151,6 +151,30 @@ func TestBuild_SkipEngine_EmptyBinaries(t *testing.T) {
 	}
 }
 
+func TestValidateSkipEngine_ReadDirError(t *testing.T) {
+	// A path containing a NUL byte makes ReadDir fail with a non-IsNotExist
+	// error, which validateSkipEngine surfaces as a read failure.
+	sourcePath := filepath.Join(t.TempDir(), "\x00")
+	if err := validateSkipEngine(sourcePath); err == nil {
+		t.Fatal("expected error when binaries dir cannot be read")
+	}
+}
+
+func TestValidateSkipEngine_Present(t *testing.T) {
+	tmpDir := t.TempDir()
+	binDir := filepath.Join(tmpDir, "Engine", "Binaries", "Linux")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "UnrealServer"), []byte("binary"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := validateSkipEngine(tmpDir); err != nil {
+		t.Errorf("validateSkipEngine() error = %v, want nil", err)
+	}
+}
+
 func TestEngineImageOptions_PlatformArg(t *testing.T) {
 	tests := []struct {
 		arch string

--- a/internal/dockerbuild/macos_preflight_test.go
+++ b/internal/dockerbuild/macos_preflight_test.go
@@ -55,6 +55,24 @@ func TestMacOSPreflightOptions_PlatformString(t *testing.T) {
 	}
 }
 
+func TestMacOSPreflightOptions_BaseImage(t *testing.T) {
+	tests := []struct {
+		name      string
+		opts      MacOSPreflightOptions
+		wantImage string
+	}{
+		{"defaults to ubuntu", MacOSPreflightOptions{}, "ubuntu:22.04"},
+		{"explicit override", MacOSPreflightOptions{BaseImage: "amazonlinux:2023"}, "amazonlinux:2023"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.opts.baseImage(); got != tt.wantImage {
+				t.Errorf("baseImage() = %q, want %q", got, tt.wantImage)
+			}
+		})
+	}
+}
+
 func TestRunLinuxToolchainBootstrap_DryRun(t *testing.T) {
 	root := t.TempDir()
 	r := runner.NewRunner(false, true) // dry-run — command printed, not executed

--- a/internal/game/workarounds_windows_test.go
+++ b/internal/game/workarounds_windows_test.go
@@ -30,3 +30,23 @@ func TestDisableDumpSymsMissingConfig(t *testing.T) {
 	t.Setenv("APPDATA", t.TempDir())
 	newTestBuilder(BuildOptions{}).disableDumpSyms()()
 }
+
+func TestRestoreFileWriteError(t *testing.T) {
+	// restoreFile's closure surfaces (logs) a WriteFile failure without panicking.
+	path := filepath.Join(t.TempDir(), "missing-dir", "config.xml")
+	restore := restoreFile(path, []byte("original"))
+	restore()
+}
+
+func TestDisableDumpSymsInConfigWriteError(t *testing.T) {
+	// Put a directory at the config path: patch content differs from the
+	// original, so WriteFile is attempted and fails against the directory.
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.xml")
+	if err := os.Mkdir(configPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	restore := newTestBuilder(BuildOptions{}).disableDumpSymsInConfig(configPath, []byte("<Configuration>\n</Configuration>\n"))
+	restore()
+}


### PR DESCRIPTION
Raises full-suite coverage 79.8% to 79.9% by covering error/edge branches:

- internal/awsutil: IsNotFound OperationError block (63.6% to 90.9%; the errStr=="" unwrap path is unreachable because smithy.OperationError.Error() never returns empty)
- internal/dockerbuild: validateSkipEngine non-IsNotExist ReadDir error + present path (77.8% to 100%), baseImage explicit override (66.7% to 100%)
- internal/game: restoreFile and disableDumpSymsInConfig WriteFile error branches (to 100%)

Diff is 100% *_test.go. Deferred per AGENTS.md: AWS/Docker/exec-bound surfaces (checkDocker/checkPodman, CheckContainerImage, resolveDiskSpace branches), Linux/Windows/macOS-gated paths (maybeRunMacOSPreflights, checkAppleSiliconContainer, internal/ci Install/Status/Uninstall bodies).
