### PR TITLE
test: Batch F coverage to 80%

### DIFF
--- a/cmd/configcmd/configcmd_test.go
+++ b/cmd/configcmd/configcmd_test.go
@@ -106,3 +106,32 @@ func TestRunGet_NoConfigFile(t *testing.T) {
 		t.Error("expected error when ludus.yaml absent")
 	}
 }
+
+func TestRunSet_UnreadableConfig(t *testing.T) {
+	t.Chdir(t.TempDir())
+	orig := globals.Profile
+	t.Cleanup(func() { globals.Profile = orig })
+	globals.Profile = ""
+
+	// A malformed YAML file makes ReadInConfig fail with a non-not-found error.
+	if err := os.WriteFile("ludus.yaml", []byte(": not: valid {yaml"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runSet(nil, []string{"engine.version", "5.7.3"}); err == nil {
+		t.Error("expected error reading malformed config")
+	}
+}
+
+func TestRunGet_UnreadableConfig(t *testing.T) {
+	t.Chdir(t.TempDir())
+	orig := globals.Profile
+	t.Cleanup(func() { globals.Profile = orig })
+	globals.Profile = ""
+
+	if err := os.WriteFile("ludus.yaml", []byte("[unclosed"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := runGet(nil, []string{"engine.version"}); err == nil {
+		t.Error("expected error reading malformed config")
+	}
+}

--- a/internal/config/config_load_test.go
+++ b/internal/config/config_load_test.go
@@ -1,9 +1,12 @@
 package config
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/spf13/viper"
 )
 
 func TestLoad_MissingFile(t *testing.T) {
@@ -219,5 +222,21 @@ func TestLoad_DDCConfig(t *testing.T) {
 	}
 	if cfg.DDC.LocalPath != "/custom/ddc" {
 		t.Errorf("ddc localPath: got %q, want %q", cfg.DDC.LocalPath, "/custom/ddc")
+	}
+}
+
+func TestHandleReadError_ConfigFileNotFound(t *testing.T) {
+	cfg, err := handleReadError(&Config{}, viper.ConfigFileNotFoundError{})
+	if err != nil {
+		t.Fatalf("ConfigFileNotFoundError should be swallowed: %v", err)
+	}
+	if cfg == nil {
+		t.Fatal("expected non-nil config on not-found")
+	}
+}
+
+func TestHandleReadError_RealError(t *testing.T) {
+	if _, err := handleReadError(&Config{}, errors.New("boom")); err == nil {
+		t.Fatal("expected real errors to be wrapped")
 	}
 }

--- a/internal/ddc/ddc_size_test.go
+++ b/internal/ddc/ddc_size_test.go
@@ -1,6 +1,7 @@
 package ddc
 
 import (
+	"errors"
 	"path/filepath"
 	"testing"
 )
@@ -78,5 +79,21 @@ func TestDirSize_FileRoot(t *testing.T) {
 	}
 	if size != 4096 {
 		t.Errorf("DirSize(file) = %d, want 4096", size)
+	}
+}
+
+func TestDirSize_WalkError(t *testing.T) {
+	// A path containing a NUL byte makes WalkDir fail with a non-ErrNotExist
+	// error, which DirSize surfaces instead of treating the path as missing.
+	_, err := DirSize(filepath.Join(t.TempDir(), "\x00"))
+	if err == nil {
+		t.Fatal("expected error when the path cannot be walked")
+	}
+}
+
+func TestEntrySize_InfoError(t *testing.T) {
+	got := entrySize("ignored", fakeDirEntry{err: errors.New("stat failed")})
+	if got != 0 {
+		t.Errorf("entrySize() = %d, want 0 when Info fails", got)
 	}
 }

--- a/internal/progress/progress_test.go
+++ b/internal/progress/progress_test.go
@@ -22,6 +22,14 @@ func TestStartStop(t *testing.T) {
 	}
 }
 
+func TestTickerFires(t *testing.T) {
+	// Sleep past several intervals so the ticker goroutine runs its printing
+	// branch at least once; this exercises the elapsed-time message path.
+	ticker := Start("test operation", time.Millisecond)
+	time.Sleep(5 * time.Millisecond)
+	ticker.Stop()
+}
+
 func TestStopBlocksUntilDone(t *testing.T) {
 	ticker := Start("test operation", 10*time.Millisecond)
 


### PR DESCRIPTION
## What

Batch F coverage pass (test-only): 79.8% -> 80.0%.

- cmd/configcmd: exercise runSet/runGet non-not-found config read branches via malformed YAML (configcmd.go:79-80, 111).
- internal/config: cover handleReadError viper ConfigFileNotFoundError and wrapped-error branches (config.go:42-48).
- internal/ddc: cover DirSize NUL-byte walk error and entrySize Info-error branch (size.go:22, 48).
- internal/progress: let the ticker fire at least once to cover the elapsed-time print branch (progress.go:34-36).

All files are *_test.go; no production code touched. Codecov patch gate satisfied (diff is 100% test files).