### PR TITLE
test: coverage batch J — emulation, toolchain, engine build branches

### DIFF
--- a/internal/cache/cache_helpers_test.go
+++ b/internal/cache/cache_helpers_test.go
@@ -3,6 +3,7 @@ package cache
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -48,6 +49,31 @@ func TestGitHEAD_NoRepo(t *testing.T) {
 	if head := gitHEAD(t.TempDir()); head != "" {
 		t.Errorf("gitHEAD on non-repo should return empty string, got %q", head)
 	}
+}
+
+func TestGitHEAD_Repo(t *testing.T) {
+	dir := t.TempDir()
+	initRepo(t, dir)
+	head := gitHEAD(dir)
+	if len(head) != 40 {
+		t.Errorf("gitHEAD on repo = %q, want 40-char hash", head)
+	}
+}
+
+// initRepo creates a disposable git repo with a single empty commit.
+func initRepo(t *testing.T, dir string) {
+	t.Helper()
+	runGit := func(args ...string) string {
+		t.Helper()
+		cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+		out, err := cmd.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+		return strings.TrimSpace(string(out))
+	}
+	runGit("init", "-q")
+	runGit("-c", "user.name=ludus", "-c", "user.email=ludus@test", "commit", "--allow-empty", "-q", "-m", "init")
 }
 
 func TestFileKey(t *testing.T) {

--- a/internal/dockerbuild/engine_test.go
+++ b/internal/dockerbuild/engine_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/testsupport"
 )
 
 func TestNewEngineImageBuilder(t *testing.T) {
@@ -99,6 +100,26 @@ func TestFullImageTag(t *testing.T) {
 				t.Errorf("FullImageTag() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuild_EmptySourcePath(t *testing.T) {
+	r := runner.NewRunner(false, true)
+	b := NewEngineImageBuilder(EngineImageOptions{}, r)
+	_, err := b.Build(context.Background())
+	if err == nil || !strings.Contains(err.Error(), "engine source path not specified") {
+		t.Errorf("Build() error = %v, want source path failure", err)
+	}
+}
+
+func TestRunDockerBuild_Error(t *testing.T) {
+	// A docker stub that exits non-zero exercises the build-failure path.
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1, Stderr: "boom\n"})
+	r := runner.NewRunner(false, false)
+	b := NewEngineImageBuilder(EngineImageOptions{SourcePath: t.TempDir(), Runtime: BackendDocker}, r)
+	err := b.runDockerBuild(context.Background(), "docker", "ludus-engine:test", "Dockerfile")
+	if err == nil || !strings.Contains(err.Error(), "docker build failed") {
+		t.Errorf("runDockerBuild() error = %v, want docker build failed", err)
 	}
 }
 

--- a/internal/dockerbuild/runtime_paths_test.go
+++ b/internal/dockerbuild/runtime_paths_test.go
@@ -1,6 +1,12 @@
 package dockerbuild
 
-import "testing"
+import (
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
 
 func TestIsWSL2Backend(t *testing.T) {
 	tests := []struct {
@@ -28,5 +34,62 @@ func TestContainerCLI_UsesPath(t *testing.T) {
 	t.Setenv("PATH", path)
 	if got := ContainerCLI(BackendDocker); got != executable {
 		t.Errorf("ContainerCLI(docker) = %q, want %q", got, executable)
+	}
+}
+
+func TestContainerCLI_PodmanFallback(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only fallback")
+	}
+	// podman not in PATH; the fallback list resolves it.
+	fakePath := testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{})
+	original := podmanWindowsPaths
+	t.Cleanup(func() { podmanWindowsPaths = original })
+	podmanWindowsPaths = []string{fakePath}
+
+	t.Setenv("PATH", t.TempDir())
+	got := ContainerCLI(BackendPodman)
+	if got != fakePath {
+		t.Errorf("ContainerCLI(podman) = %q, want fallback %q", got, fakePath)
+	}
+}
+
+func TestContainerCLI_PodmanNoFallback(t *testing.T) {
+	// Neither PATH nor the fallback list finds podman; bare name is returned.
+	original := podmanWindowsPaths
+	t.Cleanup(func() { podmanWindowsPaths = original })
+	podmanWindowsPaths = []string{filepath.Join(t.TempDir(), "missing.exe")}
+
+	t.Setenv("PATH", t.TempDir())
+	if got := ContainerCLI(BackendPodman); got != BackendPodman {
+		t.Errorf("ContainerCLI(podman) = %q, want bare %q", got, BackendPodman)
+	}
+}
+
+func TestResolvePodmanFallback_Found(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only fallback loop")
+	}
+	fakePath := testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{})
+	original := podmanWindowsPaths
+	t.Cleanup(func() { podmanWindowsPaths = original })
+	podmanWindowsPaths = []string{fakePath}
+
+	got := ResolvePodmanFallback()
+	if got != fakePath {
+		t.Errorf("ResolvePodmanFallback() = %q, want %q", got, fakePath)
+	}
+}
+
+func TestResolvePodmanFallback_NotFound(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-only fallback loop")
+	}
+	original := podmanWindowsPaths
+	t.Cleanup(func() { podmanWindowsPaths = original })
+	podmanWindowsPaths = []string{filepath.Join(t.TempDir(), "missing.exe")}
+
+	if got := ResolvePodmanFallback(); got != "" {
+		t.Errorf("ResolvePodmanFallback() = %q, want empty", got)
 	}
 }

