### PR TITLE
test: batch M coverage — prereq, game, engine, wsl

### DIFF
--- a/cmd/engine/coverage_test.go
+++ b/cmd/engine/coverage_test.go
@@ -1,0 +1,236 @@
+package engine
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/cache"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+	"github.com/spf13/cobra"
+)
+
+func engineCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+// seedEngineCache chdirs to a temp dir and writes a cache entry marking the
+// engine stage up to date for the given hash.
+func seedEngineCache(t *testing.T, hash string) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	c := &cache.Cache{Entries: map[cache.StageKey]*cache.Entry{
+		cache.StageEngine: {Hash: hash, BuiltAt: "test"},
+	}}
+	if err := cache.Save(c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// TestRunBuild_PrereqFailure covers the CheckEngineReady error branch of
+// runBuild: an empty engine source path fails before any dispatch.
+func TestRunBuild_PrereqFailure(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{}, globals.WithDryRun(true))
+
+	err := runBuild(engineCmd(t), nil)
+	if err == nil || !strings.Contains(err.Error(), "prerequisite check(s) failed") {
+		t.Fatalf("runBuild() error = %v, want prereq failure", err)
+	}
+}
+
+// TestRunSetup_MissingSourcePath covers the makeBuilder error branch of
+// runSetup.
+func TestRunSetup_MissingSourcePath(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{})
+
+	err := runSetup(engineCmd(t), nil)
+	if err == nil || !strings.Contains(err.Error(), "engine source path not configured") {
+		t.Fatalf("runSetup() error = %v, want source path error", err)
+	}
+}
+
+// TestRunSetup_Success covers the full success path of runSetup, including
+// the maybeRunMacOSPreflights early return for non-macOS hosts.
+func TestRunSetup_Success(t *testing.T) {
+	engineRoot := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: engineRoot,
+			Version:    "5.7.3",
+			MaxJobs:    1,
+		},
+		Game: config.GameConfig{ProjectName: "TestGame"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	if err := runSetup(engineCmd(t), nil); err != nil {
+		t.Fatalf("runSetup() error = %v, want nil", err)
+	}
+}
+
+// TestRunNativeEngineBuild_CacheHit covers the cache-skip early return of
+// runNativeEngineBuild.
+func TestRunNativeEngineBuild_CacheHit(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{SourcePath: "C:/ue5", Version: "5.7.3"},
+		Game:   config.GameConfig{ProjectName: "TestGame"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	seedEngineCache(t, cache.EngineKey(cfg))
+
+	if err := runNativeEngineBuild(engineCmd(t)); err != nil {
+		t.Fatalf("runNativeEngineBuild(cached) error = %v, want nil", err)
+	}
+}
+
+// TestRunContainerBuild_CacheHit covers the cache-skip early return of
+// runContainerBuild.
+func TestRunContainerBuild_CacheHit(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  "C:/ue5",
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{ProjectName: "TestGame"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	seedEngineCache(t, cache.EngineKey(cfg))
+
+	if err := runContainerBuild(engineCmd(t), "docker"); err != nil {
+		t.Fatalf("runContainerBuild(cached) error = %v, want nil", err)
+	}
+}
+
+// TestRunContainerBuild_MissingSourcePath covers the makeContainerEngineBuilder
+// error branch of runContainerBuild.
+func TestRunContainerBuild_MissingSourcePath(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  "",
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{ProjectName: "TestGame"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	t.Chdir(t.TempDir())
+
+	err := runContainerBuild(engineCmd(t), "docker")
+	if err == nil || !strings.Contains(err.Error(), "engine source path not configured") {
+		t.Fatalf("runContainerBuild() error = %v, want source path error", err)
+	}
+}
+
+// TestRunContainerBuild_SkipEnginePackaging covers the skip-engine packaging
+// branch of runContainerBuild: with --skip-engine and no cache, the engine
+// binaries are packaged instead of built.
+func TestRunContainerBuild_SkipEnginePackaging(t *testing.T) {
+	engineRoot := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	binDir := filepath.Join(engineRoot, "Engine", "Binaries", "Linux")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "UnrealEditor"), []byte("binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  engineRoot,
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{ProjectName: "TestGame"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	t.Chdir(t.TempDir())
+
+	skipEngine, noCache = true, true
+	t.Cleanup(func() { skipEngine, noCache = false, false })
+
+	output := captureStdout(func() {
+		if err := runContainerBuild(engineCmd(t), "docker"); err != nil {
+			t.Fatalf("runContainerBuild() error = %v, want nil", err)
+		}
+	})
+	if !strings.Contains(output, "Packaging pre-built engine binaries") {
+		t.Fatalf("runContainerBuild() output missing skip-engine line: %s", output)
+	}
+}
+
+// TestRunContainerBuild_StateWarning covers the UpdateEngineImage failure
+// branch of runContainerBuild: a write failure degrades to a warning.
+func TestRunContainerBuild_StateWarning(t *testing.T) {
+	engineRoot := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  engineRoot,
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{ProjectName: "TestGame"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	dir := t.TempDir()
+	t.Chdir(dir)
+	if err := os.WriteFile(filepath.Join(dir, ".ludus"), []byte("block"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	noCache = true
+	t.Cleanup(func() { noCache = false })
+
+	output := captureStdout(func() {
+		if err := runContainerBuild(engineCmd(t), "docker"); err != nil {
+			t.Fatalf("runContainerBuild() error = %v, want nil with warning", err)
+		}
+	})
+	if !strings.Contains(output, "Warning: failed to write state") {
+		t.Fatalf("runContainerBuild() output missing state warning: %s", output)
+	}
+}
+
+// TestRunWSL2Build_MissingSourcePath covers the missing source path branch of
+// runWSL2Build before any wsl.exe probing.
+func TestRunWSL2Build_MissingSourcePath(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{}, globals.WithDryRun(true))
+
+	err := runWSL2Build(engineCmd(t))
+	if err == nil || !strings.Contains(err.Error(), "engine source path not configured") {
+		t.Fatalf("runWSL2Build() error = %v, want source path error", err)
+	}
+}
+
+// TestRunWSL2Build_WslUnavailable covers the wsl.New error branch of
+// runWSL2Build: a configured source path but no wsl.exe on PATH.
+func TestRunWSL2Build_WslUnavailable(t *testing.T) {
+	engineRoot := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: engineRoot,
+			Version:    "5.7.3",
+			Backend:    "wsl2",
+		},
+		Game: config.GameConfig{ProjectName: "TestGame"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	t.Setenv("PATH", t.TempDir())
+
+	err := runWSL2Build(engineCmd(t))
+	if err == nil || !strings.Contains(err.Error(), "WSL2 is not available") {
+		t.Fatalf("runWSL2Build() error = %v, want WSL2 unavailable error", err)
+	}
+}

--- a/cmd/game/coverage_test.go
+++ b/cmd/game/coverage_test.go
@@ -1,0 +1,428 @@
+package game
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/cmd/globals"
+	"github.com/jpvelasco/ludus/internal/cache"
+	"github.com/jpvelasco/ludus/internal/config"
+	"github.com/jpvelasco/ludus/internal/state"
+	"github.com/jpvelasco/ludus/internal/testsupport"
+	"github.com/spf13/cobra"
+)
+
+// seedGameCache chdirs to a temp dir and writes a cache entry that marks the
+// given stage up to date for the given hash.
+func seedGameCache(t *testing.T, stage cache.StageKey, hash string) {
+	t.Helper()
+	t.Chdir(t.TempDir())
+	c := &cache.Cache{Entries: map[cache.StageKey]*cache.Entry{
+		stage: {Hash: hash, BuiltAt: "test"},
+	}}
+	if err := cache.Save(c); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func gameCmd(t *testing.T) *cobra.Command {
+	t.Helper()
+	cmd := &cobra.Command{}
+	cmd.SetContext(context.Background())
+	return cmd
+}
+
+// TestRunBuild_PrereqFailure covers the Validate error branch of runBuild:
+// an empty engine source path fails CheckGameReady before any dispatch.
+func TestRunBuild_PrereqFailure(t *testing.T) {
+	globals.SetGlobals(t, &config.Config{}, globals.WithDryRun(true))
+
+	err := runBuild(gameCmd(t), nil)
+	if err == nil || !strings.Contains(err.Error(), "prerequisite check(s) failed") {
+		t.Fatalf("runBuild() error = %v, want prereq failure", err)
+	}
+}
+
+// TestRunBuild_WSL2CacheHit covers the WSL2 dispatch branch of runBuild plus
+// the cache-hit early return inside runWSL2GameBuild.
+func TestRunBuild_WSL2CacheHit(t *testing.T) {
+	engineRoot := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	projectPath := testsupport.FakeProject(t, "TestGame")
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: engineRoot,
+			Version:    "5.7.3",
+			Backend:    "wsl2",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: projectPath,
+			Platform:    "Linux",
+			Arch:        "amd64",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	resolved := resolvedBuildConfig()
+	engineHash := cache.EngineKey(&resolved)
+	serverHash := cache.GameServerKey(&resolved, engineHash)
+	seedGameCache(t, cache.StageGameServer, serverHash)
+
+	if err := runBuild(gameCmd(t), nil); err != nil {
+		t.Fatalf("runBuild(wsl2, cached) error = %v, want nil", err)
+	}
+}
+
+// TestRunContainerBuild_PreflightFailsWithoutDryRun covers the non-dry-run
+// preflight branch: a failing docker daemon hard-fails the check before any
+// build work happens.
+func TestRunContainerBuild_PreflightFailsWithoutDryRun(t *testing.T) {
+	projectPath := testsupport.FakeProject(t, "TestGame")
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  "C:/ue5",
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: projectPath,
+			Platform:    "Linux",
+		},
+	}
+	globals.SetGlobals(t, cfg)
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
+
+	err := runContainerBuild(gameCmd(t), "docker", cfg)
+	if err == nil || !strings.Contains(err.Error(), "prerequisite check(s) failed") {
+		t.Fatalf("runContainerBuild() error = %v, want preflight failure", err)
+	}
+}
+
+// TestRunContainerBuild_CacheHit covers the cache-hit early return of
+// runContainerBuild after the (dry-run-skipped) preflight.
+func TestRunContainerBuild_CacheHit(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  "C:/ue5",
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: "C:/project/TestGame.uproject",
+			Platform:    "Linux",
+			Arch:        "amd64",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	serverHash := cache.GameServerKey(cfg, cache.EngineKey(cfg))
+	seedGameCache(t, cache.StageGameServer, serverHash)
+
+	if err := runContainerBuild(gameCmd(t), "docker", cfg); err != nil {
+		t.Fatalf("runContainerBuild(cached) error = %v, want nil", err)
+	}
+}
+
+// TestRunContainerBuild_InvalidDDCMode covers the ResolveContainerGameOptions
+// error branch of runContainerBuild.
+func TestRunContainerBuild_InvalidDDCMode(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  "C:/ue5",
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: "C:/project/TestGame.uproject",
+		},
+		DDC: config.DDCConfig{Mode: "bogus"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	t.Chdir(t.TempDir())
+
+	err := runContainerBuild(gameCmd(t), "docker", cfg)
+	if err == nil || !strings.Contains(err.Error(), "resolving DDC config") {
+		t.Fatalf("runContainerBuild() error = %v, want DDC config error", err)
+	}
+}
+
+// TestRunClientBuild_ContainerDispatch covers the container dispatch branch of
+// runClientBuild: a podman backend routes to the container client build.
+func TestRunClientBuild_ContainerDispatch(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  "C:/ue5",
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "native",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: "C:/project/TestGame.uproject",
+			Platform:    "Linux",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	origBackend, origPlatform := backend, clientPlatform
+	backend, clientPlatform = "podman", "Linux"
+	t.Cleanup(func() { backend, clientPlatform = origBackend, origPlatform })
+
+	if err := runClientBuild(gameCmd(t), nil); err != nil {
+		t.Fatalf("runClientBuild(container dispatch) error = %v, want nil", err)
+	}
+}
+
+// TestRunClientBuild_CacheHit covers the cache-hit early return of
+// runClientBuild before any engine path resolution.
+func TestRunClientBuild_CacheHit(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: "C:/ue5",
+			Version:    "5.7.3",
+			Backend:    "native",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: "C:/project/TestGame.uproject",
+			Arch:        "amd64",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	origPlatform := clientPlatform
+	clientPlatform = "Linux"
+	t.Cleanup(func() { clientPlatform = origPlatform })
+
+	clientHash := cache.GameClientKey(cfg, cache.EngineKey(cfg), clientPlatform)
+	seedGameCache(t, cache.StageGameClient, clientHash)
+
+	if err := runClientBuild(gameCmd(t), nil); err != nil {
+		t.Fatalf("runClientBuild(cached) error = %v, want nil", err)
+	}
+}
+
+// TestRunContainerClientBuild_CacheHit covers the cache-hit early return of
+// runContainerClientBuild.
+func TestRunContainerClientBuild_CacheHit(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  "C:/ue5",
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: "C:/project/TestGame.uproject",
+			Arch:        "amd64",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	origPlatform := clientPlatform
+	clientPlatform = "Linux"
+	t.Cleanup(func() { clientPlatform = origPlatform })
+
+	clientHash := cache.GameClientKey(cfg, cache.EngineKey(cfg), clientPlatform)
+	seedGameCache(t, cache.StageGameClient, clientHash)
+
+	if err := runContainerClientBuild(gameCmd(t), "docker"); err != nil {
+		t.Fatalf("runContainerClientBuild(cached) error = %v, want nil", err)
+	}
+}
+
+// TestRunContainerClientBuild_InvalidDDCMode covers the
+// ResolveContainerGameOptions error branch of runContainerClientBuild.
+func TestRunContainerClientBuild_InvalidDDCMode(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath:  "C:/ue5",
+			Version:     "5.7.3",
+			DockerImage: "my.repo/engine:5.7.3",
+			Backend:     "docker",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: "C:/project/TestGame.uproject",
+		},
+		DDC: config.DDCConfig{Mode: "bogus"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	t.Chdir(t.TempDir())
+
+	err := runContainerClientBuild(gameCmd(t), "docker")
+	if err == nil || !strings.Contains(err.Error(), "resolving DDC config") {
+		t.Fatalf("runContainerClientBuild() error = %v, want DDC config error", err)
+	}
+}
+
+// TestRunNativeBuild_InvalidDDCMode covers the ResolveDDC error branch of
+// runNativeBuild.
+func TestRunNativeBuild_InvalidDDCMode(t *testing.T) {
+	engineRoot := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	projectPath := testsupport.FakeProject(t, "TestGame")
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: engineRoot,
+			Version:    "5.7.3",
+			Backend:    "native",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: projectPath,
+			Platform:    "Linux",
+		},
+		DDC: config.DDCConfig{Mode: "bogus"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	t.Chdir(t.TempDir())
+
+	err := runNativeBuild(gameCmd(t), cfg, "test_hash")
+	if err == nil || !strings.Contains(err.Error(), "invalid DDC mode") {
+		t.Fatalf("runNativeBuild() error = %v, want invalid DDC mode error", err)
+	}
+}
+
+// TestRunBuild_NativeCacheHit covers the cache-skip early return at the
+// runBuild level for the native backend.
+func TestRunBuild_NativeCacheHit(t *testing.T) {
+	engineRoot := testsupport.FakeEngineTree(t, testsupport.WithVersion("5.7.3"))
+	projectPath := testsupport.FakeProject(t, "TestGame")
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{
+			SourcePath: engineRoot,
+			Version:    "5.7.3",
+			Backend:    "native",
+		},
+		Game: config.GameConfig{
+			ProjectName: "TestGame",
+			ProjectPath: projectPath,
+			Arch:        "amd64",
+		},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	serverHash := cache.GameServerKey(cfg, cache.EngineKey(cfg))
+	seedGameCache(t, cache.StageGameServer, serverHash)
+
+	if err := runBuild(gameCmd(t), nil); err != nil {
+		t.Fatalf("runBuild(native, cached) error = %v, want nil", err)
+	}
+}
+
+// TestRunNativeBuild_MissingSourcePath covers the missing engine source path
+// branch of runNativeBuild.
+func TestRunNativeBuild_MissingSourcePath(t *testing.T) {
+	cfg := &config.Config{
+		Engine: config.EngineConfig{SourcePath: "", Version: "5.7.3"},
+		Game:   config.GameConfig{ProjectName: "TestGame", ProjectPath: "C:/project/TestGame.uproject"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+	t.Chdir(t.TempDir())
+
+	err := runNativeBuild(gameCmd(t), cfg, "test_hash")
+	if err == nil || !strings.Contains(err.Error(), "engine source path not configured") {
+		t.Fatalf("runNativeBuild() error = %v, want source path error", err)
+	}
+}
+
+// TestRunWSL2GameBuild_CorruptState covers the state load error branch of
+// runWSL2GameBuild: an unparseable state file fails the build before any WSL2
+// probing.
+func TestRunWSL2GameBuild_CorruptState(t *testing.T) {
+	t.Chdir(t.TempDir())
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile("") })
+
+	if err := os.MkdirAll(".ludus", 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(".ludus", "state.json"), []byte("{not json"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{SourcePath: "C:/ue5", Version: "5.7.3", Backend: "wsl2"},
+		Game:   config.GameConfig{ProjectName: "TestGame", ProjectPath: "C:/project/TestGame.uproject"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	err := runWSL2GameBuild(gameCmd(t), cfg)
+	if err == nil || !strings.Contains(err.Error(), "loading state") {
+		t.Fatalf("runWSL2GameBuild() error = %v, want state load error", err)
+	}
+}
+
+// TestRunWSL2GameBuild_WslUnavailable covers the wsl.New error branch of
+// runWSL2GameBuild: valid engine state but no wsl.exe on PATH.
+func TestRunWSL2GameBuild_WslUnavailable(t *testing.T) {
+	t.Chdir(t.TempDir())
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile("") })
+
+	if err := state.UpdateWSL2Engine(&state.WSL2EngineState{
+		EnginePath: "/home/user/ludus/engine/5.7",
+		DDCPath:    "/home/user/ludus/ddc",
+		IsNative:   true,
+	}); err != nil {
+		t.Fatalf("UpdateWSL2Engine() error = %v", err)
+	}
+
+	t.Setenv("PATH", t.TempDir())
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{SourcePath: "C:/ue5", Version: "5.7.3", Backend: "wsl2"},
+		Game:   config.GameConfig{ProjectName: "TestGame", ProjectPath: "C:/project/TestGame.uproject"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true))
+
+	err := runWSL2GameBuild(gameCmd(t), cfg)
+	if err == nil || !strings.Contains(err.Error(), "WSL2 is not available") {
+		t.Fatalf("runWSL2GameBuild() error = %v, want WSL2 unavailable error", err)
+	}
+}
+
+// TestRunWSL2GameBuild_InvalidDDCMode covers the ResolveDDC error branch of
+// runWSL2GameBuild: the wsl.exe stub answers the distro probe, then DDC
+// resolution fails on an invalid mode.
+func TestRunWSL2GameBuild_InvalidDDCMode(t *testing.T) {
+	t.Chdir(t.TempDir())
+	state.SetProfile("")
+	t.Cleanup(func() { state.SetProfile("") })
+
+	if err := state.UpdateWSL2Engine(&state.WSL2EngineState{
+		EnginePath: "/home/user/ludus/engine/5.7",
+		DDCPath:    "/home/user/ludus/ddc",
+		IsNative:   true,
+	}); err != nil {
+		t.Fatalf("UpdateWSL2Engine() error = %v", err)
+	}
+
+	testsupport.FakeTool(t, "wsl.exe", testsupport.ToolBehavior{
+		Stdout: "* Ubuntu          Running         2",
+	})
+
+	cfg := &config.Config{
+		Engine: config.EngineConfig{SourcePath: "C:/ue5", Version: "5.7.3", Backend: "wsl2"},
+		Game:   config.GameConfig{ProjectName: "TestGame", ProjectPath: "C:/project/TestGame.uproject"},
+	}
+	globals.SetGlobals(t, cfg, globals.WithDryRun(true), globals.WithDDCMode("bogus"))
+
+	err := runWSL2GameBuild(gameCmd(t), cfg)
+	if err == nil || !strings.Contains(err.Error(), "invalid DDC mode") {
+		t.Fatalf("runWSL2GameBuild() error = %v, want invalid DDC mode error", err)
+	}
+}

--- a/internal/prereq/checker_make_extra_test.go
+++ b/internal/prereq/checker_make_extra_test.go
@@ -1,0 +1,83 @@
+//go:build linux
+
+package prereq
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/testsupport"
+	"github.com/jpvelasco/ludus/internal/wrapper"
+)
+
+// isolateWrapperCache points the wrapper cache at an empty temp dir so the
+// IsBinaryCached probe is deterministic regardless of the host's real cache.
+func isolateWrapperCache(t *testing.T) {
+	t.Helper()
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("USERPROFILE", t.TempDir())
+}
+
+// TestCheckMakeForWrapper_MakeOnPathPasses covers the "make found" tail of
+// checkMakeForWrapper for a native linux/amd64 target on any host OS: a make
+// stub on PATH and an empty wrapper cache must yield a clean pass.
+func TestCheckMakeForWrapper_MakeOnPathPasses(t *testing.T) {
+	isolateWrapperCache(t)
+	testsupport.FakeTool(t, "make", testsupport.ToolBehavior{})
+
+	res := (&Checker{}).checkMakeForWrapper("linux", "amd64")
+	if !res.Passed || res.Warning {
+		t.Fatalf("checkMakeForWrapper() = %+v, want clean pass", res)
+	}
+	if !strings.Contains(res.Message, "make found") {
+		t.Fatalf("checkMakeForWrapper() message = %q, want 'make found'", res.Message)
+	}
+}
+
+// TestCheckMakeForWrapper_MakeMissingFails covers the hard-failure branch: a
+// native linux/amd64 target with no cached wrapper binary and no make on PATH.
+func TestCheckMakeForWrapper_MakeMissingFails(t *testing.T) {
+	isolateWrapperCache(t)
+	t.Setenv("PATH", t.TempDir())
+
+	res := (&Checker{}).checkMakeForWrapper("linux", "amd64")
+	if res.Passed {
+		t.Fatalf("checkMakeForWrapper() = %+v, want hard failure", res)
+	}
+	if !strings.Contains(res.Message, "make not found in PATH") {
+		t.Fatalf("checkMakeForWrapper() message = %q, want 'make not found in PATH'", res.Message)
+	}
+}
+
+// TestCheckMakeForWrapper_CachedBinarySkips covers the cache-hit branch: a
+// prebuilt wrapper binary in the cache means make is not needed even though
+// the target is native linux/amd64 and make is absent from PATH.
+func TestCheckMakeForWrapper_CachedBinarySkips(t *testing.T) {
+	isolateWrapperCache(t)
+	t.Setenv("PATH", t.TempDir())
+
+	cacheDir, err := wrapper.CacheDir()
+	if err != nil {
+		t.Fatalf("wrapper.CacheDir() error = %v", err)
+	}
+	binaryPath := wrapper.BinaryPath(cacheDir, "linux", "amd64")
+	if err := os.MkdirAll(filepath.Dir(binaryPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(binaryPath, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !wrapper.IsBinaryCached("linux", "amd64") {
+		t.Fatal("IsBinaryCached() = false, want true after seeding cache")
+	}
+
+	res := (&Checker{}).checkMakeForWrapper("linux", "amd64")
+	if !res.Passed || res.Warning {
+		t.Fatalf("checkMakeForWrapper() = %+v, want clean pass via cache", res)
+	}
+	if !strings.Contains(res.Message, "already cached") {
+		t.Fatalf("checkMakeForWrapper() message = %q, want 'already cached'", res.Message)
+	}
+}

--- a/internal/prereq/checker_runtime_fakes_test.go
+++ b/internal/prereq/checker_runtime_fakes_test.go
@@ -53,6 +53,14 @@ func TestCheckContainerRuntime_DockerBackendNotReady(t *testing.T) {
 	}
 }
 
+func TestCheckContainerRuntime_DockerBackendReady(t *testing.T) {
+	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{})
+	res := (&Checker{Backend: "docker"}).checkContainerRuntime()
+	if !res.Passed || res.Warning || !strings.Contains(res.Message, "docker daemon running") {
+		t.Fatalf("checkContainerRuntime() = %+v", res)
+	}
+}
+
 func TestCheckDocker_DaemonDownOtherBackend(t *testing.T) {
 	testsupport.FakeTool(t, "docker", testsupport.ToolBehavior{ExitCode: 1})
 	res := (&Checker{Backend: "podman"}).checkDocker()

--- a/internal/prereq/checker_unix_test.go
+++ b/internal/prereq/checker_unix_test.go
@@ -1,0 +1,90 @@
+//go:build !windows
+
+package prereq
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/dockerbuild"
+	"github.com/jpvelasco/ludus/internal/toolchain"
+)
+
+// TestCheckWSL2_NonWindowsWarns covers the early return for non-Windows hosts:
+// WSL2 is only meaningful on Windows, so the check passes with a warning.
+func TestCheckWSL2_NonWindowsWarns(t *testing.T) {
+	res := (&Checker{}).checkWSL2()
+	if !res.Passed || !res.Warning {
+		t.Fatalf("checkWSL2() = %+v, want pass+warning", res)
+	}
+	if !strings.Contains(res.Message, "only available on Windows") {
+		t.Fatalf("checkWSL2() message = %q, want 'only available on Windows'", res.Message)
+	}
+}
+
+// TestCheckDocker_NotFoundWithOtherBackendWarns covers the non-Windows branch
+// where docker is missing but a different backend is selected: warning, not
+// failure.
+func TestCheckDocker_NotFoundWithOtherBackendWarns(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	res := (&Checker{Backend: dockerbuild.BackendPodman}).checkDocker()
+	if !res.Passed || !res.Warning {
+		t.Fatalf("checkDocker() = %+v, want pass+warning", res)
+	}
+	if !strings.Contains(res.Message, "not needed for podman backend") {
+		t.Fatalf("checkDocker() message = %q, want 'not needed for podman backend'", res.Message)
+	}
+}
+
+// TestCheckDocker_NotFoundHardFails covers the non-Windows branch where docker
+// is missing and no other backend is selected: hard failure.
+func TestCheckDocker_NotFoundHardFails(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	res := (&Checker{}).checkDocker()
+	if res.Passed {
+		t.Fatalf("checkDocker() = %+v, want hard failure", res)
+	}
+	if !strings.Contains(res.Message, "docker not found in PATH") {
+		t.Fatalf("checkDocker() message = %q, want 'docker not found in PATH'", res.Message)
+	}
+}
+
+// TestCheckOS_HostDetected covers the host's GOOS branch of checkOS on
+// non-Windows CI legs (Linux on ubuntu, darwin on macOS).
+func TestCheckOS_HostDetected(t *testing.T) {
+	res := (&Checker{}).checkOS()
+	if !res.Passed || res.Warning {
+		t.Fatalf("checkOS() = %+v, want clean pass", res)
+	}
+	if !strings.Contains(res.Message, "detected") {
+		t.Fatalf("checkOS() message = %q, want host 'detected'", res.Message)
+	}
+}
+
+// TestToolchainNotFoundResult_NonWindowsFixOff covers the non-Windows result
+// path without --fix: the guidance suffix is appended and the check fails.
+func TestToolchainNotFoundResult_NonWindowsFixOff(t *testing.T) {
+	tc := toolchain.CheckResult{Message: "toolchain v26 not found"}
+	res := (&Checker{}).toolchainNotFoundResult(tc)
+	if res.Passed || res.Warning {
+		t.Fatalf("toolchainNotFoundResult() = %+v, want hard failure", res)
+	}
+	if !strings.Contains(res.Message, "run with --fix for instructions") {
+		t.Fatalf("toolchainNotFoundResult() message = %q, want '--fix' guidance", res.Message)
+	}
+}
+
+// TestToolchainNotFoundResult_NonWindowsFixOn covers the non-Windows path with
+// --fix set: the plain message is returned without the guidance suffix.
+func TestToolchainNotFoundResult_NonWindowsFixOn(t *testing.T) {
+	tc := toolchain.CheckResult{Message: "toolchain v26 not found"}
+	res := (&Checker{Fix: true}).toolchainNotFoundResult(tc)
+	if res.Passed || res.Warning {
+		t.Fatalf("toolchainNotFoundResult() = %+v, want hard failure", res)
+	}
+	if strings.Contains(res.Message, "run with --fix") {
+		t.Fatalf("toolchainNotFoundResult() message = %q, want no --fix suffix with Fix set", res.Message)
+	}
+}

--- a/internal/prereq/checker_win_extras_test.go
+++ b/internal/prereq/checker_win_extras_test.go
@@ -77,6 +77,27 @@ func TestScanCodeIntegrityBlocks_DedupesAndNames(t *testing.T) {
 	}
 }
 
+// TestScanCodeIntegrityBlocks_PowershellUnavailable covers the error branch:
+// when the Code Integrity event log query fails, the scan degrades to nil.
+func TestScanCodeIntegrityBlocks_PowershellUnavailable(t *testing.T) {
+	sacBatchFake(t, "", 1)
+	if got := (&Checker{}).scanCodeIntegrityBlocks(); got != nil {
+		t.Fatalf("scanCodeIntegrityBlocks() = %v, want nil on powershell failure", got)
+	}
+}
+
+// TestScanCodeIntegrityBlocks_SourceCodePath covers the device-path
+// shortening branch: a blocked path under \Source Code\ is trimmed to the
+// readable prefix instead of the bare file name.
+func TestScanCodeIntegrityBlocks_SourceCodePath(t *testing.T) {
+	sacBatchFake(t, `C:\Users\me\Source Code\UE5\Game\Foo.dll`, 0)
+	got := (&Checker{}).scanCodeIntegrityBlocks()
+	want := "Source Code\\UE5\\Game\\Foo.dll"
+	if len(got) != 1 || got[0] != want {
+		t.Fatalf("scanCodeIntegrityBlocks() = %v, want [%q]", got, want)
+	}
+}
+
 // sdkEngineFixture builds an engine tree and a fake Windows SDK host dir, both
 // under temp dirs, and returns a Checker whose platformChecks will take the
 // SDK >= 26100 engine-patch branches.

--- a/internal/prereq/checker_wsl2_coverage_test.go
+++ b/internal/prereq/checker_wsl2_coverage_test.go
@@ -1,0 +1,38 @@
+//go:build windows
+
+package prereq
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/jpvelasco/ludus/internal/dockerbuild"
+)
+
+// TestCheckWSL2_WslExeMissingWarns covers the wsl.exe-not-found branch when
+// WSL2 is not the selected backend: the check degrades to a warning.
+func TestCheckWSL2_WslExeMissingWarns(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	res := (&Checker{}).checkWSL2()
+	if !res.Passed || !res.Warning {
+		t.Fatalf("checkWSL2() = %+v, want pass+warning", res)
+	}
+	if !strings.Contains(res.Message, "wsl.exe not found") {
+		t.Fatalf("checkWSL2() message = %q, want 'wsl.exe not found'", res.Message)
+	}
+}
+
+// TestCheckWSL2_WslExeMissingRequired covers the same branch when the WSL2
+// backend is selected: the check becomes a hard failure.
+func TestCheckWSL2_WslExeMissingRequired(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+
+	res := (&Checker{Backend: dockerbuild.BackendWSL2}).checkWSL2()
+	if res.Passed {
+		t.Fatalf("checkWSL2() = %+v, want hard failure", res)
+	}
+	if !strings.Contains(res.Message, "wsl.exe not found") {
+		t.Fatalf("checkWSL2() message = %q, want 'wsl.exe not found'", res.Message)
+	}
+}

--- a/internal/wsl/detect_distro_extra_test.go
+++ b/internal/wsl/detect_distro_extra_test.go
@@ -1,0 +1,22 @@
+package wsl
+
+import "testing"
+
+func TestParseDistroLine_TooFewFields(t *testing.T) {
+	if d, ok := parseDistroLine("Ubuntu"); ok || d != (DistroInfo{}) {
+		t.Fatalf("parseDistroLine(short) = (%+v, %v), want empty false", d, ok)
+	}
+}
+
+func TestParseDistroLine_NonNumericVersion(t *testing.T) {
+	if d, ok := parseDistroLine("Ubuntu Running latest"); ok || d != (DistroInfo{}) {
+		t.Fatalf("parseDistroLine(bad version) = (%+v, %v), want empty false", d, ok)
+	}
+}
+
+func TestParseDistroLine_NameWithSpaces(t *testing.T) {
+	d, ok := parseDistroLine("* Ubuntu Server LTS          Stopped         2")
+	if !ok || d.Name != "Ubuntu Server LTS" || d.Version != 2 || d.Running || !d.Default {
+		t.Fatalf("parseDistroLine(spaces) = %+v, %v", d, ok)
+	}
+}


### PR DESCRIPTION
## Summary

Batch M of the coverage campaign: 28 new tests across prereq, game, engine, and wsl packages. Test-only diff (no production code changes).

Measured locally (Windows, all packages): **83.6% → 83.9%**; the `//go:build`-gated files add further coverage on the ubuntu/macOS CI legs.

### What's covered

- **`cmd/game`** (13 tests): `runBuild` WSL2/native/container dispatch, cache-skip early returns for all build paths, preflight failure without `--dry-run`, DDC resolution errors, corrupt state file, wsl.exe missing on PATH, client container dispatch.
- **`cmd/engine`** (10 tests): `runBuild` prereq failure, `runSetup` success + missing source path, cache-skip for native and container engine builds, missing source path for container/WSL2 builds, `--skip-engine` packaging branch, `UpdateEngineImage` state-write warning, wsl.exe unavailable.
- **`internal/prereq`** (14 tests): `checkMakeForWrapper` make-found / make-missing / cached-binary branches (Linux-gated — `wrapper.UsesMake` is host-sensitive), `checkWSL2` wsl.exe missing warn/fail (Windows-gated), docker-not-found warn/fail + host-OS + toolchain-not-found branches (non-Windows), `scanCodeIntegrityBlocks` powershell failure + `Source Code` path shortening, docker daemon ready.
- **`internal/wsl`** (3 tests): `parseDistroLine` short-line, non-numeric version, and name-with-spaces fallbacks.

### Notes

- `wrapper.UsesMake` (wrapper.go:120) only returns true on Linux hosts, so the make-branch tests are `//go:build linux` and run on the ubuntu CI leg.
- Unreachable-from-tests branches left as-is (e.g. `resolveHome`'s `/root` and Windows terminal tails — `user.Current` resolves via process token on Windows; `xml.MarshalIndent` error path).
