### PR TITLE
test: Batch G coverage to 80.2%

### DIFF
--- a/cmd/pipeline/stages_state_test.go
+++ b/cmd/pipeline/stages_state_test.go
@@ -1,0 +1,49 @@
+package pipeline
+
+import (
+	"os"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/deploy"
+	"github.com/jpvelasco/ludus/internal/game"
+	"github.com/jpvelasco/ludus/internal/state"
+)
+
+// blockStateWrites replaces the .ludus directory with a file so every
+// state.Save fails at MkdirAll, forcing the save*State warning branches.
+func blockStateWrites(t *testing.T) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	orig := state.ActiveProfile()
+	t.Cleanup(func() { state.SetProfile(orig) })
+	state.SetProfile("")
+	if err := os.WriteFile(".ludus", []byte("not a directory"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSaveDeployState_WriteFails(t *testing.T) {
+	blockStateWrites(t)
+	p := &pipelineCtx{}
+	p.saveDeployState(&deploy.DeployResult{
+		TargetName: "binary",
+		Status:     "exported",
+		Detail:     "/tmp/out",
+	})
+}
+
+func TestSaveEngineImageState_WriteFails(t *testing.T) {
+	blockStateWrites(t)
+	p := &pipelineCtx{}
+	p.saveEngineImageState("v26")
+}
+
+func TestSaveClientState_WriteFails(t *testing.T) {
+	blockStateWrites(t)
+	p := &pipelineCtx{}
+	p.saveClientState(&game.ClientBuildResult{
+		ClientBinary: "/tmp/client",
+		OutputDir:    "/tmp/out",
+		Platform:     "windows",
+	})
+}

--- a/internal/awsenv/resolve_test.go
+++ b/internal/awsenv/resolve_test.go
@@ -224,3 +224,27 @@ func TestAccountID(t *testing.T) {
 		}
 	})
 }
+
+func TestNewResolver_DefaultWiring(t *testing.T) {
+	// The real resolver's default closures must be wired: loadConfig resolves
+	// a region from the SDK chain, and newIdentityClient builds an STS client.
+	r := NewResolver(true)
+	if r.loadConfig == nil {
+		t.Fatal("NewResolver left loadConfig nil")
+	}
+	if r.newIdentityClient == nil {
+		t.Fatal("NewResolver left newIdentityClient nil")
+	}
+
+	cfg, err := r.loadConfig(context.Background(), "us-east-1", false)
+	if err != nil {
+		t.Fatalf("defaultLoadConfig failed: %v", err)
+	}
+	if cfg.Region != "us-east-1" {
+		t.Errorf("loadConfig region = %q, want 'us-east-1'", cfg.Region)
+	}
+
+	if id := r.newIdentityClient(cfg); id == nil {
+		t.Fatal("newIdentityClient returned nil STS client")
+	}
+}

--- a/internal/binary/exporter_test.go
+++ b/internal/binary/exporter_test.go
@@ -186,3 +186,41 @@ func TestDeploy_FileUsedAsBuildDir(t *testing.T) {
 		t.Fatal("expected error when ServerBuildDir is a file (copyWalk fails)")
 	}
 }
+
+func TestDeploy_MkdirAllError(t *testing.T) {
+	// A file in place of an ancestor dir makes os.MkdirAll fail with ENOTDIR.
+	srcDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(srcDir, "server.exe"), []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	blocker := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	e := NewExporter(filepath.Join(blocker, "sub"))
+	_, err := e.Deploy(context.Background(), deploy.DeployInput{ServerBuildDir: srcDir})
+	if err == nil {
+		t.Fatal("expected error when output parent is a file")
+	}
+}
+
+func TestStatus_ReadDirError(t *testing.T) {
+	// A NUL byte in the path makes os.ReadDir fail with a non-IsNotExist error.
+	// On Windows filepath.Abs rejects it first; either way the error status branch runs.
+	e := NewExporter(filepath.Join(t.TempDir(), "out\x00nul"))
+	s, err := e.Status(context.Background())
+	if err != nil {
+		t.Fatalf("status failed: %v", err)
+	}
+	if s.Status != "error" {
+		t.Errorf("expected status 'error', got %q", s.Status)
+	}
+}
+
+func TestDestroy_RemoveAllError(t *testing.T) {
+	// A NUL byte in the path makes os.RemoveAll fail (or filepath.Abs on Windows).
+	e := NewExporter(filepath.Join(t.TempDir(), "out\x00nul"))
+	if err := e.Destroy(context.Background()); err == nil {
+		t.Fatal("expected error removing a path with a NUL byte")
+	}
+}

--- a/internal/cleanup/cleanup_ecr_test.go
+++ b/internal/cleanup/cleanup_ecr_test.go
@@ -40,6 +40,18 @@ func (m *mockECRClient) DeleteRepository(ctx context.Context, params *ecr.Delete
 	return &ecr.DeleteRepositoryOutput{}, nil
 }
 
