### PR TITLE
test: coverage batch K — trivy/hadolint exec paths, VS installer, client launch

### DIFF
--- a/cmd/connect/launch_windows_test.go
+++ b/cmd/connect/launch_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package connect
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLaunchClient_Win64Success(t *testing.T) {
+	binaryPath := filepath.Join(t.TempDir(), "client.bat")
+	if err := os.WriteFile(binaryPath, []byte("@echo off\r\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := launchClient(binaryPath, "Win64", t.TempDir(), "10.1.2.3:7777", "TestGame"); err != nil {
+		t.Errorf("launchClient() error = %v, want nil", err)
+	}
+}
+
+func TestLaunchClient_StartFailure(t *testing.T) {
+	err := launchClient(filepath.Join(t.TempDir(), "missing.exe"), "Win64", t.TempDir(), "10.1.2.3:7777", "TestGame")
+	if err == nil || !strings.Contains(err.Error(), "failed to launch client") {
+		t.Errorf("launchClient() error = %v, want launch failure", err)
+	}
+}

--- a/internal/dflint/tools_extra_test.go
+++ b/internal/dflint/tools_extra_test.go
@@ -1,0 +1,127 @@
+package dflint
+
+import (
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+// These tests exercise the trivy/hadolint exec paths on every platform.
+// On Unix they overlap tools_unix_test.go coverage; on Windows they are the
+// only coverage for runTrivy/imageExistsLocally/execTrivyScan/LintImage.
+
+func TestLintImageWithStubTools(t *testing.T) {
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {ExitCode: 0},
+		"trivy":  {Stdout: `{"Results":[{"Vulnerabilities":[{"VulnerabilityID":"CVE-1","Severity":"CRITICAL","Title":"issue","PkgName":"pkg"}]}]}`},
+	})
+	result := LintImage("example:latest")
+	if !result.TrivyAvailable {
+		t.Error("LintImage() TrivyAvailable = false, want true")
+	}
+	if len(result.Findings) != 1 || result.Findings[0].Rule != "CVE-1" {
+		t.Errorf("LintImage() findings = %+v, want one CVE-1", result.Findings)
+	}
+}
+
+func TestLintImageNoTrivy(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	result := LintImage("example:latest")
+	if result.TrivyAvailable {
+		t.Error("LintImage() TrivyAvailable = true, want false without trivy")
+	}
+	if len(result.Findings) != 0 {
+		t.Errorf("LintImage() findings = %+v, want none", result.Findings)
+	}
+}
+
+func TestRunTrivyToolUnavailable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	findings, available := runTrivy("example:latest")
+	if available || findings != nil {
+		t.Errorf("runTrivy() = (%+v, %v), want nil unavailable result", findings, available)
+	}
+}
+
+func TestRunTrivyMissingImageSkipsScan(t *testing.T) {
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {ExitCode: 1},
+		"trivy":  {Stdout: "unused"},
+	})
+	findings, available := runTrivy("missing:latest")
+	if !available || findings != nil {
+		t.Errorf("runTrivy() = (%+v, %v), want nil available result", findings, available)
+	}
+}
+
+func TestRunTrivyMalformedOutput(t *testing.T) {
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {ExitCode: 0},
+		"trivy":  {Stdout: "not-json"},
+	})
+	findings, available := runTrivy("example:latest")
+	if !available || findings != nil {
+		t.Errorf("runTrivy() = (%+v, %v), want nil available result on malformed output", findings, available)
+	}
+}
+
+func TestRunTrivyExitWithNoOutput(t *testing.T) {
+	testsupport.FakeTools(t, map[string]testsupport.ToolBehavior{
+		"docker": {ExitCode: 0},
+		"trivy":  {ExitCode: 1},
+	})
+	findings, available := runTrivy("example:latest")
+	if !available || findings != nil {
+		t.Errorf("runTrivy() = (%+v, %v), want nil available result on empty failed output", findings, available)
+	}
+}
+
+func TestImageExistsLocallyCases(t *testing.T) {
+	t.Run("docker reports present", func(t *testing.T) {
+		testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 0})
+		if !imageExistsLocally("example:latest") {
+			t.Error("imageExistsLocally() = false, want true")
+		}
+	})
+	t.Run("docker reports missing", func(t *testing.T) {
+		testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
+		if imageExistsLocally("example:latest") {
+			t.Error("imageExistsLocally() = true, want false")
+		}
+	})
+	t.Run("no docker on path", func(t *testing.T) {
+		t.Setenv("PATH", t.TempDir())
+		if imageExistsLocally("example:latest") {
+			t.Error("imageExistsLocally() = true, want false without docker")
+		}
+	})
+}
+
+func TestRunHadolintToolMissing(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	findings, available := runHadolint("FROM example\n")
+	if available || findings != nil {
+		t.Errorf("runHadolint() = (%+v, %v), want nil unavailable result", findings, available)
+	}
+}
+
+func TestRunHadolintEmptyOutput(t *testing.T) {
+	testsupport.FakeTool(t, "hadolint", testsupport.ToolBehavior{ExitCode: 1})
+	findings, available := runHadolint("FROM example\n")
+	if !available || len(findings) != 0 {
+		t.Errorf("runHadolint() = (%+v, %v), want empty available result", findings, available)
+	}
+}
+
+func TestRunHadolintLevelsViaStub(t *testing.T) {
+	testsupport.FakeTool(t, "hadolint", testsupport.ToolBehavior{
+		Stdout: `[{"line":1,"code":"DL3006","message":"pin base image","level":"warning"},{"line":2,"code":"DL4006","message":"set shell","level":"error"},{"line":3,"code":"DL1000","message":"other","level":"notice"}]`,
+	})
+	findings, available := runHadolint("FROM example\n")
+	if !available || len(findings) != 3 {
+		t.Fatalf("runHadolint() = (%+v, %v), want three findings", findings, available)
+	}
+	if findings[0].Level != SeverityWarning || findings[1].Level != SeverityError || findings[2].Level != SeverityInfo {
+		t.Errorf("levels = %v/%v/%v, want warning/error/info", findings[0].Level, findings[1].Level, findings[2].Level)
+	}
+}

