### PR TITLE
test: Batch H coverage to 80.3%

### DIFF
--- a/internal/config/client_binary_test.go
+++ b/internal/config/client_binary_test.go
@@ -39,6 +39,22 @@ func TestDiscoverClientBinary_LinuxFindsRealTarget(t *testing.T) {
 	}
 }
 
+func TestDiscoverClientBinary_SkipsDirectories(t *testing.T) {
+	// A subdirectory named like a candidate (no dot) must be skipped; only the
+	// real executable file matches.
+	dir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(dir, "LyraGame"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFiles(t, dir, "LyraGame.sym", "LyraGame.debug")
+
+	fallback := filepath.Join(dir, "LyraStarterGameGame")
+	got := DiscoverClientBinary(dir, fallback, false)
+	if got != fallback {
+		t.Errorf("DiscoverClientBinary() = %q, want fallback %q (dir skipped)", got, fallback)
+	}
+}
+
 func TestDiscoverClientBinary_WindowsPrefersExe(t *testing.T) {
 	dir := t.TempDir()
 	writeFiles(t, dir, "LyraGame.exe", "LyraGame.pdb")

--- a/internal/dockerbuild/engine_test.go
+++ b/internal/dockerbuild/engine_test.go
@@ -265,19 +265,22 @@ func TestBuild_ForcesAmd64Platform(t *testing.T) {
 	}
 }
 
-func TestBuild_PrunesCacheWithAll(t *testing.T) {
+func TestBuild_CacheFlags(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.WriteFile(filepath.Join(tmpDir, "Setup.sh"), []byte("#!/bin/sh"), 0755); err != nil {
 		t.Fatal(err)
 	}
 
 	tests := []struct {
-		name      string
-		keepCache bool
-		wantPrune bool
+		name       string
+		keepCache  bool
+		noCache    bool
+		wantPrune  bool
+		wantNoCach bool
 	}{
 		{name: "default prunes all cache", keepCache: false, wantPrune: true},
 		{name: "keep-cache skips prune", keepCache: true, wantPrune: false},
+		{name: "no-cache adds flag", keepCache: true, noCache: true, wantNoCach: true},
 	}
 
 	for _, tt := range tests {
@@ -290,17 +293,23 @@ func TestBuild_PrunesCacheWithAll(t *testing.T) {
 				SourcePath: tmpDir,
 				Runtime:    "docker",
 				KeepCache:  tt.keepCache,
+				NoCache:    tt.noCache,
 			}, r)
 
 			if _, err := b.Build(context.Background()); err != nil {
 				t.Fatalf("Build() error = %v", err)
 			}
+			out := buf.String()
 
 			// --all is required to reclaim the large non-dangling engine build
 			// cache; bare `builder prune -f` only clears dangling layers.
-			gotPrune := strings.Contains(buf.String(), "builder prune --all -f")
+			gotPrune := strings.Contains(out, "builder prune --all -f")
 			if gotPrune != tt.wantPrune {
-				t.Errorf("prune --all present = %v, want %v; output: %s", gotPrune, tt.wantPrune, buf.String())
+				t.Errorf("prune --all present = %v, want %v; output: %s", gotPrune, tt.wantPrune, out)
+			}
+			gotNoCache := strings.Contains(out, "--no-cache")
+			if gotNoCache != tt.wantNoCach {
+				t.Errorf("--no-cache present = %v, want %v; output: %s", gotNoCache, tt.wantNoCach, out)
 			}
 		})
 	}