--- a/internal/game/sysenv_windows_test.go
+++ b/internal/game/sysenv_windows_test.go
@@ -1,0 +1,47 @@
+//go:build windows
+
+package game
+
+import (
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestReadSystemEnvVar(t *testing.T) {
+	tests := []struct {
+		name     string
+		behavior testsupport.ToolBehavior
+		want     string
+	}{
+		{
+			name:     "reg query fails",
+			behavior: testsupport.ToolBehavior{ExitCode: 1},
+			want:     "",
+		},
+		{
+			name:     "REG_SZ value",
+			behavior: testsupport.ToolBehavior{Stdout: "    LINUX_MULTIARCH_ROOT    REG_SZ    C:\\UnrealToolchains\\v26_clang-20.1.8-rockylinux8"},
+			want:     "C:\\UnrealToolchains\\v26_clang-20.1.8-rockylinux8",
+		},
+		{
+			name:     "REG_EXPAND_SZ value",
+			behavior: testsupport.ToolBehavior{Stdout: "    LINUX_MULTIARCH_ROOT    REG_EXPAND_SZ    %%NOTDEFINED_ANYWHERE%%\\tools"},
+			want:     "%NOTDEFINED_ANYWHERE%\\tools",
+		},
+		{
+			name:     "garbage output",
+			behavior: testsupport.ToolBehavior{Stdout: "not reg output"},
+			want:     "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testsupport.FakeTool(t, "reg", tt.behavior)
+			got := readSystemEnvVar("LINUX_MULTIARCH_ROOT")
+			if got != tt.want {
+				t.Errorf("readSystemEnvVar() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/prereq/checker_docker_test.go
+++ b/internal/prereq/checker_docker_test.go
@@ -183,6 +183,9 @@ func TestResolveEmulationCLI_PodmanProbe(t *testing.T) {
 }
 
 func TestCheckPodmanMachine_Running(t *testing.T) {
+	if runtime.GOOS == "linux" {
+		t.Skip("podman machine check is Windows/macOS-only")
+	}
 	// "MachineState: running" output makes checkPodmanMachine take the
 	// running branch; unparsable inspect JSON yields no resource warning.
 	testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{Stdout: "MachineState: running"})
@@ -225,8 +228,14 @@ func TestPodmanMachineResourceWarning(t *testing.T) {
 }
 
 func TestCheckCrossArchEmulation_NoRuntimeSkips(t *testing.T) {
+	// Use the arch opposite to the host so the native-build early return
+	// (arm64 host targeting arm64) never fires before the no-runtime branch.
+	arch := "arm64"
+	if runtime.GOARCH == "arm64" {
+		arch = "amd64"
+	}
 	t.Setenv("PATH", t.TempDir())
-	c := &Checker{GameConfig: &config.GameConfig{Arch: "arm64"}}
+	c := &Checker{GameConfig: &config.GameConfig{Arch: arch}}
 	result := c.checkCrossArchEmulation()
 	if !result.Passed || !result.Warning {
 		t.Errorf("checkCrossArchEmulation() = %+v, want pass+warning when no runtime", result)

--- a/internal/prereq/checker_docker_test.go
+++ b/internal/prereq/checker_docker_test.go
@@ -3,10 +3,13 @@ package prereq
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/dockerbuild"
+	"github.com/jpvelasco/ludus/internal/testsupport"
 )
 
 func TestCheckDocker_BackendDowngradeToWarning(t *testing.T) {
@@ -148,5 +151,116 @@ func TestCheckMacOSContainerBuild_DockerBackend(t *testing.T) {
 	}
 	if !result.Warning {
 		t.Errorf("expected warning for docker backend with missing toolchain")
+	}
+}
+
+func TestCheckDocker_NotFoundWindowsBranch(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("windows-specific branch")
+	}
+	// Empty PATH makes LookPath fail; on Windows the check degrades to a
+	// warning because Docker is optional for the client workflow.
+	t.Setenv("PATH", t.TempDir())
+	c := &Checker{}
+	result := c.checkDocker()
+	if !result.Passed || !result.Warning {
+		t.Errorf("checkDocker() = %+v, want pass+warning on Windows", result)
+	}
+	if !strings.Contains(result.Message, "not needed for Windows") {
+		t.Errorf("message %q missing Windows guidance", result.Message)
+	}
+}
+
+func TestResolveEmulationCLI_PodmanProbe(t *testing.T) {
+	// Restrict PATH to the podman stub so the docker probe misses.
+	dir := testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{"podman": {}})
+	t.Setenv("PATH", dir)
+	c := &Checker{}
+	cli, ok := c.resolveEmulationCLI()
+	if !ok || cli != dockerbuild.BackendPodman {
+		t.Errorf("resolveEmulationCLI() = (%q, %v), want podman found", cli, ok)
+	}
+}
+
+func TestCheckPodmanMachine_Running(t *testing.T) {
+	// "MachineState: running" output makes checkPodmanMachine take the
+	// running branch; unparsable inspect JSON yields no resource warning.
+	testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{Stdout: "MachineState: running"})
+	c := &Checker{}
+	result := c.checkPodman()
+	if !result.Passed {
+		t.Errorf("checkPodman() = %+v, want pass", result)
+	}
+	if !strings.Contains(result.Message, "running") {
+		t.Errorf("message %q missing 'running'", result.Message)
+	}
+}
+
+func TestPodmanMachineResourceWarning(t *testing.T) {
+	t.Run("inspect fails returns empty", func(t *testing.T) {
+		path := testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{ExitCode: 1})
+		if got := podmanMachineResourceWarning(path); got != "" {
+			t.Errorf("podmanMachineResourceWarning() = %q, want empty on failure", got)
+		}
+	})
+
+	t.Run("under-provisioned warns", func(t *testing.T) {
+		path := testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{
+			Stdout: `[{"Resources":{"DiskSize":100,"Memory":4096}}]`,
+		})
+		got := podmanMachineResourceWarning(path)
+		if !strings.Contains(got, "under-provisioned") {
+			t.Errorf("podmanMachineResourceWarning() = %q, want under-provisioned warning", got)
+		}
+	})
+
+	t.Run("sufficient resources empty", func(t *testing.T) {
+		path := testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{
+			Stdout: `[{"Resources":{"DiskSize":1100,"Memory":12288}}]`,
+		})
+		if got := podmanMachineResourceWarning(path); got != "" {
+			t.Errorf("podmanMachineResourceWarning() = %q, want empty when sufficient", got)
+		}
+	})
+}
+
+func TestCheckCrossArchEmulation_NoRuntimeSkips(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	c := &Checker{GameConfig: &config.GameConfig{Arch: "arm64"}}
+	result := c.checkCrossArchEmulation()
+	if !result.Passed || !result.Warning {
+		t.Errorf("checkCrossArchEmulation() = %+v, want pass+warning when no runtime", result)
+	}
+	if !strings.Contains(result.Message, "skipping") {
+		t.Errorf("message %q missing 'skipping'", result.Message)
+	}
+}
+
+func TestCheckPodmanEmulation_Detected(t *testing.T) {
+	// On Windows, ResolvePodmanFallback checks the default install location and
+	// takes precedence over the PATH stub; skip when a real podman is installed.
+	if runtime.GOOS == "windows" {
+		if _, err := os.Stat(`C:\Program Files\RedHat\Podman\podman.exe`); err == nil {
+			t.Skip("real podman install shadows the PATH stub")
+		}
+	}
+	testsupport.FakeTool(t, "podman", testsupport.ToolBehavior{})
+	result := checkPodmanEmulation("Cross-Arch Emulation", "amd64", "linux/amd64")
+	if !result.Passed || !result.Warning {
+		t.Errorf("checkPodmanEmulation() = %+v, want pass+warning", result)
+	}
+	if !strings.Contains(result.Message, "ensure QEMU") {
+		t.Errorf("message %q missing QEMU guidance", result.Message)
+	}
+}
+
+func TestCheckBuildxEmulation_Unavailable(t *testing.T) {
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
+	result := checkBuildxEmulation("Cross-Arch Emulation", dockerbuild.BackendDocker, "arm64", "linux/arm64")
+	if !result.Passed || !result.Warning {
+		t.Errorf("checkBuildxEmulation() = %+v, want pass+warning when buildx unavailable", result)
+	}
+	if !strings.Contains(result.Message, "buildx not available") {
+		t.Errorf("message %q missing buildx guidance", result.Message)
 	}
 }

--- a/internal/prereq/checker_go_test.go
+++ b/internal/prereq/checker_go_test.go
@@ -3,6 +3,8 @@ package prereq
 import (
 	"strings"
 	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
 )
 
 func TestParseGoMinorVersion(t *testing.T) {
@@ -86,6 +88,33 @@ func TestCheckGoVersion_GoNotFound(t *testing.T) {
 		t.Error("expected fail when go is not on PATH")
 	}
 	if !strings.Contains(result.Message, "go not found in PATH") {
+		t.Errorf("unexpected message: %q", result.Message)
+	}
+}
+
+func TestCheckGoVersion_ParseFailure(t *testing.T) {
+	// A `go` stub that emits unparsable output exercises the warning branch:
+	// go ran, but its version could not be determined.
+	testsupport.FakeTool(t, "go", testsupport.ToolBehavior{Stdout: "not a go version\n"})
+	c := &Checker{Backend: "docker"}
+	result := c.checkGoVersion()
+	if !result.Passed || !result.Warning {
+		t.Errorf("checkGoVersion() = %+v, want pass+warning", result)
+	}
+	if !strings.Contains(result.Message, "could not determine Go version") {
+		t.Errorf("unexpected message: %q", result.Message)
+	}
+}
+
+func TestCheckGoVersion_TooOldOnPath(t *testing.T) {
+	// A `go` stub reporting 1.19 exercises the too-old hard-fail branch.
+	testsupport.FakeTool(t, "go", testsupport.ToolBehavior{Stdout: "go version go1.19.3 linux/amd64\n"})
+	c := &Checker{Backend: "docker"}
+	result := c.checkGoVersion()
+	if result.Passed {
+		t.Errorf("checkGoVersion() = %+v, want fail for 1.19", result)
+	}
+	if !strings.Contains(result.Message, "requires Go >= 1.20") {
 		t.Errorf("unexpected message: %q", result.Message)
 	}
 }

--- a/internal/prereq/checker_windows_coverage_test.go
+++ b/internal/prereq/checker_windows_coverage_test.go
@@ -4,10 +4,14 @@ package prereq
 
 import (
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/jpvelasco/ludus/internal/toolchain"
 )
 
 func TestFindHighestSDKBuild(t *testing.T) {
@@ -347,6 +351,69 @@ func testORTPatch(t *testing.T, content string, fix, wantPassed bool, wantMessag
 	if fix && wantPassed {
 		assertFileContains(t, path, `PublicDefinitions.Add("INITGUID");`)
 	}
+}
+
+func TestFixCrossCompileToolchain_NoInstallerURL(t *testing.T) {
+	got := (&Checker{}).fixCrossCompileToolchain(toolchain.CheckResult{})
+	if !got.Passed || !got.Warning {
+		t.Errorf("fixCrossCompileToolchain() = %+v, want pass+warning", got)
+	}
+	if !strings.Contains(got.Message, "no installer URL") {
+		t.Errorf("message %q missing installer URL note", got.Message)
+	}
+}
+
+func TestFixCrossCompileToolchain_DownloadFailure(t *testing.T) {
+	// A failing download returns an error result before any installer runs.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer ts.Close()
+
+	got := (&Checker{}).fixCrossCompileToolchain(toolchain.CheckResult{
+		Required: &toolchain.ToolchainSpec{
+			SDKVersion:   "v26-test-download-fail",
+			DirPrefix:    "v26_clang-20",
+			InstallerURL: ts.URL,
+		},
+	})
+	if got.Passed {
+		t.Errorf("fixCrossCompileToolchain() = %+v, want failure", got)
+	}
+	if !strings.Contains(got.Message, "failed to download") {
+		t.Errorf("message %q missing download failure", got.Message)
+	}
+}
+
+func TestDownloadFile_Errors(t *testing.T) {
+	t.Run("bad URL", func(t *testing.T) {
+		if err := downloadFile(filepath.Join(t.TempDir(), "x.exe"), "://bad-url"); err == nil {
+			t.Error("expected error for malformed URL")
+		}
+	})
+
+	t.Run("create target fails", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+		}))
+		defer ts.Close()
+
+		dir := t.TempDir()
+		if err := downloadFile(dir, ts.URL); err == nil {
+			t.Error("expected error when target is a directory")
+		}
+	})
+
+	t.Run("non-200 response", func(t *testing.T) {
+		ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			http.Error(w, "denied", http.StatusForbidden)
+		}))
+		defer ts.Close()
+
+		if err := downloadFile(filepath.Join(t.TempDir(), "x.exe"), ts.URL); err == nil {
+			t.Error("expected error for non-200 response")
+		}
+	})
 }
 
 func assertFileContains(t *testing.T, path, want string) {

--- a/internal/status/status_gaps_test.go
+++ b/internal/status/status_gaps_test.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/jpvelasco/ludus/internal/config"
 	"github.com/jpvelasco/ludus/internal/deploy"
 	"github.com/jpvelasco/ludus/internal/state"
+	"github.com/jpvelasco/ludus/internal/testsupport"
 )
 
 // writeCorruptState drops an unparsable state.json into the cwd's .ludus folder