--- a/internal/game/logic_windows_test.go
+++ b/internal/game/logic_windows_test.go
@@ -1,0 +1,52 @@
+//go:build windows
+
+package game
+
+import (
+	"os/exec"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/runner"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestDiagnoseBuildError_SmartScreenExit(t *testing.T) {
+	// powershell exit codes wrap mod 2^32, so `exit -1058471934` yields the
+	// magic 0xC0E90002 DWORD — the SmartScreen/UAC exit code.
+	runErr := exec.Command("powershell", "-NoProfile", "-Command", "exit -1058471934").Run()
+	if runErr == nil {
+		t.Fatal("expected non-zero exit from powershell")
+	}
+	if !isSmartScreenExit(runErr) {
+		t.Errorf("isSmartScreenExit() = false for exit code 0xC0E90002")
+	}
+	got := diagnoseBuildError(runErr, "game build", t.TempDir())
+	if !strings.Contains(got.Error(), "SmartScreen") || !strings.Contains(got.Error(), "game build") {
+		t.Errorf("diagnoseBuildError() = %v, want SmartScreen guidance", got)
+	}
+}
+
+func TestEnsureLinuxMultiarchRoot_RegistryFallback(t *testing.T) {
+	t.Run("registry value appended", func(t *testing.T) {
+		t.Setenv("LINUX_MULTIARCH_ROOT", "")
+		testsupport.FakeTool(t, "reg", testsupport.ToolBehavior{
+			Stdout: "    LINUX_MULTIARCH_ROOT    REG_SZ    C:\\toolchains\\v26_clang-20",
+		})
+		b := NewBuilder(BuildOptions{}, runner.NewRunner(false, true))
+		b.ensureLinuxMultiarchRoot()
+		if len(b.Runner.Env) != 1 || !strings.Contains(b.Runner.Env[0], "v26_clang-20") {
+			t.Errorf("runner env = %v, want registry fallback appended", b.Runner.Env)
+		}
+	})
+
+	t.Run("registry unreadable appends nothing", func(t *testing.T) {
+		t.Setenv("LINUX_MULTIARCH_ROOT", "")
+		testsupport.FakeTool(t, "reg", testsupport.ToolBehavior{ExitCode: 1})
+		b := NewBuilder(BuildOptions{}, runner.NewRunner(false, true))
+		b.ensureLinuxMultiarchRoot()
+		if len(b.Runner.Env) != 0 {
+			t.Errorf("runner env = %v, want empty", b.Runner.Env)
+		}
+	})
+}

--- a/internal/prereq/checker_logic_test.go
+++ b/internal/prereq/checker_logic_test.go
@@ -183,6 +183,19 @@ func TestToolchainNotFoundResult(t *testing.T) {
 	}
 }
 