@@ -367,5 +376,33 @@ func assertPositiveMaxJobs(t *testing.T, out string) {
 	n, err := strconv.Atoi(rest[:end])
 	if err != nil || n < 1 {
 		t.Errorf("auto-detected MAX_JOBS should be a positive integer, got %q (err=%v)", rest[:end], err)
+	}
+}
+
+func TestWriteBuildContext_DockerfileError(t *testing.T) {
+	// A directory at tmpDir/Dockerfile makes os.WriteFile fail.
+	tmpDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(tmpDir, "Dockerfile"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	r := runner.NewRunner(false, true)
+	b := NewEngineImageBuilder(EngineImageOptions{SourcePath: t.TempDir(), Runtime: "docker"}, r)
+
+	if _, _, err := b.writeBuildContext(tmpDir); err == nil || !strings.Contains(err.Error(), "writing Dockerfile") {
+		t.Errorf("expected Dockerfile write error, got %v", err)
+	}
+}
+
+func TestWriteBuildContext_DockerignoreError(t *testing.T) {
+	// A directory at SourcePath/.dockerignore makes os.WriteFile fail.
+	srcPath := t.TempDir()
+	if err := os.Mkdir(filepath.Join(srcPath, ".dockerignore"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	r := runner.NewRunner(false, true)
+	b := NewEngineImageBuilder(EngineImageOptions{SourcePath: srcPath, Runtime: "docker"}, r)
+
+	if _, _, err := b.writeBuildContext(t.TempDir()); err == nil || !strings.Contains(err.Error(), "writing .dockerignore") {
+		t.Errorf("expected .dockerignore write error, got %v", err)
 	}
 }

--- a/internal/dockerbuild/game_container_test.go
+++ b/internal/dockerbuild/game_container_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/runner"
@@ -90,5 +91,45 @@ func TestRunClientBuildContainer(t *testing.T) {
 
 	if err := b.runClientBuildContainer(context.Background(), t.TempDir()); err != nil {
 		t.Fatalf("runClientBuildContainer() error: %v", err)
+	}
+}
+
+func TestBuild_EngineImageRequired(t *testing.T) {
+	r := runner.NewRunner(false, true)
+	b := NewDockerGameBuilder(DockerGameOptions{}, r)
+
+	if _, err := b.Build(context.Background()); err == nil || !strings.Contains(err.Error(), "engine Docker image not specified") {
+		t.Errorf("expected engine image error, got %v", err)
+	}
+}
+
+func TestBuildClient_UnsupportedPlatform(t *testing.T) {
+	r := runner.NewRunner(false, true)
+	b := NewDockerGameBuilder(DockerGameOptions{ClientPlatform: "Win64"}, r)
+
+	if _, err := b.BuildClient(context.Background()); err == nil || !strings.Contains(err.Error(), "only supports Linux client builds") {
+		t.Errorf("expected unsupported platform error, got %v", err)
+	}
+}
+
+func TestBuildClient_EngineImageRequired(t *testing.T) {
+	r := runner.NewRunner(false, true)
+	b := NewDockerGameBuilder(DockerGameOptions{ClientPlatform: "Linux"}, r)
+
+	if _, err := b.BuildClient(context.Background()); err == nil || !strings.Contains(err.Error(), "engine Docker image not specified") {
+		t.Errorf("expected engine image error, got %v", err)
+	}
+}
+
+func TestPrepareBuildContext_MkdirAllError(t *testing.T) {
+	// A file in place of an ancestor dir makes os.MkdirAll fail.
+	blocker := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	b := NewDockerGameBuilder(DockerGameOptions{}, runner.NewRunner(false, true))
+
+	if _, err := b.prepareBuildContext(filepath.Join(blocker, "out"), "PackagedServer"); err == nil {
+		t.Error("expected error when output parent is a file")
 	}
 }

--- a/internal/dockerbuild/game_ddc_test.go
+++ b/internal/dockerbuild/game_ddc_test.go
@@ -100,6 +100,31 @@ func TestDDCArgs_ZenWithoutPathErrors(t *testing.T) {
 	}
 }
 
+func TestDDCArgs_ZenMkdirAllError(t *testing.T) {
+	// A file in place of an ancestor dir makes os.MkdirAll fail.
+	blocker := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	r := runner.NewRunner(false, false)
+	b := NewDockerGameBuilder(DockerGameOptions{DDCMode: ddc.ModeZen, DDCZenPath: filepath.Join(blocker, "zen")}, r)
+	if _, err := b.ddcArgs(); err == nil || !strings.Contains(err.Error(), "creating DDC zen directory") {
+		t.Errorf("expected zen dir creation error, got %v", err)
+	}
+}
+
+func TestDDCArgs_LocalMkdirAllError(t *testing.T) {
+	blocker := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	r := runner.NewRunner(false, false)
+	b := NewDockerGameBuilder(DockerGameOptions{DDCMode: ddc.ModeLocal, DDCPath: filepath.Join(blocker, "ddc")}, r)
+	if _, err := b.ddcArgs(); err == nil || !strings.Contains(err.Error(), "creating DDC directory") {
+		t.Errorf("expected DDC dir creation error, got %v", err)
+	}
+}
+
 func TestDDCArgs_LocalMountsOnlyFilesystem(t *testing.T) {
 	ddcDir := filepath.Join(t.TempDir(), "ddc")
 	r := runner.NewRunner(false, false)

--- a/internal/game/builder_ddc_test.go
+++ b/internal/game/builder_ddc_test.go
@@ -116,3 +116,17 @@ func TestSetupDDC_CreatesNestedDirectory(t *testing.T) {
 		t.Errorf("DDC directory not created (nested): %v", err)
 	}
 }
+
+func TestSetupDDC_LocalMkdirAllError(t *testing.T) {
+	// A file in place of an ancestor dir makes os.MkdirAll fail.
+	blocker := filepath.Join(t.TempDir(), "afile")
+	if err := os.WriteFile(blocker, []byte("x"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	r := runner.NewRunner(false, false)
+	b := NewBuilder(BuildOptions{DDCMode: "local", DDCPath: filepath.Join(blocker, "ddc")}, r)
+	err := b.setupDDC()
+	if err == nil || !strings.Contains(err.Error(), "creating DDC directory") {
+		t.Errorf("expected DDC dir creation error, got %v", err)
+	}
+}

--- a/internal/state/state_io_test.go
+++ b/internal/state/state_io_test.go
@@ -159,9 +159,9 @@ func TestListProfiles_SortedSkipsDirectories(t *testing.T) {
 func TestListProfiles_UnreadableDir(t *testing.T) {
 	setupTest(t)
 
-	// A file at the profiles dir path makes os.ReadDir fail; on Windows the
-	// error maps to IsNotExist so ListProfiles treats it as "no profiles",
-	// which is the intended graceful degradation.
+	// A file at the profiles dir path makes os.ReadDir fail. On Windows the
+	// error maps to IsNotExist and ListProfiles degrades to nil; on Unix it
+	// surfaces as ENOTDIR and is returned as-is. Both are acceptable.
 	if err := os.MkdirAll(stateDir, 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -169,7 +169,13 @@ func TestListProfiles_UnreadableDir(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	got := mustListProfiles(t)
+	got, err := ListProfiles()
+	if err != nil {
+		if os.IsNotExist(err) {
+			t.Fatalf("ListProfiles error = %v, want non-IsNotExist or nil", err)
+		}
+		return
+	}
 	if got != nil {
 		t.Errorf("ListProfiles = %v, want nil (profiles dir unusable)", got)
 	}

--- a/internal/state/state_io_test.go
+++ b/internal/state/state_io_test.go
@@ -83,6 +83,20 @@ func TestLoadEmptyJSON(t *testing.T) {
 	}
 }
 
+func TestLoad_UnreadableState(t *testing.T) {
+	setupTest(t)
+
+	// A directory at the state path makes os.ReadFile fail with a
+	// non-IsNotExist error, which Load surfaces.
+	if err := os.MkdirAll(filepath.Join(stateDir, stateFile), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error when state path is a directory")
+	}
+}
+
 func TestSave_MkdirAllFails(t *testing.T) {
 	setupTest(t)
 
@@ -139,5 +153,24 @@ func TestListProfiles_SortedSkipsDirectories(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("ListProfiles[%d] = %q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+func TestListProfiles_UnreadableDir(t *testing.T) {
+	setupTest(t)
+
+	// A file at the profiles dir path makes os.ReadDir fail; on Windows the
+	// error maps to IsNotExist so ListProfiles treats it as "no profiles",
+	// which is the intended graceful degradation.
+	if err := os.MkdirAll(stateDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(stateDir, "profiles"), []byte("not a dir"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := mustListProfiles(t)
+	if got != nil {
+		t.Errorf("ListProfiles = %v, want nil (profiles dir unusable)", got)
 	}
 }


### PR DESCRIPTION
# Batch H coverage — 80.2% → 80.3%

Test-only PR. Extends statement coverage across the batch H targets.

## Files (all test files, +195 lines)
- `internal/dockerbuild/engine_test.go` — `writeBuildContext` Dockerfile/.dockerignore write errors; consolidated `Build` cache-flag table (`--all` prune + `--no-cache`)
- `internal/dockerbuild/game_container_test.go` — `Build`/`BuildClient` engine-image required; unsupported Win64 client platform; `prepareBuildContext` MkdirAll error
- `internal/dockerbuild/game_ddc_test.go` — zen/local DDC args MkdirAll errors
- `internal/state/state_io_test.go` — `Load` unreadable state file; profiles-dir degradation
- `internal/config/client_binary_test.go` — `DiscoverClientBinary` skips directories
- `internal/game/builder_ddc_test.go` — `setupLocalDDC` MkdirAll error

## Verification
- `go test -count=1 ./...` green
- `golangci-lint run ./...` 0 issues; `go vet` clean; gofmt clean; gocyclo < 8
- Full-suite coverage: **80.3%** (from 80.2%)

All changes are 100% `*_test.go` — patch coverage unaffected.