### PR TITLE
test: Batch I coverage to 81.2%

### DIFF
--- a/cmd/doctor/doctor_test.go
+++ b/cmd/doctor/doctor_test.go
@@ -5,6 +5,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jpvelasco/ludus/cmd/globals"
 	"github.com/jpvelasco/ludus/internal/config"
 )
 
@@ -148,6 +149,24 @@ func TestFormatDiagnosticSummary(t *testing.T) {
 // TestCheckAppleSiliconContainer covers the new platform-aware check (both AS + container
 // case and skip paths). Uses runtime to decide expectations (works on all hosts; macOS arm64
 // CI will exercise the warn path).
+func TestRunDoctorWiresAllChecks(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{})
+	t.Setenv("PATH", t.TempDir()) // exec-based checks degrade via LookPath
+
+	output, err := captureDoctorOutput(t, func() error { return runDoctor(Cmd, nil) })
+	if !strings.Contains(output, "Running diagnostics...") {
+		t.Errorf("output %q missing diagnostics header", output)
+	}
+	// Every check either passes or warns with an empty config; the summary
+	// must reflect the error consistency.
+	if err == nil && !strings.Contains(output, "No issues found") {
+		t.Errorf("output %q missing clean summary", output)
+	}
+	if err != nil && !strings.Contains(output, "issue(s) found") {
+		t.Errorf("output %q missing failure summary", output)
+	}
+}
+
 func TestCheckAppleSiliconContainer(t *testing.T) {
 	isAS := runtime.GOOS == "darwin" && runtime.GOARCH == "arm64"
 	tests := []struct {

--- a/cmd/logs/logs_test.go
+++ b/cmd/logs/logs_test.go
@@ -106,6 +106,30 @@ func TestRunListReportsEmptyDirectory(t *testing.T) {
 	}
 }
 
+func TestRunTailReportsEmptyDirectory(t *testing.T) {
+	dir := t.TempDir()
+	setLogsConfig(t, dir)
+
+	output, err := captureStdout(t, func() error { return runTail(nil, nil) })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := "No build logs in " + dir; !strings.Contains(output, want) {
+		t.Fatalf("output = %q, want it to contain %q", output, want)
+	}
+}
+
+func TestRunTail_ReadDirError(t *testing.T) {
+	// A directory path containing a NUL byte makes logFiles fail with a
+	// non-IsNotExist error, which runTail surfaces.
+	dir := filepath.Join(t.TempDir(), "\x00")
+	setLogsConfig(t, dir)
+
+	if err := runTail(nil, nil); err == nil {
+		t.Fatal("expected error when logs dir cannot be read")
+	}
+}
+
 func setLogsConfig(t *testing.T, dir string) {
 	t.Helper()
 	previous := globals.Cfg

--- a/cmd/root/init_test.go
+++ b/cmd/root/init_test.go
@@ -1,0 +1,69 @@
+package root
+
+import (
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+)
+
+func captureRootStdout(t *testing.T, run func() error) (string, error) {
+	t.Helper()
+	reader, writer, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	previous := os.Stdout
+	os.Stdout = writer
+	runErr := run()
+	os.Stdout = previous
+	if err := writer.Close(); err != nil {
+		t.Fatal(err)
+	}
+	defer reader.Close()
+	data, err := io.ReadAll(reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data), runErr
+}
+
+func TestRunInitReportsFailedChecks(t *testing.T) {
+	setRootGlobals(t)
+	previousJSON := globals.JSONOutput
+	globals.JSONOutput = false
+	t.Cleanup(func() { globals.JSONOutput = previousJSON })
+	t.Setenv("PATH", t.TempDir()) // every exec-based check degrades via LookPath
+
+	output, err := captureRootStdout(t, func() error { return runInit(initCmd, nil) })
+	if err == nil {
+		t.Fatal("runInit() expected error when prerequisites fail")
+	}
+	if !strings.Contains(output, "Validating prerequisites...") {
+		t.Errorf("output %q missing header line", output)
+	}
+	if !strings.Contains(output, "[FAIL]") {
+		t.Errorf("output %q missing [FAIL] markers", output)
+	}
+}
+
+func TestRunInitJSONOutput(t *testing.T) {
+	setRootGlobals(t)
+	previousJSON := globals.JSONOutput
+	globals.JSONOutput = true
+	t.Cleanup(func() { globals.JSONOutput = previousJSON })
+	t.Setenv("PATH", t.TempDir())
+
+	output, err := captureRootStdout(t, func() error { return runInit(initCmd, nil) })
+	if err != nil {
+		t.Fatalf("runInit() JSON error = %v", err)
+	}
+	if !strings.Contains(output, `"passed"`) {
+		t.Errorf("output %q missing JSON passed field", output)
+	}
+	if strings.Contains(output, "Validating prerequisites...") {
+		t.Errorf("output %q should not contain human-readable header in JSON mode", output)
+	}
+}

--- a/internal/awsutil/poller_test.go
+++ b/internal/awsutil/poller_test.go
@@ -25,6 +25,16 @@ func TestPollWithOptionsDone(t *testing.T) {
 	}
 }
 
+func TestPollDelegatesToPollWithOptions(t *testing.T) {
+	err := Poll(context.Background(), time.Millisecond, time.Millisecond, func() (bool, error) {
+		return false, nil
+	})
+
+	if !errors.Is(err, ErrPollTimeout) {
+		t.Fatalf("Poll() error = %v, want ErrPollTimeout", err)
+	}
+}
+
 func TestPollWithOptionsTimeout(t *testing.T) {
 	err := PollWithOptions(context.Background(), PollOptions{
 		Interval: time.Millisecond,

--- a/internal/buildlog/buildlog_test.go
+++ b/internal/buildlog/buildlog_test.go
@@ -128,6 +128,18 @@ func TestNew_MkdirAllFails(t *testing.T) {
 	}
 }
 
+func TestNew_OpenFileFails(t *testing.T) {
+	// A NUL byte in the run name makes os.OpenFile fail with a non-IsExist
+	// error, which New surfaces after the retry loop gives up.
+	_, err := New(t.TempDir(), "run\x00x", testTime())
+	if err == nil {
+		t.Fatal("expected error when log file cannot be created")
+	}
+	if !strings.Contains(err.Error(), "creating log file") {
+		t.Errorf("error = %v, want it to describe the file failure", err)
+	}
+}
+
 func TestSection_WritesHeader(t *testing.T) {
 	dir := t.TempDir()
 	lg, err := New(dir, "run", testTime())

--- a/internal/cache/cache_io_test.go
+++ b/internal/cache/cache_io_test.go
@@ -2,6 +2,7 @@ package cache
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 )
 
@@ -52,6 +53,20 @@ func TestLoadCorruptedFile(t *testing.T) {
 
 	if _, err := Load(); err == nil {
 		t.Fatal("expected error loading corrupted cache file")
+	}
+}
+
+func TestLoadUnreadableFile(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	// A directory at the cache path makes os.ReadFile fail with a
+	// non-IsNotExist error, which Load surfaces.
+	if err := os.MkdirAll(filepath.Join(cacheDir, cacheFile), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Load(); err == nil {
+		t.Fatal("expected error loading unreadable cache path")
 	}
 }
 

--- a/internal/ddc/ddc_ops_test.go
+++ b/internal/ddc/ddc_ops_test.go
@@ -70,6 +70,20 @@ func TestClean_FileReadDirError(t *testing.T) {
 	}
 }
 
+func TestClean_InvalidPathError(t *testing.T) {
+	// A NUL byte in the path makes os.ReadDir fail with a non-IsNotExist
+	// error on every platform, exercising the error branch deterministically.
+	dir := filepath.Join(t.TempDir(), "x\x00nul")
+
+	_, err := Clean(dir)
+	if err == nil {
+		t.Fatal("Clean() on invalid path should error")
+	}
+	if !strings.Contains(err.Error(), "reading DDC directory") {
+		t.Errorf("error = %v, want it to wrap the ReadDir failure", err)
+	}
+}
+
 func TestPrune(t *testing.T) {
 	dir := t.TempDir()
 

--- a/internal/status/status_gaps_test.go
+++ b/internal/status/status_gaps_test.go
@@ -60,6 +60,28 @@ func TestCheckGameSession_DetailFormatting(t *testing.T) {
 	}
 }
 
+func TestCheckAll_ProjectPathOutputDir(t *testing.T) {
+	dir := chdirTemp(t)
+	writeState(t, dir, &state.State{})
+	cfg := &config.Config{}
+	cfg.Game.ProjectName = "MyGame"
+	cfg.Game.ProjectPath = filepath.Join(dir, "MyGame.uproject")
+
+	stages := CheckAll(context.Background(), cfg, &stubTarget{status: &deploy.DeployStatus{Status: "not_deployed"}})
+	found := false
+	for _, st := range stages {
+		if st.Name == "MyGame Server Build" {
+			found = true
+			if st.Status != "fail" || st.Detail != "not built" {
+				t.Errorf("got %+v, want fail/not built", st)
+			}
+		}
+	}
+	if !found {
+		t.Error("expected a 'MyGame Server Build' stage")
+	}
+}
+
 func TestCheckAll_LyraFallbackOutputDir(t *testing.T) {
 	dir := chdirTemp(t)
 	writeState(t, dir, &state.State{})

--- a/internal/toolchain/toolchain_test.go
+++ b/internal/toolchain/toolchain_test.go
@@ -1,0 +1,77 @@
+package toolchain
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func toolchain58Spec(t *testing.T) *ToolchainSpec {
+	t.Helper()
+	spec := LookupToolchain("5.8")
+	if spec == nil {
+		t.Fatal("no toolchain spec for 5.8")
+	}
+	return spec
+}
+
+func TestCheckToolchainLinux_FoundInEngineSDK(t *testing.T) {
+	spec := toolchain58Spec(t)
+	engineRoot := t.TempDir()
+	sdkDir := filepath.Join(engineRoot, "Engine", "Extras", "ThirdPartyNotUE", "SDKs", "HostLinux", "Linux_x64")
+	toolDir := filepath.Join(sdkDir, spec.DirPrefix+"-20.1.8-rockylinux8")
+	if err := os.MkdirAll(toolDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	result := checkToolchainLinux(engineRoot, CheckResult{
+		EngineVersion: "5.8",
+		VersionSource: "config",
+		Required:      spec,
+	})
+	if !result.Found {
+		t.Errorf("checkToolchainLinux() Found = false, want true: %+v", result)
+	}
+	if !strings.Contains(result.Message, "found at") {
+		t.Errorf("message %q missing 'found at'", result.Message)
+	}
+}
+
+func TestCheckToolchainLinux_FoundViaMultiarchRoot(t *testing.T) {
+	spec := toolchain58Spec(t)
+	root := t.TempDir()
+	toolDir := filepath.Join(root, spec.DirPrefix+"-20.1.8-rockylinux8")
+	if err := os.MkdirAll(toolDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("LINUX_MULTIARCH_ROOT", root)
+
+	result := checkToolchainLinux(t.TempDir(), CheckResult{
+		EngineVersion: "5.8",
+		VersionSource: "config",
+		Required:      spec,
+	})
+	if !result.Found {
+		t.Errorf("checkToolchainLinux() Found = false, want true via LINUX_MULTIARCH_ROOT: %+v", result)
+	}
+	if !strings.Contains(result.Message, "LINUX_MULTIARCH_ROOT") {
+		t.Errorf("message %q missing LINUX_MULTIARCH_ROOT mention", result.Message)
+	}
+}
+
+func TestCheckToolchainLinux_NotFound(t *testing.T) {
+	spec := toolchain58Spec(t)
+	t.Setenv("LINUX_MULTIARCH_ROOT", "")
+	result := checkToolchainLinux(t.TempDir(), CheckResult{
+		EngineVersion: "5.8",
+		VersionSource: "config",
+		Required:      spec,
+	})
+	if result.Found {
+		t.Errorf("checkToolchainLinux() Found = true, want false: %+v", result)
+	}
+	if !strings.Contains(result.Message, "not found") {
+		t.Errorf("message %q missing 'not found'", result.Message)
+	}
+}


### PR DESCRIPTION
# Batch I coverage — 80.3% → 81.2%

Test-only PR. Extends statement coverage across the Batch I targets.

## Files (all test files)
- `cmd/root/init_test.go` (new) — `runInit` orchestration: failed-checks path + JSON output branch
- `cmd/doctor/doctor_test.go` — `runDoctor` full wiring (all 12 checks, empty config + PATH)
- `internal/toolchain/toolchain_test.go` (new) — `checkToolchainLinux`: engine SDK dir, LINUX_MULTIARCH_ROOT fallback, not-found
- `internal/cache/cache_io_test.go` — `Load` non-IsNotExist ReadFile error (dir-as-cache-file)
- `internal/awsutil/poller_test.go` — `Poll` wrapper delegation
- `internal/buildlog/buildlog_test.go` — `New` OpenFile failure (NUL-byte run name)
- `internal/ddc/ddc_ops_test.go` — `Clean` ReadDir error (NUL-byte path, all platforms)
- `cmd/logs/logs_test.go` — `runTail` empty-dir and ReadDir-error branches
- `internal/status/status_gaps_test.go` — `CheckAll` ProjectPath output-dir branch

## Verification
- `go test -count=1 ./...` green
- `golangci-lint run ./...` 0 issues; `go vet` clean; gofmt clean; gocyclo < 8
- Full-suite coverage: **81.2%** (from 80.3%)

All changes are 100% `*_test.go` — patch coverage unaffected.