+func TestNewCleaner(t *testing.T) {
+	// Constructing a Cleaner from a zero config only builds clients — no AWS
+	// calls happen until a method is invoked.
+	c := NewCleaner(aws.Config{})
+	if c == nil {
+		t.Fatal("NewCleaner returned nil")
+	}
+	if c.ecr == nil || c.s3 == nil {
+		t.Error("NewCleaner left ecr/s3 clients nil")
+	}
+}
+
 var deleteECRRepositoryTests = []struct {
 	name    string
 	mock    *mockECRClient

--- a/internal/dflint/lint_env_test.go
+++ b/internal/dflint/lint_env_test.go
@@ -22,6 +22,7 @@ func TestCheckSensitiveEnv_WithSecrets(t *testing.T) {
 		{"secret", "ENV API_SECRET=abc"},
 		{"token", "ENV AUTH_TOKEN=xyz"},
 		{"key", "ENV AWS_SECRET_KEY=foo"},
+		{"key without separator", "ENV SECRET"},
 	}
 
 	for _, tt := range tests {

--- a/internal/prereq/checker_go_test.go
+++ b/internal/prereq/checker_go_test.go
@@ -1,6 +1,7 @@
 package prereq
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -73,5 +74,18 @@ func TestCheckGoVersion_ContainerBackendChecks(t *testing.T) {
 		if !result.Passed {
 			t.Errorf("backend %q: expected pass on this host, got fail: %s", be, result.Message)
 		}
+	}
+}
+
+func TestCheckGoVersion_GoNotFound(t *testing.T) {
+	// Empty PATH makes exec.LookPath("go") fail, exercising the not-found branch.
+	t.Setenv("PATH", "")
+	c := &Checker{Backend: "docker"}
+	result := c.checkGoVersion()
+	if result.Passed {
+		t.Error("expected fail when go is not on PATH")
+	}
+	if !strings.Contains(result.Message, "go not found in PATH") {
+		t.Errorf("unexpected message: %q", result.Message)
 	}
 }

--- a/internal/prereq/checker_logic_test.go
+++ b/internal/prereq/checker_logic_test.go
@@ -196,6 +196,36 @@ func TestCheckToolchain_UnknownVersionWarns(t *testing.T) {
 	}
 }
 
+func TestCheckToolchain_Found(t *testing.T) {
+	// A LINUX_MULTIARCH_ROOT containing the v26 toolchain dir makes the
+	// cross-compile check find it, exercising the Found branch.
+	root := t.TempDir()
+	toolchainDir := filepath.Join(root, "v26_clang-20.1.8-rockylinux8")
+	if err := os.MkdirAll(toolchainDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LINUX_MULTIARCH_ROOT", root)
+
+	c := &Checker{EngineSourcePath: t.TempDir(), EngineVersion: "5.7.3"}
+	res := c.checkToolchain()
+	if !res.Passed {
+		t.Errorf("expected pass with toolchain found, got %+v", res)
+	}
+	if !strings.Contains(res.Message, "found") {
+		t.Errorf("unexpected message: %q", res.Message)
+	}
+}
+
+func TestCheckCommand_NotFound(t *testing.T) {
+	res := (&Checker{}).checkCommand("ludus-definitely-not-installed", "X")
+	if res.Passed {
+		t.Error("expected fail for a command not on PATH")
+	}
+	if !strings.Contains(res.Message, "not found in PATH") {
+		t.Errorf("unexpected message: %q", res.Message)
+	}
+}
+
 // --- checkEngineSource ------------------------------------------------------
 
 func TestCheckEngineSource(t *testing.T) {

--- a/internal/prereq/checker_msvc_test.go
+++ b/internal/prereq/checker_msvc_test.go
@@ -21,6 +21,7 @@ func TestNeedsNewerMSVC(t *testing.T) {
 		{"5.8.0", true},
 		{"", false},
 		{"garbage", false},
+		{"5.abc", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.configVersion, func(t *testing.T) {


### PR DESCRIPTION
## What

Batch G coverage pass (test-only): 80.0% -> 80.2%.

- internal/binary: force Deploy MkdirAll error, Status ReadDir error, Destroy RemoveAll error via NUL-byte/file-blocker paths (exporter.go:50, 67/84, 157/161).
- internal/prereq: checkGoVersion go-not-found via empty PATH (checker_go.go:55,74); checkCommand not-found (checker.go:248); checkToolchain Found branch via LINUX_MULTIARCH_ROOT fixture (checker.go:331); needsNewerMSVC non-numeric minor (checker_msvc.go:188).
- internal/dflint: checkSensitiveEnv key-without-separator branch (checks.go:141).
- internal/awsenv: NewResolver default loadConfig/newIdentityClient wiring (resolve.go:55,59).
- internal/cleanup: NewCleaner construction (cleanup.go:37).
- cmd/pipeline: saveDeployState/saveEngineImageState/saveClientState write-failure branches via .ludus-as-file (stages_deploy.go:141, stages_engine.go:83, stages_game.go:123).

All files are *_test.go; no production code touched. Codecov patch gate satisfied (diff is 100% test files).