+func TestToolchainNotFoundResult_FixMode(t *testing.T) {
+	if runtime.GOOS != "windows" {
+		t.Skip("auto-fix toolchain download is Windows-only")
+	}
+	res := (&Checker{Fix: true}).toolchainNotFoundResult(toolchain.CheckResult{})
+	if !res.Passed || !res.Warning {
+		t.Errorf("fix mode: want warning pass, got %+v", res)
+	}
+	if !strings.Contains(res.Message, "no installer URL") {
+		t.Errorf("unexpected fix-mode message: %q", res.Message)
+	}
+}
+
 func TestCheckToolchain_UnknownVersionWarns(t *testing.T) {
 	// An engine source path with no detectable version yields no toolchain
 	// requirement → warning pass (tc.Required == nil).

--- a/internal/prereq/checker_lyra_overlay_test.go
+++ b/internal/prereq/checker_lyra_overlay_test.go
@@ -1,0 +1,21 @@
+package prereq
+
+import (
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+)
+
+func TestCPOverlay_Success(t *testing.T) {
+	testsupport.FakeTool(t, "cp", testsupport.ToolBehavior{ExitCode: 0})
+	if err := (&Checker{}).cpOverlay("/src", "/dst"); err != nil {
+		t.Errorf("cpOverlay() error = %v, want nil", err)
+	}
+}
+
+func TestCPOverlay_Failure(t *testing.T) {
+	testsupport.FakeTool(t, "cp", testsupport.ToolBehavior{ExitCode: 1})
+	if err := (&Checker{}).cpOverlay("/src", "/dst"); err == nil {
+		t.Error("cpOverlay() error = nil, want failure")
+	}
+}

--- a/internal/prereq/checker_msvc_test.go
+++ b/internal/prereq/checker_msvc_test.go
@@ -2,7 +2,13 @@
 
 package prereq
 
-import "testing"
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 // TestNeedsNewerMSVC pins the engine-version gate that selects the MSVC toolset.
 // UE 5.7+ (incl. 5.8) needs MSVC 14.44; 5.6 and earlier use 14.38. A drift in
@@ -89,5 +95,163 @@ func TestVswhereRequiresArgsIncludesComponent(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("vswhereRequiresArgs(%q) = %v; component id not present", id, args)
+	}
+}
+
+// writeBatStub writes a minimal .bat that echoes stdout and exits with code.
+// Used to impersonate vswhere.exe/setup.exe at arbitrary absolute paths.
+func writeBatStub(t *testing.T, dir, name string, exitCode int, stdout string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	body := "@echo off\r\n"
+	if stdout != "" {
+		body += "echo " + stdout + "\r\n"
+	}
+	if exitCode != 0 {
+		body += fmt.Sprintf("exit /b %d\r\n", exitCode)
+	}
+	if err := os.WriteFile(path, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestFindVSInstallsBranches(t *testing.T) {
+	const validJSON = `[{"displayName":"Visual Studio Community 2022","installationPath":"C:\\VS2022"}]`
+	tests := []struct {
+		name     string
+		setup    func(*testing.T) string
+		wantErr  string
+		wantInst bool
+	}{
+		{
+			name: "vswhere missing",
+			setup: func(t *testing.T) string {
+				return filepath.Join(t.TempDir(), "missing.exe")
+			},
+			wantErr: "vswhere.exe not found",
+		},
+		{
+			name: "vswhere fails",
+			setup: func(t *testing.T) string {
+				return writeBatStub(t, t.TempDir(), "vswhere.bat", 1, "")
+			},
+			wantErr: "vswhere failed",
+		},
+		{
+			name: "no installations",
+			setup: func(t *testing.T) string {
+				return writeBatStub(t, t.TempDir(), "vswhere.bat", 0, "[]")
+			},
+			wantErr: "no Visual Studio installation",
+		},
+		{
+			name: "malformed json",
+			setup: func(t *testing.T) string {
+				return writeBatStub(t, t.TempDir(), "vswhere.bat", 0, "garbage")
+			},
+			wantErr: "no Visual Studio installation",
+		},
+		{
+			name: "valid installation",
+			setup: func(t *testing.T) string {
+				return writeBatStub(t, t.TempDir(), "vswhere.bat", 0, validJSON)
+			},
+			wantInst: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			installs, err := findVSInstalls(tt.setup(t))
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Errorf("findVSInstalls() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil || len(installs) != 1 || installs[0].DisplayName == "" {
+				t.Errorf("findVSInstalls() = (%+v, %v), want one install", installs, err)
+			}
+		})
+	}
+}
+
+func TestFindMissingComponentsBranches(t *testing.T) {
+	const validJSON = `[{"displayName":"Visual Studio Community 2022","installationPath":"C:\\VS2022"}]`
+	required := []vsComponent{
+		{"Microsoft.VisualStudio.Component.VC.Tools.x86.x64", "C++ build tools"},
+		{"Microsoft.VisualStudio.Component.VC.14.38.17.8.x86.x64", "MSVC v14.38"},
+	}
+	tests := []struct {
+		name     string
+		stdout   string
+		exitCode int
+		want     int
+	}{
+		{"tool exits non-zero", "", 1, 2},
+		{"tool returns no instances", "[]", 0, 2},
+		{"tool returns instances", validJSON, 0, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := writeBatStub(t, t.TempDir(), "vswhere.bat", tt.exitCode, tt.stdout)
+			got := findMissingComponents(path, required)
+			if len(got) != tt.want {
+				t.Errorf("findMissingComponents() = %v, want %d missing", got, tt.want)
+			}
+		})
+	}
+}
+
+// writeSetupExe creates ProgramFiles(x86)/Microsoft Visual Studio/Installer/
+// setup.exe under root and returns the installer directory path.
+func writeSetupExe(t *testing.T, root string) string {
+	t.Helper()
+	installerDir := filepath.Join(root, "Microsoft Visual Studio", "Installer")
+	if err := os.MkdirAll(installerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(installerDir, "setup.exe"), []byte("dummy"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return installerDir
+}
+
+func fixVSComponentArgs() (vswhereResult, []string, []vsComponent) {
+	return vswhereResult{InstallationPath: `C:\VS2022`},
+		[]string{"C++ build tools"},
+		[]vsComponent{{"X", "C++ build tools"}}
+}
+
+func TestFixMissingVSComponents_SetupExeMissing(t *testing.T) {
+	t.Setenv("ProgramFiles(x86)", t.TempDir())
+	install, missing, required := fixVSComponentArgs()
+	got := (&Checker{}).fixMissingVSComponents(install, missing, required)
+	if got.Passed || !strings.Contains(got.Message, "setup.exe not found") {
+		t.Errorf("fixMissingVSComponents() = %+v, want setup.exe not found failure", got)
+	}
+}
+
+func TestFixMissingVSComponents_StartFails(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ProgramFiles(x86)", root)
+	writeSetupExe(t, root)
+	t.Setenv("PATH", t.TempDir())
+	install, missing, required := fixVSComponentArgs()
+	got := (&Checker{}).fixMissingVSComponents(install, missing, required)
+	if got.Passed || !strings.Contains(got.Message, "failed to launch") {
+		t.Errorf("fixMissingVSComponents() = %+v, want launch failure", got)
+	}
+}
+
+func TestFixMissingVSComponents_Launches(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("ProgramFiles(x86)", root)
+	writeSetupExe(t, root)
+	sacBatchFake(t, "ok", 0)
+	install, missing, required := fixVSComponentArgs()
+	got := (&Checker{}).fixMissingVSComponents(install, missing, required)
+	if !got.Passed || !got.Warning || !strings.Contains(got.Message, "launched VS Installer") {
+		t.Errorf("fixMissingVSComponents() = %+v, want launched warning", got)
 	}
 }


### PR DESCRIPTION
## What

Test-only coverage batch K: covers dflint's trivy/hadolint exec paths on all platforms, Visual Studio installer fix branches, lyra overlay cp path, client launch, SmartScreen detection, and toolchain fix-mode routing.

## Coverage

81.9% → 82.8% (statements, full suite profile).

Newly covered branches:

- `internal/dflint` (`tools_extra_test.go`, cross-platform — previously these were 0% on Windows because the only tests were `//go:build !windows`): `LintImage` full + no-trivy paths, `runTrivy` unavailable/missing-image/malformed/exit-no-output, `imageExistsLocally` present/missing/no-docker, `runHadolint` tool-missing/empty-output/level-mapping
- `internal/prereq/checker_msvc.go` (windows-gated): `findVSInstalls` all error branches + valid install (vswhere `.bat` stubs), `findMissingComponents` exit/empty/present, `fixMissingVSComponents` setup.exe-missing, powershell-start-fails, and launched-success paths
- `internal/prereq/checker_lyra.go`: `cpOverlay` success/failure via `cp` stub
- `internal/prereq/checker.go`: `toolchainNotFoundResult` `--fix` routing on Windows
- `cmd/connect/launch_windows.go`: `launchClient` success (stub client.bat) + start-failure
- `internal/game/diagnostics.go`: `isSmartScreenExit` true path via real powershell `exit -1058471934` (0xC0E90002 DWORD) + `diagnoseBuildError` SmartScreen branch
- `internal/game/workarounds.go`: `ensureLinuxMultiarchRoot` registry fallback (reg stub value + unreadable)

## Notes

- 100% test files; no production code touched
- Windows-gated files (`launch_windows_test.go`, `logic_windows_test.go`, msvc additions) run on the Windows CI leg
- Cross-platform dflint tests overlap existing Unix-leg coverage harmlessly (unique test names avoid redeclaration with `tools_unix_test.go`)
- `fixMissingVSComponents` split into three top-level tests + `writeSetupExe`/`fixVSComponentArgs` helpers to satisfy gocyclo