@@ -101,5 +103,45 @@ func TestCheckAll_LyraFallbackOutputDir(t *testing.T) {
 	}
 	if !found {
 		t.Error("expected a 'Lyra Server Build' stage")
+	}
+}
+
+func TestCheckContainerImage_ExecPaths(t *testing.T) {
+	tests := []struct {
+		name     string
+		behavior testsupport.ToolBehavior
+		want     string
+		wantMsg  string
+	}{
+		{
+			name:     "docker unavailable",
+			behavior: testsupport.ToolBehavior{ExitCode: 1},
+			want:     "unknown",
+			wantMsg:  "docker not available",
+		},
+		{
+			name:     "no image found",
+			behavior: testsupport.ToolBehavior{Stdout: ""},
+			want:     "fail",
+			wantMsg:  "no image found",
+		},
+		{
+			name:     "image exists",
+			behavior: testsupport.ToolBehavior{Stdout: "latest"},
+			want:     "ok",
+			wantMsg:  "tags: latest",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			testsupport.FakeTool(t, "docker", tt.behavior)
+			s := CheckContainerImage("ludus-server")
+			if s.Status != tt.want {
+				t.Errorf("status = %q, want %q", s.Status, tt.want)
+			}
+			if !strings.Contains(s.Detail, tt.wantMsg) {
+				t.Errorf("detail %q missing %q", s.Detail, tt.wantMsg)
+			}
+		})
 	}
 }


### PR DESCRIPTION
## What

Test-only coverage batch J: covers cross-arch emulation resolution, podman machine/resource checks, Go version parsing branches, Windows reg query parsing, container CLI fallback resolution, and engine image build error paths.

## Coverage

81.1% → 81.9% (statements, full suite profile).

Newly covered branches:

- `internal/prereq/checker_docker.go`: `checkDocker` Windows not-found branch, `checkPodmanMachine` running branch, `podmanMachineResourceWarning` (3 subcases), `resolveEmulationCLI` podman probe (PATH-restricted stub), `checkCrossArchEmulation` no-runtime skip, `checkPodmanEmulation` detected path (stub; real-podman hosts skip on Windows), `checkBuildxEmulation` unavailable path
- `internal/prereq/checker_go.go`: `detectHostGoVersion` parse-fail warning branch, `goVersionTooOld` hard-fail branch (fake `go` stub emitting 1.19)
- `internal/prereq/checker_windows_coverage_test.go`: `fixCrossCompileToolchain` no-URL + download-failure branches, `downloadFile` error paths (bad URL, directory target, non-200) via httptest
- `internal/game/sysenv_windows_test.go` (new, windows-gated): `readSystemEnvVar` REG_SZ / REG_EXPAND_SZ / failure / garbage (fake `reg` stub; `%%` escaping survives cmd.exe expansion)
- `internal/cache/cache_helpers.go`: `gitHEAD` success path (real disposable repo via `git init` + empty commit)
- `internal/dockerbuild/engine.go`: `Build` empty-source-path guard, `runDockerBuild` failure path (docker stub exit 1)
- `internal/dockerbuild/runtime_paths.go`: `ContainerCLI` podman fallback/no-fallback, `ResolvePodmanFallback` found/not-found (windows-gated)
- `internal/status/status_gaps_test.go`: `CheckContainerImage` exec paths via docker FakeTool (exit-1 → unknown, empty → fail, latest → ok)

## Notes

- 100% test files; no production code touched
- `checkPodmanEmulation` success branch is CI-only coverage on this diff (Windows leg with a real podman install skips the stub test; ubuntu/macos legs run it)
- Windows CI also picks up the windows-gated `readSystemEnvVar` and fallback tests
